### PR TITLE
Add standalone build command, simplify errors to pure query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ The `jdt` CLI gives you the same semantic understanding of Java code that a deve
 | Task | Use `jdt` | Not grep |
 |------|-----------|----------|
 | Find call sites | `jdt refs <FQN> <method>` | grep returns string matches, comments, identically-named methods |
-| Check compilation | `jdt errors --project <name>` | Maven takes 30-90s, jdt is sub-second |
+| Check compilation | `jdt errors --project <name>` | Maven takes 30-90s, jdt is instant |
+| Trigger build | `jdt build --project <name> [--clean]` | `mvn compile` has 30s+ overhead |
 | Read library source | `jdt source <FQN>` | Library sources are inside JARs — grep can't reach them |
 | Type hierarchy | `jdt hierarchy <FQN>` | grep for "extends/implements" misses transitive hierarchy |
 | Run single test | `jdt test <FQN> [method]` | Maven Surefire has 30s+ lifecycle overhead |
@@ -48,6 +49,7 @@ jdt hierarchy <FQN>                       supers + interfaces + subtypes
 jdt impl <FQN> <method> [--arity N]       implementations of interface method
 jdt type-info <FQN>                       class overview (fields, methods, signatures)
 jdt source <FQN> [method] [--arity N]     source code (project + library classes)
+jdt build [--project <name>] [--clean]    build project (incremental or clean)
 jdt test <FQN> [method]                   run JUnit test
 jdt errors [--project <name>]             compilation errors
 jdt format <file>                         format with Eclipse settings

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Multiple Eclipse instances are supported — each writes its own instance file, 
 
 ## Known limitations
 
-- **Workspace must be fully built.** JDT search relies on the Eclipse index. If the workspace hasn't been fully indexed, results may be incomplete. Use `jdt errors --build` or `--clean` to trigger builds.
+- **Workspace must be fully built.** JDT search relies on the Eclipse index. If the workspace hasn't been fully indexed, results may be incomplete. Use `jdt build` or `jdt build --clean` to trigger builds.
 
 ## License
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -41,21 +41,20 @@ jdt type-info <FQN>                                    # (alias: ti) class overv
 jdt source <FQN> [method] [--arity N]                  # (alias: src) source code (project + libraries)
 ```
 
-### Testing
+### Testing & building
 
 ```bash
+jdt build [--project <name>] [--clean]                 # (alias: b) build project
 jdt test <FQN> [method] [--timeout N]                  # run JUnit test class or method
 jdt test --project <name> [--package <pkg>]            # run tests in project/package
 ```
 
-Tests auto-refresh from disk and wait for auto-build. Use `--no-refresh` to skip.
+All commands auto-refresh from disk. `build` is the only command that triggers explicit builds.
 
 ### Diagnostics
 
 ```bash
 jdt errors [--project <name>] [--file <path>]          # (alias: err) compilation errors
