### PR TITLE
Split CI/deploy workflows, add PR auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cli/**'
+
+plugin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'plugin/**'
+          - 'plugin.tests/**'
+          - 'feature/**'
+          - 'site/**'
+          - 'branding/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    paths-ignore: ['**.md', 'docs/**', 'scripts/**', 'LICENSE']
+  pull_request:
+    branches: [master]
+    paths-ignore: ['**.md', 'docs/**', 'scripts/**', 'LICENSE']
+
+jobs:
+  cli:
+    name: CLI tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - run: npm ci
+      - run: npm test
+
+  plugin:
+    name: Plugin build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build and test
+        run: xvfb-run mvn clean verify -B -Pci
+        env:
+          MAVEN_OPTS: >-
+            -Djdk.xml.totalEntitySizeLimit=0
+            -Djdk.xml.maxGeneralEntitySizeLimit=0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,13 @@
-name: Build
+name: Deploy
 
 on:
   push:
-    branches: [master]
     tags: ['v*']
-  pull_request:
-    branches: [master]
 
 jobs:
-  cli:
-    name: CLI tests
+  build:
+    name: Build release
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: cli
     steps:
       - uses: actions/checkout@v4
 
@@ -23,14 +17,7 @@ jobs:
           cache: npm
           cache-dependency-path: cli/package-lock.json
 
-      - run: npm ci
-      - run: npm test
-
-  plugin:
-    name: Plugin build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+      - run: cd cli && npm ci && npm test
 
       - uses: actions/setup-java@v4
         with:
@@ -52,7 +39,6 @@ jobs:
             -Djdk.xml.maxGeneralEntitySizeLimit=0
 
       - name: Upload p2 repository
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
           name: p2-repository
@@ -60,8 +46,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [cli, plugin]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: Labeler
+
+on:
+  pull_request_target:
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
## Summary
- Split `build.yml` into `ci.yml` (tests) and `deploy.yml` (release tag → GitHub Pages)
- `ci.yml` has `paths-ignore` for docs-only changes — no more Maven builds for README edits
- Add `actions/labeler` to auto-label PRs based on changed files (`cli`, `plugin`, `documentation`, `ci`)