### PR TITLE
Handle non-finite test durations in CLI test results

### DIFF
--- a/cli/src/client.mjs
+++ b/cli/src/client.mjs
@@ -41,6 +41,27 @@ function authHeaders() {
 }
 
 /**
+ * Parse JSON responses, tolerating non-finite numeric literals sometimes
+ * returned by the Eclipse bridge (for example `time: NaN` in test results).
+ * @param {string} data
+ * @returns {any}
+ */
+function parseJson(data) {
+  try {
+    return JSON.parse(data);
+  } catch {
+    const sanitized = data
+      .replace(/:\s*NaN\b/g, ": null")
+      .replace(/:\s*Infinity\b/g, ": null")
+      .replace(/:\s*-Infinity\b/g, ": null");
+    if (sanitized !== data) {
+      return JSON.parse(sanitized);
+    }
+    throw new Error("Invalid JSON: " + data);
+  }
+}
+
+/**
  * HTTP GET request, returns parsed JSON.
  * @param {string} path - URL path with query string
  * @param {number} [timeoutMs=10000]
@@ -67,9 +88,9 @@ export function get(path, timeoutMs = 10_000) {
             return;
           }
           try {
-            resolve(JSON.parse(data));
-          } catch {
-            reject(new Error("Invalid JSON: " + data));
+            resolve(parseJson(data));
+          } catch (e) {
+            reject(e);
           }
         });
       },
@@ -113,14 +134,14 @@ export function getRaw(path, timeoutMs = 10_000) {
           const contentType = res.headers["content-type"] || "";
           if (contentType.startsWith("application/json")) {
             try {
-              const json = JSON.parse(data);
+              const json = parseJson(data);
               if (json.error) {
                 reject(new Error(json.error));
               } else {
                 resolve({ headers: res.headers, body: data });
               }
-            } catch {
-              reject(new Error("Invalid JSON: " + data));
+            } catch (e) {
+              reject(e);
             }
           } else {
             resolve({ headers: res.headers, body: data });

--- a/cli/src/format/test-results.mjs
+++ b/cli/src/format/test-results.mjs
@@ -10,7 +10,8 @@ export function formatTestResults(result) {
   if (result.failed > 0) parts.push(red(`${result.failed} failed`));
   if (result.errors > 0) parts.push(red(`${result.errors} errors`));
   if (result.ignored > 0) parts.push(yellow(`${result.ignored} ignored`));
-  parts.push(`${result.time.toFixed(1)}s`);
+  const time = Number.isFinite(result.time) ? result.time : 0;
+  parts.push(`${time.toFixed(1)}s`);
   console.log(parts.join(", "));
 
   // Failure details

--- a/cli/test/client.test.mjs
+++ b/cli/test/client.test.mjs
@@ -74,6 +74,18 @@ describe("client", () => {
     await expect(get("/bad")).rejects.toThrow("Invalid JSON");
   });
 
+  it("get() tolerates NaN in JSON response", async () => {
+    let port;
+    ({ server, port } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"total":0,"passed":0,"failed":0,"errors":0,"ignored":0,"time":NaN,"failures":[]}');
+    }));
+    mockDiscovery(port);
+    const { get } = await import("../src/client.mjs");
+    const result = await get("/test");
+    expect(result.time).toBeNull();
+  });
+
   it("get() sends Bearer token when present", async () => {
     let receivedAuth;
     let port;
@@ -178,6 +190,18 @@ describe("client", () => {
     mockDiscovery(port);
     const { getRaw } = await import("../src/client.mjs");
     await expect(getRaw("/bad")).rejects.toThrow("Invalid JSON");
+  });
+
+  it("getRaw() tolerates NaN in JSON content", async () => {
+    let port;
+    ({ server, port } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"time":NaN}');
+    }));
+    mockDiscovery(port);
+    const { getRaw } = await import("../src/client.mjs");
+    const result = await getRaw("/test");
+    expect(result.body).toContain('"time":NaN');
   });
 
   it("getRaw() rejects on non-200", async () => {

--- a/cli/test/format-test-results.test.mjs
+++ b/cli/test/format-test-results.test.mjs
@@ -26,6 +26,14 @@ describe("formatTestResults", () => {
     expect(logs[0]).toContain("1.2s");
   });
 
+  it("falls back to 0.0s when time is not finite", () => {
+    formatTestResults({
+      total: 0, passed: 0, failed: 0, errors: 0, ignored: 0,
+      time: Number.NaN, failures: [],
+    });
+    expect(logs[0]).toContain("0.0s");
+  });
+
   it("shows failed and error counts", () => {
     formatTestResults({
       total: 10, passed: 7, failed: 2, errors: 1, ignored: 0,


### PR DESCRIPTION
## Summary

This patch makes the CLI resilient when the Eclipse bridge returns non-finite numeric literals in test results, such as `time: NaN`.

## Concrete case

Command:

```powershell
jdt test cz.ifortuna.offer.structure.eps.write.topology.offer.category.OfferCategoryTest
```

Observed bridge payload:

```json
{"total":0,"passed":0,"failed":0,"errors":0,"ignored":0,"time":NaN,"failures":[]}
```

Observed CLI failure:

```text
Invalid JSON: {"total":0,"passed":0,"failed":0,"errors":0,"ignored":0,"time":NaN,"failures":[]}
```

## What changed

- sanitize `NaN`, `Infinity`, and `-Infinity` before JSON parsing in the CLI client
- make test result formatting fall back safely when `result.time` is not finite
- add tests for tolerant parsing and non-finite time formatting

## Why

`NaN` is not valid JSON, so the CLI can fail even though the underlying test run succeeded. This patch prevents that failure mode and keeps `jdt test` usable in integrations that consume the bridge response programmatically.

## Related issue

Closes #5

## Notes

A more complete long-term fix would also ensure the bridge itself never emits non-finite numeric literals in JSON responses.
