### PR TITLE
Migrate plugin tests to JUnit 5 Jupiter, upgrade Tycho to 5.0.2

### DIFF
--- a/plugin.tests/META-INF/MANIFEST.MF
+++ b/plugin.tests/META-INF/MANIFEST.MF
@@ -6,4 +6,5 @@ Bundle-SymbolicName: io.github.kaluchi.jdtbridge.tests
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: io.github.kaluchi.jdtbridge
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.junit;bundle-version="4.13"
+Require-Bundle: junit-jupiter-api;bundle-version="5.14",
+ org.opentest4j

--- a/plugin.tests/pom.xml
+++ b/plugin.tests/pom.xml
@@ -22,7 +22,22 @@
                 <configuration>
                     <useUIHarness>false</useUIHarness>
                     <useUIThread>false</useUIThread>
-                    <argLine>-Xmx512m</argLine>
+                    <argLine>-Xmx512m -Djdtbridge.integration-tests=true</argLine>
+                    <providerHint>junit5</providerHint>
+                    <dependencies>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>junit-platform-launcher</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>junit-platform-commons</artifactId>
+                        </dependency>
+                    </dependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ActivatorTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ActivatorTest.java
@@ -1,8 +1,8 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Activator utilities: token generation and bridge file format.
@@ -27,23 +27,23 @@ public class ActivatorTest {
     @Test
     public void tokenIs32HexChars() {
         String token = invokeGenerateToken();
-        assertEquals("Token should be 32 chars", 32, token.length());
-        assertTrue("Token should be lowercase hex: " + token,
-                HEX_32.matcher(token).matches());
+        assertEquals(32, token.length(), "Token should be 32 chars");
+        assertTrue(HEX_32.matcher(token).matches(),
+                "Token should be lowercase hex: " + token);
     }
 
     @Test
     public void tokenIsUnique() {
         String token1 = invokeGenerateToken();
         String token2 = invokeGenerateToken();
-        assertNotEquals("Tokens should differ", token1, token2);
+        assertNotEquals(token1, token2, "Tokens should differ");
     }
 
     @Test
     public void tokenContainsNoUpperCase() {
         String token = invokeGenerateToken();
-        assertEquals("Should be lowercase",
-                token, token.toLowerCase());
+        assertEquals(token, token.toLowerCase(),
+                "Should be lowercase");
     }
 
     // ---- Bridge file format ----
@@ -90,8 +90,8 @@ public class ActivatorTest {
 
             assertEquals(String.valueOf(port), parsed.get("port"));
             assertEquals(token, parsed.get("token"));
-            assertTrue("PID should be numeric",
-                    parsed.get("pid").matches("\\d+"));
+            assertTrue(parsed.get("pid").matches("\\d+"),
+                    "PID should be numeric");
             assertEquals("D:/test-workspace", parsed.get("workspace"));
         } finally {
             Files.deleteIfExists(tempFile);
@@ -104,10 +104,10 @@ public class ActivatorTest {
         String content = "port=8080\ntoken=abc\npid=1\nworkspace=/w\n";
         Map<String, String> parsed = parseBridgeFile(content);
 
-        assertTrue("Must have port", parsed.containsKey("port"));
-        assertTrue("Must have token", parsed.containsKey("token"));
-        assertTrue("Must have pid", parsed.containsKey("pid"));
-        assertTrue("Must have workspace", parsed.containsKey("workspace"));
+        assertTrue(parsed.containsKey("port"), "Must have port");
+        assertTrue(parsed.containsKey("token"), "Must have token");
+        assertTrue(parsed.containsKey("pid"), "Must have pid");
+        assertTrue(parsed.containsKey("workspace"), "Must have workspace");
     }
 
     // ---- Helpers ----

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsHandlerTest.java
@@ -1,8 +1,8 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for DiagnosticsHandler utility methods.

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
@@ -1,30 +1,32 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Integration tests for DiagnosticsHandler using a real JDT workspace.
  * The test project has a BrokenClass with an intentional compilation error.
  */
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
 public class DiagnosticsIntegrationTest {
 
     private static final DiagnosticsHandler handler =
             new DiagnosticsHandler();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TestFixture.create();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         TestFixture.destroy();
     }
@@ -35,12 +37,12 @@ public class DiagnosticsIntegrationTest {
         params.put("project", TestFixture.PROJECT_NAME);
         params.put("no-refresh", "");
         String json = handler.handleErrors(params);
-        assertTrue("Should find error in BrokenClass: " + json,
-                json.contains("BrokenClass"));
-        assertTrue("Should be ERROR severity: " + json,
-                json.contains("\"severity\":\"ERROR\""));
-        assertTrue("Should mention UnknownType: " + json,
-                json.contains("UnknownType"));
+        assertTrue(json.contains("BrokenClass"),
+                "Should find error in BrokenClass: " + json);
+        assertTrue(json.contains("\"severity\":\"ERROR\""),
+                "Should be ERROR severity: " + json);
+        assertTrue(json.contains("UnknownType"),
+                "Should mention UnknownType: " + json);
     }
 
     @Test
@@ -51,7 +53,7 @@ public class DiagnosticsIntegrationTest {
                 "/" + TestFixture.PROJECT_NAME + "/src/test/model/Dog.java");
         params.put("no-refresh", "");
         String json = handler.handleErrors(params);
-        assertEquals("Dog.java should have no errors", "[]", json);
+        assertEquals("[]", json, "Dog.java should have no errors");
     }
 
     @Test
@@ -62,8 +64,8 @@ public class DiagnosticsIntegrationTest {
         params.put("no-refresh", "");
         String json = handler.handleErrors(params);
         // Should at least find the ERROR
-        assertTrue("Should find errors: " + json,
-                json.contains("ERROR"));
+        assertTrue(json.contains("ERROR"),
+                "Should find errors: " + json);
     }
 
     @Test
@@ -72,7 +74,7 @@ public class DiagnosticsIntegrationTest {
         params.put("project", "no-such-project-xyz");
         params.put("no-refresh", "");
         String json = handler.handleErrors(params);
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/EdgeCaseIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/EdgeCaseIntegrationTest.java
@@ -1,28 +1,30 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Integration tests for edge cases: overloaded methods, inner classes,
  * enums, annotations, abstract classes.
  */
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
 public class EdgeCaseIntegrationTest {
 
     private static final SearchHandler search = new SearchHandler();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TestFixture.create();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         TestFixture.destroy();
     }
@@ -40,7 +42,7 @@ public class EdgeCaseIntegrationTest {
             count++;
             idx++;
         }
-        assertEquals("Should have 3 add() overloads", 3, count);
+        assertEquals(3, count, "Should have 3 add() overloads");
     }
 
     @Test
@@ -49,12 +51,12 @@ public class EdgeCaseIntegrationTest {
                 Map.of("class", "test.edge.Calculator", "method", "add"));
         // Without arity, all overloads should be returned
         String body = resp.body();
-        assertTrue("Should contain int overload: " + body,
-                body.contains("int add(int a, int b)"));
-        assertTrue("Should contain double overload: " + body,
-                body.contains("double add(double a, double b)"));
-        assertTrue("Should contain 3-arg overload: " + body,
-                body.contains("int add(int a, int b, int c)"));
+        assertTrue(body.contains("int add(int a, int b)"),
+                "Should contain int overload: " + body);
+        assertTrue(body.contains("double add(double a, double b)"),
+                "Should contain double overload: " + body);
+        assertTrue(body.contains("int add(int a, int b, int c)"),
+                "Should contain 3-arg overload: " + body);
     }
 
     @Test
