### PR TITLE
Make environment check mandatory in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # JDT Bridge — Agent Instructions
 
-## First-time setup check
+## Environment check (REQUIRED)
 
-Before doing any work, verify the development environment:
+**MUST run these checks at the start of every conversation, before any other work.** Do not skip this even if the user's request seems unrelated — the `jdt` CLI is central to this project and must be verified working.
 
 1. **Check if `jdt` CLI is available:** run `jdt setup --check`
    - If the command is not found: `cd cli && npm install && npm link`


### PR DESCRIPTION
## Summary
- Rename "First-time setup check" → "Environment check (REQUIRED)"
- Strengthen wording so AI agents never skip `jdt setup --check` verification at conversation start

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm new wording triggers mandatory checks in agent conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)