-jdt errors --build                                     # trigger incremental build
-jdt errors --clean --project <name>                    # clean + full rebuild
 jdt errors --warnings --all                            # include warnings and all marker types
 ```
 

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -10,6 +10,7 @@ import { hierarchy, help as hierarchyHelp } from "./commands/hierarchy.mjs";
 import { implementors, help as implementorsHelp } from "./commands/implementors.mjs";
 import { typeInfo, help as typeInfoHelp } from "./commands/type-info.mjs";
 import { source, help as sourceHelp } from "./commands/source.mjs";
+import { build, help as buildHelp } from "./commands/build.mjs";
 import { test, help as testHelp } from "./commands/test.mjs";
 import { errors, help as errorsHelp } from "./commands/errors.mjs";
 import {
@@ -42,6 +43,7 @@ const commands = {
   implementors: { fn: implementors, help: implementorsHelp },
   "type-info": { fn: typeInfo, help: typeInfoHelp },
   source: { fn: source, help: sourceHelp },
+  build: { fn: build, help: buildHelp },
   test: { fn: test, help: testHelp },
   errors: { fn: errors, help: errorsHelp },
   "organize-imports": { fn: organizeImports, help: organizeImportsHelp },
@@ -64,6 +66,7 @@ const aliases = {
   oi: "organize-imports",
   ae: "active-editor",
   src: "source",
+  b: "build",
   err: "errors",
   fmt: "format",
 };
@@ -100,12 +103,13 @@ Search & navigation:
   type-info${fmtAliases("type-info")} <FQN>                             class overview (fields, methods, line numbers)
   source${fmtAliases("source")} <FQN> [method] [--arity n]           type or method source code (project and libraries)
 
-Testing:
+Testing & building:
+  build${fmtAliases("build")} [--project <name>] [--clean]      build project (incremental or clean)
   test <FQN> [method]                         run JUnit test class or method
   test --project <name> [--package <pkg>]     run tests in project/package
 
 Diagnostics:
-  errors${fmtAliases("errors")} [--file <path>] [--project <name>]   compilation errors (refresh by default)
+  errors${fmtAliases("errors")} [--file <path>] [--project <name>]   compilation errors
 
 Refactoring:
   organize-imports${fmtAliases("organize-imports")} <file>                     organize imports

--- a/cli/src/commands/build.mjs
+++ b/cli/src/commands/build.mjs
@@ -1,0 +1,40 @@
+import { get } from "../client.mjs";
+import { parseFlags } from "../args.mjs";
+
+export async function build(args) {
+  const flags = parseFlags(args);
+  const params = [];
+  if (flags.project) params.push(`project=${encodeURIComponent(flags.project)}`);
+  if (flags.clean) params.push("clean");
+
+  let url = "/build";
+  if (params.length > 0) url += "?" + params.join("&");
+  const result = await get(url, 180_000);
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+  const n = result.errors || 0;
+  if (n === 0) {
+    console.log("Build complete (0 errors)");
+  } else {
+    console.log(`Build complete (${n} errors)`);
+    process.exit(1);
+  }
+}
+
+export const help = `Build a project via Eclipse incremental or clean builder.
+
+Usage:  jdt build [--project <name>] [--clean]
+
+Options:
+  --project <name>   project to build (omit for workspace-wide incremental)
+  --clean            clean + full rebuild (requires --project)
+
+Always refreshes from disk before building.
+Exit code: 0 if no compilation errors, 1 if errors found.
+
+Examples:
+  jdt build --project m8-client
+  jdt build --project m8-client --clean
+  jdt build --project m8-client --clean && jdt test --project m8-client-gwt`;

--- a/cli/src/commands/errors.mjs
+++ b/cli/src/commands/errors.mjs
@@ -8,18 +8,12 @@ export async function errors(args) {
   const params = [];
   if (flags.file) params.push(`file=${encodeURIComponent(toWsPath(flags.file))}`);
   if (flags.project) params.push(`project=${encodeURIComponent(flags.project)}`);
-  const noRefresh = args.includes("--no-refresh");
-  if (noRefresh) params.push("no-refresh");
-  if (flags.build) params.push("build");
-  if (flags.clean) params.push("clean");
   if (flags.warnings) params.push("warnings");
   if (flags.all) params.push("all");
 
   let url = "/errors";
   if (params.length > 0) url += "?" + params.join("&");
-  const timeout =
-    !noRefresh || flags.build || flags.clean ? 180_000 : 10_000;
-  const results = await get(url, timeout);
+  const results = await get(url, 180_000);
   if (results.error) {
     console.error(results.error);
     process.exit(1);
@@ -39,20 +33,20 @@ export async function errors(args) {
 export const help = `Check compilation errors and diagnostics.
 
 Usage:  jdt errors [--file <path>] [--project <name>]
-                   [--no-refresh] [--build] [--clean]
                    [--warnings] [--all]
 
 Scope (pick one or omit for entire workspace):
   --file <path>       single file (workspace-relative)
   --project <name>    entire project
 
-Build/refresh flags:
-  (default)           refresh from disk + wait for auto-build
-  --no-refresh        skip disk refresh
-  --build             trigger incremental build
-  --clean             clean + full rebuild (requires --project)
+Options:
+  --warnings          include warnings (default: errors only)
+  --all               all marker types (jdt + checkstyle + maven + ...)
+
+Refreshes from disk and waits for auto-build before reading markers.
+Use 'jdt build' to trigger explicit builds.
 
 Examples:
   jdt errors --project m8-server
   jdt errors --file m8-server/src/main/java/.../Foo.java
-  jdt errors --project m8-server --clean`;
+  jdt errors --project m8-server --all --warnings`;

--- a/cli/src/commands/test.mjs
+++ b/cli/src/commands/test.mjs
@@ -39,7 +39,6 @@ Usage:  jdt test <FQN> [method]
 Flags:
   --project <name>   run all tests in a project
   --package <pkg>    narrow to a specific package (with --project)
-  --no-refresh       skip disk refresh + auto-build
   --timeout <sec>    test run timeout in seconds (default: 120)
 
 Examples:

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -138,7 +138,7 @@ describe("commands (integration)", () => {
       ]));
     });
     const { errors } = await import("../src/commands/errors.mjs");
