### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  cli:
+    name: CLI tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - run: npm ci
+      - run: npm test
+
+  plugin:
+    name: Plugin build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build and test
+        run: xvfb-run mvn clean verify -B -Pci
+        env:
+          MAVEN_OPTS: >-
+            -Djdk.xml.totalEntitySizeLimit=0
+            -Djdk.xml.maxGeneralEntitySizeLimit=0

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ coverage/
 
 # Generated
 *.target
+!jdtbridge.target
+!jdtbridge-ci.target
 *.class
 
 # OS

--- a/jdtbridge-ci.target
+++ b/jdtbridge-ci.target
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="jdtbridge-ci" sequenceNumber="1">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true"
+                  includeMode="planner" includeSource="false"
+                  type="InstallableUnit">
+            <repository location="https://download.eclipse.org/eclipse/updates/4.39/"/>
+            <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+        </location>
+    </locations>
+</target>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,17 @@
     <properties>
         <tycho.version>4.0.9</tycho.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <target.file>jdtbridge.target</target.file>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <properties>
+                <target.file>jdtbridge-ci.target</target.file>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -63,7 +73,7 @@
                 <version>${tycho.version}</version>
                 <configuration>
                     <target>
-                        <file>${project.basedir}/../jdtbridge.target</file>
+                        <file>${project.basedir}/../${target.file}</file>
                     </target>
                     <environments>
                         <environment>


### PR DESCRIPTION
## Summary

- Add two-job GitHub Actions workflow (`build.yml`): **CLI tests** (Node.js 22 / vitest) and **Plugin build** (Java 21 / Tycho / Maven)
- Add `jdtbridge-ci.target` — p2 target platform resolving Eclipse 4.39 from `download.eclipse.org`, no local Eclipse needed
- Add Maven profile `ci` (`-Pci`) to switch from the local target to the p2 target
- Default `mvn verify` still uses `jdtbridge.target` (local directory) — no change for local development

## How it works

| Command | Target platform | Use case |
|---------|----------------|----------|
| `mvn verify` | `jdtbridge.target` (local `D:/eclipse`) | Local development |
| `mvn verify -Pci` | `jdtbridge-ci.target` (p2 repository) | CI / clean builds |

The CI workflow uses `xvfb-run` on Linux to provide a virtual X11 display for headless SWT class loading, and sets JVM XML entity limits to handle the large Eclipse p2 metadata.

## Test plan

- [x] `mvn clean verify -Pci` passes locally (plugin + plugin.tests)
- [x] `npm test` in `cli/` passes (214 tests)
- [ ] GitHub Actions workflow runs successfully on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)