@@ -63,11 +65,11 @@ public class EdgeCaseIntegrationTest {
                 Map.of("class", "test.edge.Calculator",
                         "method", "add", "arity", "3"));
         String body = resp.body();
-        assertTrue("Should contain 3-arg overload: " + body,
-                body.contains("int a, int b, int c"));
+        assertTrue(body.contains("int a, int b, int c"),
+                "Should contain 3-arg overload: " + body);
         // Should be a single method, not multiple
-        assertTrue("Should have start line header",
-                resp.headers().containsKey("X-Start-Line"));
+        assertTrue(resp.headers().containsKey("X-Start-Line"),
+                "Should have start line header");
     }
 
     @Test
@@ -85,16 +87,16 @@ public class EdgeCaseIntegrationTest {
     @Test
     public void findInnerClass() throws Exception {
         String json = search.handleFind(Map.of("name", "Inner"));
-        assertTrue("Should find Outer.Inner: " + json,
-                json.contains("test.edge.Outer.Inner")
-                        || json.contains("Outer$Inner"));
+        assertTrue(json.contains("test.edge.Outer.Inner")
+                        || json.contains("Outer$Inner"),
+                "Should find Outer.Inner: " + json);
     }
 
     @Test
     public void findStaticNested() throws Exception {
         String json = search.handleFind(Map.of("name", "StaticNested"));
-        assertTrue("Should find StaticNested: " + json,
-                json.contains("StaticNested"));
+        assertTrue(json.contains("StaticNested"),
+                "Should find StaticNested: " + json);
     }
 
     @Test
@@ -102,20 +104,20 @@ public class EdgeCaseIntegrationTest {
         // Inner classes are found by $ separator in JDT
         String json = search.handleTypeInfo(
                 Map.of("class", "test.edge.Outer"));
-        assertTrue("Should be a class: " + json,
-                json.contains("\"kind\":\"class\""));
-        assertTrue("Should have name field: " + json,
-                json.contains("\"name\":\"name\""));
+        assertTrue(json.contains("\"kind\":\"class\""),
+                "Should be a class: " + json);
+        assertTrue(json.contains("\"name\":\"name\""),
+                "Should have name field: " + json);
     }
 
     @Test
     public void sourceOuter() throws Exception {
         HttpServer.Response resp = search.handleSource(
                 Map.of("class", "test.edge.Outer"));
-        assertTrue("Should contain Inner: " + resp.body(),
-                resp.body().contains("public class Inner"));
-        assertTrue("Should contain StaticNested: " + resp.body(),
-                resp.body().contains("public static class StaticNested"));
+        assertTrue(resp.body().contains("public class Inner"),
+                "Should contain Inner: " + resp.body());
+        assertTrue(resp.body().contains("public static class StaticNested"),
+                "Should contain StaticNested: " + resp.body());
     }
 
     // ---- Enum ----
@@ -124,25 +126,25 @@ public class EdgeCaseIntegrationTest {
     public void typeInfoEnum() throws Exception {
         String json = search.handleTypeInfo(
                 Map.of("class", "test.edge.Color"));
-        assertTrue("Should be enum: " + json,
-                json.contains("\"kind\":\"enum\""));
-        assertTrue("Should have lower method: " + json,
-                json.contains("\"name\":\"lower\""));
+        assertTrue(json.contains("\"kind\":\"enum\""),
+                "Should be enum: " + json);
+        assertTrue(json.contains("\"name\":\"lower\""),
+                "Should have lower method: " + json);
     }
 
     @Test
     public void sourceEnum() throws Exception {
         HttpServer.Response resp = search.handleSource(
                 Map.of("class", "test.edge.Color"));
-        assertTrue("Should contain RED: " + resp.body(),
-                resp.body().contains("RED"));
+        assertTrue(resp.body().contains("RED"),
+                "Should contain RED: " + resp.body());
     }
 
     @Test
     public void findEnum() throws Exception {
         String json = search.handleFind(Map.of("name", "Color"));
-        assertTrue("Should find Color: " + json,
-                json.contains("test.edge.Color"));
+        assertTrue(json.contains("test.edge.Color"),
+                "Should find Color: " + json);
     }
 
     // ---- Annotation ----
@@ -151,18 +153,18 @@ public class EdgeCaseIntegrationTest {
     public void typeInfoAnnotation() throws Exception {
         String json = search.handleTypeInfo(
                 Map.of("class", "test.edge.Marker"));
-        assertTrue("Should be annotation: " + json,
-                json.contains("\"kind\":\"annotation\""));
+        assertTrue(json.contains("\"kind\":\"annotation\""),
+                "Should be annotation: " + json);
     }
 
     @Test
     public void sourceAnnotation() throws Exception {
         HttpServer.Response resp = search.handleSource(
                 Map.of("class", "test.edge.Marker"));
-        assertTrue("Should contain @Retention: " + resp.body(),
-                resp.body().contains("@Retention"));
-        assertTrue("Should contain value(): " + resp.body(),
-                resp.body().contains("String value()"));
+        assertTrue(resp.body().contains("@Retention"),
+                "Should contain @Retention: " + resp.body());
+        assertTrue(resp.body().contains("String value()"),
+                "Should contain value(): " + resp.body());
     }
 
     // ---- Abstract class + deeper hierarchy ----
@@ -171,37 +173,37 @@ public class EdgeCaseIntegrationTest {
     public void subtypesOfAbstract() throws Exception {
         String json = search.handleSubtypes(
                 Map.of("class", "test.edge.AbstractPet"));
-        assertTrue("Should find Parrot: " + json,
-                json.contains("test.edge.Parrot"));
+        assertTrue(json.contains("test.edge.Parrot"),
+                "Should find Parrot: " + json);
     }
 
     @Test
     public void hierarchyOfParrot() throws Exception {
         String json = search.handleHierarchy(
                 Map.of("class", "test.edge.Parrot"));
-        // Parrot → AbstractPet → Object
-        assertTrue("Should have AbstractPet in supers: " + json,
-                json.contains("test.edge.AbstractPet"));
-        assertTrue("Should have Object in supers: " + json,
-                json.contains("java.lang.Object"));
+        // Parrot -> AbstractPet -> Object
+        assertTrue(json.contains("test.edge.AbstractPet"),
+                "Should have AbstractPet in supers: " + json);
+        assertTrue(json.contains("java.lang.Object"),
+                "Should have Object in supers: " + json);
         // Parrot implements Animal (through AbstractPet)
-        assertTrue("Should have Animal in interfaces: " + json,
-                json.contains("test.model.Animal"));
+        assertTrue(json.contains("test.model.Animal"),
+                "Should have Animal in interfaces: " + json);
     }
 
     @Test
     public void deepSubtypesOfAnimal() throws Exception {
-        // Animal → Dog, Cat, AbstractPet, Parrot
+        // Animal -> Dog, Cat, AbstractPet, Parrot
         String json = search.handleSubtypes(
                 Map.of("class", "test.model.Animal"));
-        assertTrue("Should find Dog: " + json,
-                json.contains("test.model.Dog"));
-        assertTrue("Should find Cat: " + json,
-                json.contains("test.model.Cat"));
-        assertTrue("Should find AbstractPet: " + json,
-                json.contains("test.edge.AbstractPet"));
-        assertTrue("Should find Parrot: " + json,
-                json.contains("test.edge.Parrot"));
+        assertTrue(json.contains("test.model.Dog"),
+                "Should find Dog: " + json);
+        assertTrue(json.contains("test.model.Cat"),
+                "Should find Cat: " + json);
+        assertTrue(json.contains("test.edge.AbstractPet"),
+                "Should find AbstractPet: " + json);
+        assertTrue(json.contains("test.edge.Parrot"),
+                "Should find Parrot: " + json);
     }
 
     @Test
@@ -210,12 +212,12 @@ public class EdgeCaseIntegrationTest {
         // AbstractPet, and Parrot inherits it
         String json = search.handleImplementors(
                 Map.of("class", "test.model.Animal", "method", "name"));
-        assertTrue("Should find Dog: " + json,
-                json.contains("test.model.Dog"));
-        assertTrue("Should find Cat: " + json,
-                json.contains("test.model.Cat"));
-        assertTrue("Should find AbstractPet: " + json,
-                json.contains("test.edge.AbstractPet"));
+        assertTrue(json.contains("test.model.Dog"),
+                "Should find Dog: " + json);
+        assertTrue(json.contains("test.model.Cat"),
+                "Should find Cat: " + json);
+        assertTrue(json.contains("test.edge.AbstractPet"),
+                "Should find AbstractPet: " + json);
     }
 
     // ---- Project info with edge types ----
@@ -225,13 +227,13 @@ public class EdgeCaseIntegrationTest {
         ProjectHandler handler = new ProjectHandler();
         String json = handler.handleProjectInfo(
                 Map.of("project", TestFixture.PROJECT_NAME));
-        assertTrue("Should have test.edge: " + json,
-                json.contains("test.edge"));
-        assertTrue("Should have Calculator: " + json,
-                json.contains("Calculator"));
-        assertTrue("Should have Color as enum: " + json,
-                json.contains("\"kind\":\"enum\""));
-        assertTrue("Should have Marker as annotation: " + json,
-                json.contains("\"kind\":\"annotation\""));
+        assertTrue(json.contains("test.edge"),
+                "Should have test.edge: " + json);
+        assertTrue(json.contains("Calculator"),
+                "Should have Calculator: " + json);
+        assertTrue(json.contains("\"kind\":\"enum\""),
+                "Should have Color as enum: " + json);
+        assertTrue(json.contains("\"kind\":\"annotation\""),
+                "Should have Marker as annotation: " + json);
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpIntegrationTest.java
@@ -1,7 +1,7 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -9,30 +9,32 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Tests the HTTP server layer: real TCP connections, auth, routing.
  */
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
 public class HttpIntegrationTest {
 
     private static HttpServer server;
     private static int port;
     private static final String TOKEN = "test-secret-token-42";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TestFixture.create();
         server = new HttpServer();
         server.setToken(TOKEN);
         server.start();
         port = server.getPort();
-        assertTrue("Port should be assigned", port > 0);
+        assertTrue(port > 0, "Port should be assigned");
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         if (server != null) server.stop();
         TestFixture.destroy();
@@ -44,8 +46,8 @@ public class HttpIntegrationTest {
     public void noTokenReturns401() throws Exception {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost");
-        assertTrue("Should be 401: " + response,
-                response.startsWith("HTTP/1.1 401"));
+        assertTrue(response.startsWith("HTTP/1.1 401"),
+                "Should be 401: " + response);
     }
 
     @Test
@@ -53,8 +55,8 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost",
                 "Authorization: Bearer wrong-token");
-        assertTrue("Should be 401: " + response,
-                response.startsWith("HTTP/1.1 401"));
+        assertTrue(response.startsWith("HTTP/1.1 401"),
+                "Should be 401: " + response);
     }
 
     @Test
@@ -62,8 +64,8 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost",
                 "Authorization: Bearer " + TOKEN);
-        assertTrue("Should be 200: " + response,
-                response.startsWith("HTTP/1.1 200"));
+        assertTrue(response.startsWith("HTTP/1.1 200"),
+                "Should be 200: " + response);
     }
 
     @Test
@@ -71,8 +73,8 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost",
                 "Authorization: Basic dXNlcjpwYXNz");
-        assertTrue("Basic auth should be rejected: " + response,
-                response.startsWith("HTTP/1.1 401"));
+        assertTrue(response.startsWith("HTTP/1.1 401"),
+                "Basic auth should be rejected: " + response);
     }
 
     @Test
@@ -81,8 +83,8 @@ public class HttpIntegrationTest {
                 "Host: localhost",
                 "Authorization:  Bearer  " + TOKEN);
         // Extra spaces around Bearer — should fail (strict match)
-        assertTrue("Malformed Bearer should be 401: " + response,
-                response.startsWith("HTTP/1.1 401"));
+        assertTrue(response.startsWith("HTTP/1.1 401"),
+                "Malformed Bearer should be 401: " + response);
     }
 
     @Test
