### PR TITLE
Fix JUnit 5 detection when junit-platform-commons is not resolvable

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
@@ -55,6 +55,26 @@ public class TestHandlerTest {
     }
 
     @Test
+    public void detectTestKindJunit5FallbackFromJupiterApi() {
+        // Platform markers not resolvable, but Jupiter API is
+        IJavaProject project = fakeProjectWithFallbackOnly(
+                "org.junit.jupiter.api.Test");
+
+        String kind = handler.detectTestKind(project);
+
+        assertEquals("org.eclipse.jdt.junit.loader.junit5", kind);
+    }
+
+    @Test
+    public void detectTestKindFallsBackToJunit4WhenNothingFound() {
+        IJavaProject project = fakeProjectWithFallbackOnly(null);
+
+        String kind = handler.detectTestKind(project);
+
+        assertEquals("org.eclipse.jdt.junit.loader.junit4", kind);
+    }
+
+    @Test
     public void parseTimeoutDefault() {
         assertEquals(120, invokeParseTimeout(null, 120));
     }
@@ -81,6 +101,31 @@ public class TestHandlerTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Project where platform markers are NOT resolvable,
+     * but an optional fallback type IS (e.g. Jupiter API
+     * present without junit-platform-commons).
+     */
+    private IJavaProject fakeProjectWithFallbackOnly(
+            String fallbackFqn) {
+        return (IJavaProject) Proxy.newProxyInstance(
+                IJavaProject.class.getClassLoader(),
+                new Class<?>[] { IJavaProject.class },
+                (proxy, method, args) -> {
+                    if ("findType".equals(method.getName())
+                            && args != null
+                            && args.length == 1
+                            && fallbackFqn != null
+                            && fallbackFqn.equals(args[0])) {
+                        return fakeType(fallbackFqn,
+                                "junit-jupiter-api-5.12.1.jar",
+                                new Path("/libs/junit-jupiter-api"
+                                        + "-5.12.1.jar"));
+                    }
+                    return defaultValue(method.getReturnType());
+                });
     }
 
     private IJavaProject fakeProjectWithMarker(String markerFqn,

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -344,6 +344,12 @@ class TestHandler {
                     JUnitCore.JUNIT6_CONTAINER_PATH)) {
                 return JUNIT5_KIND;
             }
+            // Fallback: Jupiter API on classpath but platform
+            // marker not resolvable (common with M2Eclipse)
+            if (project.findType(
+                    "org.junit.jupiter.api.Test") != null) {
+                return JUNIT5_KIND;
+            }
         } catch (JavaModelException e) {
             Log.warn("detectTestKind failed", e);
         }


### PR DESCRIPTION
## Summary

- `detectTestKind` fell back to JUnit 4 when M2Eclipse did not resolve `junit-platform-commons` on the Eclipse classpath, even though `junit-jupiter-api` was available
- This caused `Cannot find junit.framework.TestCase` errors when running tests via `jdt test` for pure JUnit 5 projects (e.g. Spring Boot tests with `@SpringJUnitConfig`)
- Added a fallback in `detectTestKind` that checks for `org.junit.jupiter.api.Test` on the classpath when the platform marker types (`Testable`, `Suite`) are not found
- Added 2 unit tests covering the fallback and the JUnit 4 default case

## Test plan

- [x] `mvn clean verify` — 114 tests passed (unit + integration)
- [x] `jdt test io.github.kaluchi.jdtbridge.TestHandlerTest` — 8/8 passed
- [x] Verified fix on real project: `jdt test --project m8-file-cache-client` — 5/5 passed (was failing before)
- [x] Verified no regression: `jdt test --project m8-client-gwt` — 90/90 passed (JUnit 4 project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)