### PR TITLE
Gitignore local-only files and add shared Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(jdt *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,13 +11,15 @@ coverage/
 
 # Generated
 *.target
-!jdtbridge.target
 !jdtbridge-ci.target
 *.class
 
 # OS
 .DS_Store
 Thumbs.db
+
+# Claude Code (local per-developer settings)
+.claude/settings.local.json
 
 # IDEs
 .idea/


### PR DESCRIPTION
## Summary
- Remove `!jdtbridge.target` exception from `.gitignore` — file is per-developer and should stay ignored
- Add `.claude/settings.local.json` to `.gitignore` — local per-developer settings
- Add `.claude/settings.json` with `Bash(jdt *)` permission so all agents can use the jdt CLI without prompts

## Test plan
- [ ] `git check-ignore jdtbridge.target` returns the file
- [ ] `git check-ignore .claude/settings.local.json` returns the file
- [ ] `.claude/settings.json` is tracked and visible in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)