-    await errors(["--no-refresh"]);
+    await errors([]);
     expect(io.logs[0]).toContain("ERROR");
     expect(io.logs[0]).toContain("[JDT]");
     expect(io.logs[0]).toContain("cannot resolve symbol");
@@ -150,7 +150,7 @@ describe("commands (integration)", () => {
       res.end("[]");
     });
     const { errors } = await import("../src/commands/errors.mjs");
-    await errors(["--no-refresh"]);
+    await errors([]);
     expect(io.logs[0]).toBe("(no errors)");
   });
 
@@ -238,6 +238,38 @@ describe("commands (integration)", () => {
     expect(io.logs[0]).toContain("3 tests");
     expect(io.logs[0]).toContain("1 failed");
     expect(io.logs.some((l) => l.includes("app.FooTest.testBar"))).toBe(true);
+  });
+
+  it("build shows success with 0 errors", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ errors: 0 }));
+    });
+    const { build } = await import("../src/commands/build.mjs");
+    await build(["--project", "m8-client"]);
+    expect(io.logs[0]).toBe("Build complete (0 errors)");
+  });
+
+  it("build exits 1 on compilation errors", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ errors: 3 }));
+    });
+    const { build } = await import("../src/commands/build.mjs");
+    await expect(build(["--project", "m8-client"])).rejects.toThrow("exit(1)");
+    expect(io.logs[0]).toBe("Build complete (3 errors)");
+  });
+
+  it("build with --clean flag", async () => {
+    await setupMock((req, res) => {
+      expect(req.url).toContain("clean");
+      expect(req.url).toContain("project=m8-client");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ errors: 0 }));
+    });
+    const { build } = await import("../src/commands/build.mjs");
+    await build(["--project", "m8-client", "--clean"]);
+    expect(io.logs[0]).toBe("Build complete (0 errors)");
   });
 
   it("source prints file header and body", async () => {
@@ -449,7 +481,14 @@ describe("commands (integration)", () => {
   it("errors exits on server error", async () => {
     await setupMock(errorServer());
     const { errors } = await import("../src/commands/errors.mjs");
-    await expect(errors(["--no-refresh"])).rejects.toThrow("exit(1)");
+    await expect(errors([])).rejects.toThrow("exit(1)");
+    expect(io.errors[0]).toContain("Something went wrong");
+  });
+
+  it("build exits on server error", async () => {
+    await setupMock(errorServer());
+    const { build } = await import("../src/commands/build.mjs");
+    await expect(build(["--project", "m8-client"])).rejects.toThrow("exit(1)");
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
@@ -635,7 +674,7 @@ describe("commands (integration)", () => {
       ]));
     });
     const { errors } = await import("../src/commands/errors.mjs");
-    await errors(["--no-refresh", "--warnings"]);
+    await errors(["--warnings"]);
     expect(io.logs[0]).toContain("WARN");
   });
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
@@ -35,7 +35,6 @@ public class DiagnosticsIntegrationTest {
     public void errorsFindsCompilationError() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("project", TestFixture.PROJECT_NAME);
-        params.put("no-refresh", "");
         String json = handler.handleErrors(params);
         assertTrue(json.contains("BrokenClass"),
                 "Should find error in BrokenClass: " + json);
@@ -51,7 +50,6 @@ public class DiagnosticsIntegrationTest {
         Map<String, String> params = new HashMap<>();
         params.put("file",
                 "/" + TestFixture.PROJECT_NAME + "/src/test/model/Dog.java");
-        params.put("no-refresh", "");
         String json = handler.handleErrors(params);
         assertEquals("[]", json, "Dog.java should have no errors");
     }
@@ -61,7 +59,6 @@ public class DiagnosticsIntegrationTest {
         Map<String, String> params = new HashMap<>();
         params.put("project", TestFixture.PROJECT_NAME);
         params.put("warnings", "");
-        params.put("no-refresh", "");
         String json = handler.handleErrors(params);
         // Should at least find the ERROR
         assertTrue(json.contains("ERROR"),
@@ -72,8 +69,47 @@ public class DiagnosticsIntegrationTest {
     public void errorsProjectNotFound() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("project", "no-such-project-xyz");
-        params.put("no-refresh", "");
         String json = handler.handleErrors(params);
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
+    }
+
+    @Test
+    public void buildIncremental() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("project", TestFixture.PROJECT_NAME);
+        String json = handler.handleBuild(params);
+        assertTrue(json.contains("\"errors\""),
+                "Should return errors count: " + json);
+    }
+
+    @Test
+    public void buildClean() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("project", TestFixture.PROJECT_NAME);
+        params.put("clean", "");
+        String json = handler.handleBuild(params);
+        assertTrue(json.contains("\"errors\""),
+                "Should return errors count: " + json);
+        // BrokenClass has a compilation error
+        assertTrue(json.contains("\"errors\":1") || json.contains("\"errors\": 1"),
+                "Should have 1 error from BrokenClass: " + json);
+    }
+
+    @Test
+    public void buildCleanWithoutProject() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("clean", "");
+        String json = handler.handleBuild(params);
+        assertTrue(json.contains("error"),
+                "Should return error about missing project: " + json);
+    }
+
+    @Test
+    public void buildProjectNotFound() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("project", "no-such-project-xyz");
+        String json = handler.handleBuild(params);
         assertTrue(json.contains("error"),
                 "Should return error: " + json);
     }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -59,19 +59,29 @@ Returns source code as `text/plain` with `X-File`, `X-Start-Line`, `X-End-Line` 
 
 Run JUnit tests via Eclipse's built-in runner. By default, refreshes the project from disk and waits for auto-build before launching. Returns summary and failure details.
 
