### PR TITLE
Increase timeout for find and source commands

### DIFF
--- a/cli/src/commands/find.mjs
+++ b/cli/src/commands/find.mjs
@@ -11,7 +11,7 @@ export async function find(args) {
   }
   let url = `/find?name=${encodeURIComponent(name)}`;
   if (args.includes("--source-only")) url += "&source";
-  const results = await get(url);
+  const results = await get(url, 30_000);
   if (results.error) {
     console.error(results.error);
     process.exit(1);

--- a/cli/src/commands/source.mjs
+++ b/cli/src/commands/source.mjs
@@ -14,7 +14,7 @@ export async function source(args) {
   if (method) url += `&method=${encodeURIComponent(method)}`;
   if (flags.arity !== undefined && flags.arity !== true)
     url += `&arity=${flags.arity}`;
-  const result = await getRaw(url);
+  const result = await getRaw(url, 30_000);
   const file = result.headers["x-file"] || "?";
   const startLine = result.headers["x-start-line"] || "?";
   const endLine = result.headers["x-end-line"] || "?";


### PR DESCRIPTION
## Summary
- Increase HTTP timeout from default to 30s for `jdt find` and `jdt source` commands
- On large workspaces Eclipse needs extra time to resolve and extract transitive JAR sources, causing the previous timeout to be exceeded

## Test plan
- [x] All 218 CLI tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)