@@ -90,8 +92,8 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost",
                 "Authorization: ");
-        assertTrue("Empty auth should be 401: " + response,
-                response.startsWith("HTTP/1.1 401"));
+        assertTrue(response.startsWith("HTTP/1.1 401"),
+                "Empty auth should be 401: " + response);
     }
 
     @Test
@@ -100,8 +102,8 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost",
                 "authorization: Bearer " + TOKEN);
-        assertTrue("Lowercase header should work: " + response,
-                response.startsWith("HTTP/1.1 200"));
+        assertTrue(response.startsWith("HTTP/1.1 200"),
+                "Lowercase header should work: " + response);
     }
 
     @Test
@@ -121,8 +123,8 @@ public class HttpIntegrationTest {
                         new InputStreamReader(socket.getInputStream(),
                                 StandardCharsets.UTF_8));
                 String firstLine = reader.readLine();
-                assertTrue("No-token server should allow: " + firstLine,
-                        firstLine.startsWith("HTTP/1.1 200"));
+                assertTrue(firstLine.startsWith("HTTP/1.1 200"),
+                        "No-token server should allow: " + firstLine);
             }
         } finally {
             openServer.stop();
@@ -133,8 +135,8 @@ public class HttpIntegrationTest {
     public void error401BodyIsJson() throws Exception {
         String response = rawRequest("GET /projects HTTP/1.1",
                 "Host: localhost");
-        assertTrue("401 body should be JSON: " + response,
-                response.contains("{\"error\":\"Unauthorized\"}"));
+        assertTrue(response.contains("{\"error\":\"Unauthorized\"}"),
+                "401 body should be JSON: " + response);
     }
 
     // ---- Routing ----
@@ -142,39 +144,39 @@ public class HttpIntegrationTest {
     @Test
     public void projectsEndpoint() throws Exception {
         String body = authedGet("/projects");
-        assertTrue("Should be JSON array: " + body,
-                body.startsWith("["));
-        assertTrue("Should include test project: " + body,
-                body.contains(TestFixture.PROJECT_NAME));
+        assertTrue(body.startsWith("["),
+                "Should be JSON array: " + body);
+        assertTrue(body.contains(TestFixture.PROJECT_NAME),
+                "Should include test project: " + body);
     }
 
     @Test
     public void findEndpoint() throws Exception {
         String body = authedGet("/find?name=Dog&source");
-        assertTrue("Should find Dog: " + body,
-                body.contains("test.model.Dog"));
+        assertTrue(body.contains("test.model.Dog"),
+                "Should find Dog: " + body);
     }
 
     @Test
     public void unknownPathReturnsError() throws Exception {
         String body = authedGet("/nonexistent");
-        assertTrue("Should be error: " + body,
-                body.contains("Unknown path"));
+        assertTrue(body.contains("Unknown path"),
+                "Should be error: " + body);
     }
 
     @Test
     public void errorsEndpoint() throws Exception {
         String body = authedGet("/errors?project="
                 + TestFixture.PROJECT_NAME + "&no-refresh");
-        assertTrue("Should contain BrokenClass error: " + body,
-                body.contains("BrokenClass"));
+        assertTrue(body.contains("BrokenClass"),
+                "Should contain BrokenClass error: " + body);
     }
 
     @Test
     public void typeInfoEndpoint() throws Exception {
         String body = authedGet("/type-info?class=test.model.Animal");
-        assertTrue("Should be interface: " + body,
-                body.contains("\"kind\":\"interface\""));
+        assertTrue(body.contains("\"kind\":\"interface\""),
+                "Should be interface: " + body);
     }
 
     @Test
@@ -182,12 +184,12 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET /source?class=test.model.Dog HTTP/1.1",
                 "Host: localhost",
                 "Authorization: Bearer " + TOKEN);
-        assertTrue("Should be 200: " + response,
-                response.startsWith("HTTP/1.1 200"));
-        assertTrue("Should have X-File header: " + response,
-                response.contains("X-File:"));
-        assertTrue("Should have source body: " + response,
-                response.contains("public class Dog"));
+        assertTrue(response.startsWith("HTTP/1.1 200"),
+                "Should be 200: " + response);
+        assertTrue(response.contains("X-File:"),
+                "Should have X-File header: " + response);
+        assertTrue(response.contains("public class Dog"),
+                "Should have source body: " + response);
     }
 
     @Test
@@ -195,8 +197,8 @@ public class HttpIntegrationTest {
         // URL-encoded class name
         String body = authedGet(
                 "/type-info?class=test.model.Dog");
-        assertTrue("Should work with dots: " + body,
-                body.contains("test.model.Dog"));
+        assertTrue(body.contains("test.model.Dog"),
+                "Should work with dots: " + body);
     }
 
     // ---- Helpers ----

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpServerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpServerTest.java
@@ -1,9 +1,9 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for utility methods in HttpServer and Json.

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectHandlerTest.java
@@ -1,8 +1,8 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for ProjectHandler utility methods.

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectInfoIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectInfoIntegrationTest.java
@@ -1,26 +1,28 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Integration tests for ProjectHandler using a real JDT workspace.
  */
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
 public class ProjectInfoIntegrationTest {
 
     private static final ProjectHandler handler = new ProjectHandler();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TestFixture.create();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         TestFixture.destroy();
     }
@@ -29,36 +31,36 @@ public class ProjectInfoIntegrationTest {
     public void projectInfoBasicFields() throws Exception {
         String json = handler.handleProjectInfo(
                 Map.of("project", TestFixture.PROJECT_NAME));
-        assertTrue("Should have name: " + json,
-                json.contains("\"name\":\"" + TestFixture.PROJECT_NAME + "\""));
-        assertTrue("Should have totalTypes: " + json,
-                json.contains("\"totalTypes\":"));
-        assertTrue("Should have sourceRoots: " + json,
-                json.contains("\"sourceRoots\":["));
+        assertTrue(json.contains("\"name\":\"" + TestFixture.PROJECT_NAME + "\""),
+                "Should have name: " + json);
+        assertTrue(json.contains("\"totalTypes\":"),
+                "Should have totalTypes: " + json);
+        assertTrue(json.contains("\"sourceRoots\":["),
+                "Should have sourceRoots: " + json);
     }
 
     @Test
     public void projectInfoIncludesPackages() throws Exception {
         String json = handler.handleProjectInfo(
                 Map.of("project", TestFixture.PROJECT_NAME));
-        assertTrue("Should have test.model: " + json,
-                json.contains("test.model"));
-        assertTrue("Should have test.service: " + json,
-                json.contains("test.service"));
-        assertTrue("Should have test.broken: " + json,
-                json.contains("test.broken"));
+        assertTrue(json.contains("test.model"),
+                "Should have test.model: " + json);
+        assertTrue(json.contains("test.service"),
+                "Should have test.service: " + json);
+        assertTrue(json.contains("test.broken"),
+                "Should have test.broken: " + json);
     }
 
     @Test
     public void projectInfoIncludesTypes() throws Exception {
         String json = handler.handleProjectInfo(
                 Map.of("project", TestFixture.PROJECT_NAME));
-        assertTrue("Should have Animal: " + json,
-                json.contains("Animal"));
-        assertTrue("Should have Dog: " + json,
-                json.contains("Dog"));
-        assertTrue("Should have AnimalService: " + json,
-                json.contains("AnimalService"));
+        assertTrue(json.contains("Animal"),
+                "Should have Animal: " + json);
+        assertTrue(json.contains("Dog"),
+                "Should have Dog: " + json);
+        assertTrue(json.contains("AnimalService"),
+                "Should have AnimalService: " + json);
     }
 
     @Test
@@ -66,26 +68,26 @@ public class ProjectInfoIntegrationTest {
         // Small project — members should be included
         String json = handler.handleProjectInfo(
                 Map.of("project", TestFixture.PROJECT_NAME));
-        assertTrue("Should include members: " + json,
-                json.contains("\"membersIncluded\":true"));
+        assertTrue(json.contains("\"membersIncluded\":true"),
+                "Should include members: " + json);
         // With members, methods should be an object with visibility groups
-        assertTrue("Should have public methods: " + json,
-                json.contains("\"public\":["));
+        assertTrue(json.contains("\"public\":["),
+                "Should have public methods: " + json);
     }
 
     @Test
     public void projectInfoNotFound() throws Exception {
         String json = handler.handleProjectInfo(
                 Map.of("project", "nonexistent-xyz"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     @Test
     public void projectInfoHasJavaNature() throws Exception {
         String json = handler.handleProjectInfo(
                 Map.of("project", TestFixture.PROJECT_NAME));
-        assertTrue("Should have java nature: " + json,
-                json.contains("\"java\""));
+        assertTrue(json.contains("\"java\""),
+                "Should have java nature: " + json);
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
@@ -1,17 +1,18 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.jobs.Job;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Integration tests for RefactoringHandler: rename, move, format,
@@ -20,19 +21,20 @@ import org.junit.runners.MethodSorters;
  * Tests are ordered to avoid conflicts (rename changes names
  * that subsequent tests reference).
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
 public class RefactoringIntegrationTest {
 
     private static final RefactoringHandler handler =
             new RefactoringHandler();
     private static final SearchHandler search = new SearchHandler();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TestFixture.create();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         TestFixture.destroy();
     }
@@ -47,8 +49,8 @@ public class RefactoringIntegrationTest {
             String json = handler.handleOrganizeImports(
                     Map.of("file", filePath));
             // ImportTarget imports Map and Set but only uses List
-            assertTrue("Should remove unused imports: " + json,
-                    json.contains("\"removed\":2"));
+            assertTrue(json.contains("\"removed\":2"),
+                    "Should remove unused imports: " + json);
         } catch (IllegalArgumentException e) {
             // ProjectScope.getNode() fails in headless PDE tests
             // (no project preferences area). Works in full Eclipse.
@@ -65,10 +67,10 @@ public class RefactoringIntegrationTest {
             handler.handleOrganizeImports(Map.of("file", filePath));
             String json = handler.handleOrganizeImports(
                     Map.of("file", filePath));
-            assertTrue("Should have 0 added: " + json,
-                    json.contains("\"added\":0"));
-            assertTrue("Should have 0 removed: " + json,
-                    json.contains("\"removed\":0"));
+            assertTrue(json.contains("\"added\":0"),
+                    "Should have 0 added: " + json);
+            assertTrue(json.contains("\"removed\":0"),
+                    "Should have 0 removed: " + json);
         } catch (IllegalArgumentException e) {
             System.out.println("[SKIP] organize-imports: " + e);
         }
@@ -78,8 +80,8 @@ public class RefactoringIntegrationTest {
     public void a3_organizeImportsFileNotFound() throws Exception {
         String json = handler.handleOrganizeImports(
                 Map.of("file", "/no/such/File.java"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     // ---- Format ----
@@ -90,8 +92,8 @@ public class RefactoringIntegrationTest {
                 + "/src/test/refactor/FormatTarget.java";
         String json = handler.handleFormat(
                 Map.of("file", filePath));
-        assertTrue("Should be modified: " + json,
-                json.contains("\"modified\":true"));
+        assertTrue(json.contains("\"modified\":true"),
+                "Should be modified: " + json);
     }
 
     @Test
@@ -101,16 +103,16 @@ public class RefactoringIntegrationTest {
                 + "/src/test/refactor/FormatTarget.java";
         String json = handler.handleFormat(
                 Map.of("file", filePath));
-        assertTrue("Should not be modified: " + json,
-                json.contains("\"modified\":false"));
+        assertTrue(json.contains("\"modified\":false"),
+                "Should not be modified: " + json);
     }
 
     @Test
     public void b3_formatFileNotFound() throws Exception {
         String json = handler.handleFormat(
                 Map.of("file", "/no/such/File.java"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     // ---- Rename method ----
@@ -121,8 +123,8 @@ public class RefactoringIntegrationTest {
                 "class", "test.refactor.RenameTarget",
                 "method", "increment",
                 "newName", "incrementCounter"));
-        assertTrue("Should succeed: " + json,
-                json.contains("\"ok\":true"));
+        assertTrue(json.contains("\"ok\":true"),
+                "Should succeed: " + json);
 
         // Wait for build
         Job.getJobManager().join(
@@ -131,8 +133,8 @@ public class RefactoringIntegrationTest {
         // Verify caller updated
         String source = search.handleSource(
                 Map.of("class", "test.refactor.RenameCaller")).body();
-        assertTrue("Caller should use new name: " + source,
-                source.contains("incrementCounter"));
+        assertTrue(source.contains("incrementCounter"),
+                "Caller should use new name: " + source);
     }
 
     // ---- Rename field ----
@@ -144,16 +146,16 @@ public class RefactoringIntegrationTest {
                     "class", "test.refactor.RenameTarget",
                     "field", "counter",
                     "newName", "count"));
-            assertTrue("Should succeed: " + json,
-                    json.contains("\"ok\":true"));
+            assertTrue(json.contains("\"ok\":true"),
+                    "Should succeed: " + json);
 
             // Verify getter updated
             Job.getJobManager().join(
                     ResourcesPlugin.FAMILY_AUTO_BUILD, null);
             String source = search.handleSource(
                     Map.of("class", "test.refactor.RenameTarget")).body();
-            assertTrue("Should use new field name: " + source,
-                    source.contains("count"));
+            assertTrue(source.contains("count"),
+                    "Should use new field name: " + source);
         } catch (IllegalArgumentException e) {
             // RenameFieldProcessor needs ProjectScope for getter/setter
             // detection. Fails in headless PDE tests.
@@ -168,8 +170,8 @@ public class RefactoringIntegrationTest {
         String json = handler.handleRename(Map.of(
                 "class", "test.refactor.RenameTarget",
                 "newName", "RenamedTarget"));
-        assertTrue("Should succeed: " + json,
-                json.contains("\"ok\":true"));
+        assertTrue(json.contains("\"ok\":true"),
+                "Should succeed: " + json);
 
         // Wait for build
         Job.getJobManager().join(
@@ -177,14 +179,14 @@ public class RefactoringIntegrationTest {
 
         // Verify new type exists
         String findJson = search.handleFind(Map.of("name", "RenamedTarget"));
-        assertTrue("Should find renamed type: " + findJson,
-                findJson.contains("test.refactor.RenamedTarget"));
+        assertTrue(findJson.contains("test.refactor.RenamedTarget"),
+                "Should find renamed type: " + findJson);
 
         // Verify caller references updated
         String callerSrc = search.handleSource(
                 Map.of("class", "test.refactor.RenameCaller")).body();
-        assertTrue("Caller should reference RenamedTarget: " + callerSrc,
-                callerSrc.contains("RenamedTarget"));
+        assertTrue(callerSrc.contains("RenamedTarget"),
+                "Caller should reference RenamedTarget: " + callerSrc);
     }
 
     // ---- Move ----
@@ -195,8 +197,8 @@ public class RefactoringIntegrationTest {
             String json = handler.handleMove(Map.of(
                     "class", "test.refactor.RenameCaller",
                     "target", "test.moved"));
-            assertTrue("Should succeed: " + json,
-                    json.contains("\"ok\":true"));
+            assertTrue(json.contains("\"ok\":true"),
+                    "Should succeed: " + json);
 
             // Wait for build
             Job.getJobManager().join(
@@ -205,8 +207,8 @@ public class RefactoringIntegrationTest {
             // Verify type in new package
             String findJson = search.handleFind(
                     Map.of("name", "RenameCaller"));
-            assertTrue("Should be in test.moved: " + findJson,
-                    findJson.contains("test.moved.RenameCaller"));
+            assertTrue(findJson.contains("test.moved.RenameCaller"),
+                    "Should be in test.moved: " + findJson);
         } catch (IllegalArgumentException e) {
             // MoveCuUpdateCreator needs ProjectScope for import rewriting.
             // Fails in headless PDE tests.
@@ -220,31 +222,31 @@ public class RefactoringIntegrationTest {
     public void e1_renameMissingClass() throws Exception {
         String json = handler.handleRename(
                 Map.of("newName", "Foo"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     @Test
     public void e2_renameMissingNewName() throws Exception {
         String json = handler.handleRename(
                 Map.of("class", "test.model.Dog"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     @Test
     public void e3_renameTypeNotFound() throws Exception {
         String json = handler.handleRename(
                 Map.of("class", "no.such.Type", "newName", "X"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     @Test
     public void e4_moveMissingTarget() throws Exception {
         String json = handler.handleMove(
                 Map.of("class", "test.model.Dog"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/SearchIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/SearchIntegrationTest.java
@@ -1,29 +1,31 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Integration tests for SearchHandler using a real JDT workspace.
  * Creates a test project with known classes, then verifies search results.
  */
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
 public class SearchIntegrationTest {
 
     private static final SearchHandler handler = new SearchHandler();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TestFixture.create();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws Exception {
         TestFixture.destroy();
     }
@@ -33,33 +35,33 @@ public class SearchIntegrationTest {
     @Test
     public void findByExactName() throws Exception {
         String json = handler.handleFind(Map.of("name", "Animal"));
-        assertTrue("Should find Animal: " + json,
-                json.contains("test.model.Animal"));
+        assertTrue(json.contains("test.model.Animal"),
+                "Should find Animal: " + json);
     }
 
     @Test
     public void findByPattern() throws Exception {
         String json = handler.handleFind(Map.of("name", "*Service"));
-        assertTrue("Should find AnimalService: " + json,
-                json.contains("test.service.AnimalService"));
+        assertTrue(json.contains("test.service.AnimalService"),
+                "Should find AnimalService: " + json);
     }
 
     @Test
     public void findSourceOnly() throws Exception {
         String json = handler.handleFind(
                 Map.of("name", "Dog", "source", ""));
-        assertTrue("Should find source Dog: " + json,
-                json.contains("test.model.Dog"));
+        assertTrue(json.contains("test.model.Dog"),
+                "Should find source Dog: " + json);
         // Should not include binary JDK types
-        assertFalse("Should not contain binary: " + json,
-                json.contains("binary"));
+        assertFalse(json.contains("binary"),
+                "Should not contain binary: " + json);
     }
 
     @Test
     public void findMissingParam() throws Exception {
         String json = handler.handleFind(Map.of());
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     @Test
@@ -75,25 +77,25 @@ public class SearchIntegrationTest {
     public void subtypesOfInterface() throws Exception {
         String json = handler.handleSubtypes(
                 Map.of("class", "test.model.Animal"));
-        assertTrue("Should find Dog: " + json,
-                json.contains("test.model.Dog"));
-        assertTrue("Should find Cat: " + json,
-                json.contains("test.model.Cat"));
+        assertTrue(json.contains("test.model.Dog"),
+                "Should find Dog: " + json);
+        assertTrue(json.contains("test.model.Cat"),
+                "Should find Cat: " + json);
     }
 
     @Test
     public void subtypesOfClass() throws Exception {
         String json = handler.handleSubtypes(
                 Map.of("class", "test.model.Dog"));
-        assertEquals("Dog has no subtypes", "[]", json);
+        assertEquals("[]", json, "Dog has no subtypes");
     }
 
     @Test
     public void subtypesNotFound() throws Exception {
         String json = handler.handleSubtypes(
                 Map.of("class", "no.such.Type"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     // ---- /hierarchy ----
@@ -103,24 +105,24 @@ public class SearchIntegrationTest {
         String json = handler.handleHierarchy(
                 Map.of("class", "test.model.Dog"));
         // Dog extends Object
-        assertTrue("Should have Object in supers: " + json,
-                json.contains("java.lang.Object"));
+        assertTrue(json.contains("java.lang.Object"),
+                "Should have Object in supers: " + json);
         // Dog implements Animal
-        assertTrue("Should have Animal in interfaces: " + json,
-                json.contains("test.model.Animal"));
+        assertTrue(json.contains("test.model.Animal"),
+                "Should have Animal in interfaces: " + json);
         // Dog has no subtypes
-        assertTrue("Should have empty subtypes: " + json,
-                json.contains("\"subtypes\":[]"));
+        assertTrue(json.contains("\"subtypes\":[]"),
+                "Should have empty subtypes: " + json);
     }
 
     @Test
     public void hierarchyOfAnimal() throws Exception {
         String json = handler.handleHierarchy(
                 Map.of("class", "test.model.Animal"));
-        assertTrue("Should have Dog in subtypes: " + json,
-                json.contains("test.model.Dog"));
-        assertTrue("Should have Cat in subtypes: " + json,
-                json.contains("test.model.Cat"));
+        assertTrue(json.contains("test.model.Dog"),
+                "Should have Dog in subtypes: " + json);
+        assertTrue(json.contains("test.model.Cat"),
+                "Should have Cat in subtypes: " + json);
     }
 
     // ---- /references ----
@@ -129,16 +131,16 @@ public class SearchIntegrationTest {
     public void referencesToType() throws Exception {
         String json = handler.handleReferences(
                 Map.of("class", "test.model.Dog"));
-        assertTrue("Should find ref in AnimalService: " + json,
-                json.contains("AnimalService"));
+        assertTrue(json.contains("AnimalService"),
+                "Should find ref in AnimalService: " + json);
     }
 
     @Test
     public void referencesToMethod() throws Exception {
         String json = handler.handleReferences(
                 Map.of("class", "test.model.Dog", "method", "bark"));
-        assertTrue("Should find bark() ref: " + json,
-                json.contains("AnimalService"));
+        assertTrue(json.contains("AnimalService"),
+                "Should find bark() ref: " + json);
     }
 
     @Test
@@ -153,8 +155,8 @@ public class SearchIntegrationTest {
     public void referencesMethodNotFound() throws Exception {
         String json = handler.handleReferences(
                 Map.of("class", "test.model.Dog", "method", "fly"));
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
     }
 
     // ---- /implementors ----
@@ -163,10 +165,10 @@ public class SearchIntegrationTest {
     public void implementorsOfInterfaceMethod() throws Exception {
         String json = handler.handleImplementors(
                 Map.of("class", "test.model.Animal", "method", "name"));
-        assertTrue("Should find Dog.name: " + json,
-                json.contains("test.model.Dog"));
-        assertTrue("Should find Cat.name: " + json,
-                json.contains("test.model.Cat"));
+        assertTrue(json.contains("test.model.Dog"),
+                "Should find Dog.name: " + json);
+        assertTrue(json.contains("test.model.Cat"),
+                "Should find Cat.name: " + json);
     }
 
     // ---- /type-info ----
@@ -175,24 +177,24 @@ public class SearchIntegrationTest {
     public void typeInfoClass() throws Exception {
         String json = handler.handleTypeInfo(
                 Map.of("class", "test.model.Dog"));
-        assertTrue("Should be class: " + json,
-                json.contains("\"kind\":\"class\""));
-        assertTrue("Should have name method: " + json,
-                json.contains("\"name\":\"name\""));
-        assertTrue("Should have bark method: " + json,
-                json.contains("\"name\":\"bark\""));
-        assertTrue("Should have age field: " + json,
-                json.contains("\"name\":\"age\""));
-        assertTrue("Should implement Animal: " + json,
-                json.contains("Animal"));
+        assertTrue(json.contains("\"kind\":\"class\""),
+                "Should be class: " + json);
+        assertTrue(json.contains("\"name\":\"name\""),
+                "Should have name method: " + json);
+        assertTrue(json.contains("\"name\":\"bark\""),
+                "Should have bark method: " + json);
+        assertTrue(json.contains("\"name\":\"age\""),
+                "Should have age field: " + json);
+        assertTrue(json.contains("Animal"),
+                "Should implement Animal: " + json);
     }
 
     @Test
     public void typeInfoInterface() throws Exception {
         String json = handler.handleTypeInfo(
                 Map.of("class", "test.model.Animal"));
-        assertTrue("Should be interface: " + json,
-                json.contains("\"kind\":\"interface\""));
+        assertTrue(json.contains("\"kind\":\"interface\""),
+                "Should be interface: " + json);
     }
 
     // ---- /source ----
@@ -202,10 +204,10 @@ public class SearchIntegrationTest {
         HttpServer.Response resp = handler.handleSource(
                 Map.of("class", "test.model.Dog"));
         assertEquals("text/plain", resp.contentType());
-        assertTrue("Should contain class body: " + resp.body(),
-                resp.body().contains("public class Dog"));
-        assertTrue("Should contain bark method: " + resp.body(),
-                resp.body().contains("public void bark()"));
+        assertTrue(resp.body().contains("public class Dog"),
+                "Should contain class body: " + resp.body());
+        assertTrue(resp.body().contains("public void bark()"),
+                "Should contain bark method: " + resp.body());
     }
 
     @Test
@@ -213,18 +215,18 @@ public class SearchIntegrationTest {
         HttpServer.Response resp = handler.handleSource(
                 Map.of("class", "test.model.Dog", "method", "bark"));
         assertEquals("text/plain", resp.contentType());
-        assertTrue("Should contain bark: " + resp.body(),
-                resp.body().contains("bark"));
-        assertTrue("Should have line header",
-                resp.headers().containsKey("X-Start-Line"));
+        assertTrue(resp.body().contains("bark"),
+                "Should contain bark: " + resp.body());
+        assertTrue(resp.headers().containsKey("X-Start-Line"),
+                "Should have line header");
     }
 
     @Test
     public void sourceNotFound() throws Exception {
         HttpServer.Response resp = handler.handleSource(
                 Map.of("class", "no.such.Type"));
-        assertTrue("Should be error JSON: " + resp.body(),
-                resp.body().contains("error"));
+        assertTrue(resp.body().contains("error"),
+                "Should be error JSON: " + resp.body());
     }
 
     // ---- /projects ----
@@ -232,7 +234,7 @@ public class SearchIntegrationTest {
     @Test
     public void projectsIncludesTestProject() throws Exception {
         String json = handler.handleProjects();
-        assertTrue("Should include test project: " + json,
-                json.contains(TestFixture.PROJECT_NAME));
+        assertTrue(json.contains(TestFixture.PROJECT_NAME),
+                "Should include test project: " + json);
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
@@ -1,0 +1,95 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Integration tests for TestHandler that require a real JDT workspace.
+ */
+@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")
+public class TestHandlerIntegrationTest {
+
+    private static final TestHandler handler = new TestHandler();
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        TestFixture.create();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        TestFixture.destroy();
+    }
+
+    @Test
+    public void missingParams() throws Exception {
+        String json = handler.handleTest(Map.of());
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
+        assertTrue(json.contains("Missing"),
+                "Should mention missing param: " + json);
+    }
+
+    @Test
+    public void typeNotFound() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("class", "no.such.TestClass");
+        params.put("no-refresh", "");
+        String json = handler.handleTest(params);
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
+        assertTrue(json.contains("not found"),
+                "Should mention not found: " + json);
+    }
+
+    @Test
+    public void projectNotFound() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("project", "nonexistent-project-xyz");
+        params.put("no-refresh", "");
+        String json = handler.handleTest(params);
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
+    }
+
+    @Test
+    public void detectTestKindJunit4() throws Exception {
+        // test.model.Dog has no JUnit 5 on classpath -> JUnit 4
+        Object type = invokeFindType("test.model.Dog");
+        String kind = invokeDetectTestKind(type);
+        assertEquals("org.eclipse.jdt.junit.loader.junit4", kind);
+    }
+
+    private Object invokeFindType(String fqn) {
+        try {
+            Class<?> clazz = Class.forName(
+                    "io.github.kaluchi.jdtbridge.JdtUtils");
+            var method = clazz
+                    .getDeclaredMethod("findType", String.class);
+            method.setAccessible(true);
+            return method.invoke(null, fqn);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String invokeDetectTestKind(Object type) {
+        try {
+            var method = TestHandler.class
+                    .getDeclaredMethod("detectTestKind",
+                            org.eclipse.jdt.core.IType.class);
+            method.setAccessible(true);
+            return (String) method.invoke(handler, type);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
@@ -1,11 +1,8 @@
 package io.github.kaluchi.jdtbridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Proxy;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -14,82 +11,15 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
- * Tests for TestHandler: error cases and utility methods.
- *
- * Note: actually running JUnit tests via TestHandler requires the test
- * project to have JUnit on its classpath, which is complex to set up
- * in a PDE test environment. These tests verify the handler's error
- * handling and parameter validation.
+ * Unit tests for TestHandler utility methods.
+ * Uses dynamic proxies for JDT interfaces — no workspace needed.
  */
 public class TestHandlerTest {
 
     private static final TestHandler handler = new TestHandler();
-    private static boolean fixtureReady;
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        try {
-            TestFixture.create();
-            fixtureReady = true;
-        } catch (IllegalStateException e) {
-            fixtureReady = false;
-        }
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        if (!fixtureReady) return;
-        TestFixture.destroy();
-    }
-
-    @Test
-    public void missingParams() throws Exception {
-        assumeFixtureReady();
-        String json = handler.handleTest(Map.of());
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
-        assertTrue("Should mention missing param: " + json,
-                json.contains("Missing"));
-    }
-
-    @Test
-    public void typeNotFound() throws Exception {
-        assumeFixtureReady();
-        Map<String, String> params = new HashMap<>();
-        params.put("class", "no.such.TestClass");
-        params.put("no-refresh", "");
-        String json = handler.handleTest(params);
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
-        assertTrue("Should mention not found: " + json,
-                json.contains("not found"));
-    }
-
-    @Test
-    public void projectNotFound() throws Exception {
-        assumeFixtureReady();
-        Map<String, String> params = new HashMap<>();
-        params.put("project", "nonexistent-project-xyz");
-        params.put("no-refresh", "");
-        String json = handler.handleTest(params);
-        assertTrue("Should return error: " + json,
-                json.contains("error"));
-    }
-
-    @Test
-    public void detectTestKindJunit4() throws Exception {
-        assumeFixtureReady();
-        // test.model.Dog has no JUnit 5 on classpath → JUnit 4
-        Object type = invokeFindType("test.model.Dog");
-        String kind = invokeDetectTestKind(type);
-        assertEquals("org.eclipse.jdt.junit.loader.junit4", kind);
-    }
 
     @Test
     public void detectTestKindJunit5FromPlatformCommons() {
@@ -139,32 +69,7 @@ public class TestHandlerTest {
         assertEquals(120, invokeParseTimeout("abc", 120));
     }
 
-    // ---- Reflection helpers ----
-
-    private Object invokeFindType(String fqn) {
-        try {
-            Class<?> clazz = Class.forName(
-                    "io.github.kaluchi.jdtbridge.JdtUtils");
-            var method = clazz
-                    .getDeclaredMethod("findType", String.class);
-            method.setAccessible(true);
-            return method.invoke(null, fqn);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private String invokeDetectTestKind(Object type) {
-        try {
-            var method = TestHandler.class
-                    .getDeclaredMethod("detectTestKind",
-                            org.eclipse.jdt.core.IType.class);
-            method.setAccessible(true);
-            return (String) method.invoke(handler, type);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+    // ---- Helpers ----
 
     private int invokeParseTimeout(String s, int defaultVal) {
         try {
@@ -176,11 +81,6 @@ public class TestHandlerTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void assumeFixtureReady() {
-        Assume.assumeTrue("Workspace-backed fixture unavailable",
-                fixtureReady);
     }
 
     private IJavaProject fakeProjectWithMarker(String markerFqn,

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     </modules>
 
     <properties>
-        <tycho.version>4.0.9</tycho.version>
+        <tycho.version>5.0.2</tycho.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <target.file>jdtbridge.target</target.file>
     </properties>


### PR DESCRIPTION
## Summary

- **Tycho 4.0.9 → 5.0.2** (4.x is EOL)
- **JUnit 4 → JUnit 5 Jupiter** across all 12 test classes
- **Integration test gating** via `@EnabledIfSystemProperty(named="jdtbridge.integration-tests")` — runs in `mvn verify`, cleanly ignored by `jdt test` / Eclipse
- **Split TestHandlerTest** into unit-only `TestHandlerTest` and workspace-dependent `TestHandlerIntegrationTest`, removing the runtime `Assume.assumeTrue()` workaround

## What changed

| File | Change |
|------|--------|
| `pom.xml` | Tycho 4.0.9 → 5.0.2 |
| `plugin.tests/META-INF/MANIFEST.MF` | `org.junit` → `junit-jupiter-api` + `org.opentest4j` |
| `plugin.tests/pom.xml` | junit5 provider, engine/platform deps, `-Djdtbridge.integration-tests=true` |
| 5 unit test classes | JUnit 4 → Jupiter imports and assertion signatures |
| 6 integration test classes | JUnit 4 → Jupiter + `@EnabledIfSystemProperty` on class |
| `TestHandlerIntegrationTest.java` | **New** — extracted from TestHandlerTest |
| `TestHandlerTest.java` | Stripped to pure unit tests (Proxy mocks, no workspace) |

## Test plan

- [x] `mvn clean verify` — all 112 tests pass (29 unit + 83 integration)
- [x] `mvn clean verify -Pci` — same, via p2 target platform
- [x] `jdt test --project io.github.kaluchi.jdtbridge.tests` — 29 passed, 83 ignored, 0 failures
- [x] No JUnit 4 imports remain (`import org.junit.Assert/Test/Before/After` = 0 matches)
- [ ] GitHub Actions CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)