+## Building
+
+### `GET /build?[project=<name>][&clean]`
+
+Trigger a project build. Always refreshes from disk first.
+
+| Parameter | Description |
+|-----------|-------------|
+| `project` | Project to build (omit for workspace-wide incremental) |
+| `clean` | Clean + full rebuild (requires `project`) |
+
+Returns `{"errors": N}` with the count of compilation errors after build.
+
 ## Diagnostics
 
-### `GET /errors?[file=<path>][&project=<name>][&no-refresh][&build][&clean][&warnings][&all]`
+### `GET /errors?[file=<path>][&project=<name>][&warnings][&all]`
 
-Compilation diagnostics. By default refreshes from disk and returns only errors.
+Compilation diagnostics. Refreshes from disk and waits for auto-build before reading markers.
 
 | Parameter | Description |
 |-----------|-------------|
 | `file` | Workspace-relative path to filter by specific file |
 | `project` | Project name to filter by |
-| `no-refresh` | Skip disk refresh (use if Eclipse is already in sync) |
-| `build` | Trigger explicit incremental build |
-| `clean` | Clean + full rebuild (requires `project`) |
 | `warnings` | Include warnings (default: errors only) |
 | `all` | All marker types (jdt + checkstyle + maven + ...) |
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/DiagnosticsHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/DiagnosticsHandler.java
@@ -11,17 +11,16 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 
 /**
- * Handler for /errors endpoint: compilation diagnostics
- * with optional refresh/build.
+ * Handler for /errors and /build endpoints.
  */
 class DiagnosticsHandler {
+
+    private static final String JDT_PROBLEM_MARKER =
+            "org.eclipse.jdt.core.problem";
 
     String handleErrors(Map<String, String> params) throws Exception {
         String filePath = params.get("file");
         String projectName = params.get("project");
-        boolean refresh = !params.containsKey("no-refresh");
-        boolean build = params.containsKey("build");
-        boolean clean = params.containsKey("clean");
         boolean includeWarnings = params.containsKey("warnings");
         boolean all = params.containsKey("all");
 
@@ -46,48 +45,15 @@ class DiagnosticsHandler {
             scope = root;
         }
 
-        // Determine project for build operations
-        IProject buildProject = null;
-        if (scope instanceof IProject p) {
-            buildProject = p;
-        } else if (!(scope instanceof IWorkspaceRoot)) {
-            buildProject = scope.getProject();
-        }
-
-        // Refresh from disk
-        if (refresh) {
-            int depth = (scope instanceof IFile)
-                    ? IResource.DEPTH_ZERO : IResource.DEPTH_INFINITE;
-            scope.refreshLocal(depth, null);
-        }
-
-        // Build
-        if (clean) {
-            if (buildProject == null) {
-                return Json.error("clean requires a specific project"
-                        + " (use 'project' param)");
-            }
-            buildProject.build(
-                    IncrementalProjectBuilder.CLEAN_BUILD, null);
-            buildProject.build(
-                    IncrementalProjectBuilder.FULL_BUILD, null);
-        } else if (build) {
-            if (buildProject != null) {
-                buildProject.build(
-                        IncrementalProjectBuilder.INCREMENTAL_BUILD,
-                        null);
-            } else {
-                ResourcesPlugin.getWorkspace().build(
-                        IncrementalProjectBuilder.INCREMENTAL_BUILD,
-                        null);
-            }
-        } else if (refresh) {
-            JdtUtils.joinAutoBuild();
-        }
+        // Refresh from disk and wait for auto-build
+        int depth = (scope instanceof IFile)
+                ? IResource.DEPTH_ZERO : IResource.DEPTH_INFINITE;
+        scope.refreshLocal(depth, null);
+        JdtUtils.joinAutoBuild();
 
         // Read markers
         String markerType = all ? IMarker.PROBLEM
-                : "org.eclipse.jdt.core.problem";
+                : JDT_PROBLEM_MARKER;
         IMarker[] markers = scope.findMarkers(
                 markerType, true, IResource.DEPTH_INFINITE);
 
@@ -119,6 +85,68 @@ class DiagnosticsHandler {
             arr.add(entry);
         }
         return arr.toString();
+    }
+
+    String handleBuild(Map<String, String> params) throws Exception {
+        String projectName = params.get("project");
+        boolean clean = params.containsKey("clean");
+
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+
+        // Determine scope for refresh and marker counting
+        IResource scope;
+        IProject buildProject = null;
+        if (projectName != null && !projectName.isBlank()) {
+            IProject project = root.getProject(projectName);
+            if (!project.exists()) {
+                return Json.error(
+                        "Project not found: " + projectName);
+            }
+            scope = project;
+            buildProject = project;
+        } else {
+            scope = root;
+        }
+
+        if (clean && buildProject == null) {
+            return Json.error("clean requires a specific project"
+                    + " (use 'project' param)");
+        }
+
+        // Refresh from disk and let auto-build settle
+        scope.refreshLocal(IResource.DEPTH_INFINITE, null);
+        JdtUtils.joinAutoBuild();
+
+        // Build
+        if (clean) {
+            buildProject.build(
+                    IncrementalProjectBuilder.CLEAN_BUILD, null);
+            buildProject.build(
+                    IncrementalProjectBuilder.FULL_BUILD, null);
+        } else if (buildProject != null) {
+            buildProject.build(
+                    IncrementalProjectBuilder.INCREMENTAL_BUILD,
+                    null);
+        } else {
+            ResourcesPlugin.getWorkspace().build(
+                    IncrementalProjectBuilder.INCREMENTAL_BUILD,
+                    null);
+        }
+
+        // Count error markers on scope
+        IMarker[] markers = scope.findMarkers(
+                JDT_PROBLEM_MARKER, true,
+                IResource.DEPTH_INFINITE);
+        int errorCount = 0;
+        for (IMarker marker : markers) {
+            if (marker.getAttribute(IMarker.SEVERITY, -1)
+                    == IMarker.SEVERITY_ERROR) {
+                errorCount++;
+            }
+        }
+
+        return Json.object()
+                .put("errors", errorCount).toString();
     }
 
     String shortMarkerType(String type) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -193,6 +193,8 @@ public class HttpServer {
                         search.handleImplementors(params));
                 case "/errors" -> Response.json(
                         diagnostics.handleErrors(params));
+                case "/build" -> Response.json(
+                        diagnostics.handleBuild(params));
                 case "/type-info" -> Response.json(
                         search.handleTypeInfo(params));
                 case "/source" -> search.handleSource(params);


### PR DESCRIPTION
## Summary

- **New command `jdt build`** — the only command that triggers explicit builds (incremental or clean+full)
- **Simplified `errors`** — pure diagnostic query, removed `--build`/`--clean`/`--no-refresh` flags
- Composable: `jdt build --project X --clean && jdt test --project Y`

## Motivation

The `errors` command was overloaded with build/refresh flags that created cognitive overhead for AI model consumers. Models regularly misused flag combinations. Extracting build into a standalone command follows Unix philosophy — each command does one thing well.

## Changes

**Plugin (Java):**
- `DiagnosticsHandler`: new `handleBuild()`, simplified `handleErrors()` (always refresh + joinAutoBuild)
- `HttpServer`: added `/build` route

**CLI (JS):**
- New `build.mjs` command with alias `b`
- `errors.mjs`: removed `--build`, `--clean`, `--no-refresh`
- `test.mjs`: removed `--no-refresh` from help (kept in code for backward compat)
- `cli.mjs`: registered build, renamed section to "Testing & building"

**Tests:**
- CLI: 4 new build tests, updated errors tests — **218/218 pass**
- Plugin: 4 new `handleBuild()` integration tests — **118/118 pass** (Tycho)

**Docs:** all READMEs, AGENTS.md, plugin API docs updated

## Test plan

- [x] CLI tests pass (`npm test` — 218/218)
- [x] Plugin Tycho build + tests pass (`mvn clean verify` — 118/118)
- [x] Manual verification: `jdt build --project X --clean && jdt test --project Y`
- [ ] CI workflow