### PR TITLE
Add welcome screen and JSON parser

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ActivatorTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ActivatorTest.java
@@ -2,6 +2,7 @@ package io.github.kaluchi.jdtbridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -48,7 +49,6 @@ public class ActivatorTest {
 
     @Test
     public void bridgeFileJsonFormat() {
-        // Simulate what Activator.writeBridgeFile() produces (JSON)
         String json = Json.object()
                 .put("port", 12345)
                 .put("token", "abcdef0123456789abcdef0123456789")
@@ -58,11 +58,16 @@ public class ActivatorTest {
                 .put("location", "reference:file:plugins/io.github.kaluchi.jdtbridge_1.0.0.jar")
                 .toString();
 
-        // Parse like CLI does: JSON.parse
-        assertTrue(json.contains("\"port\":12345"));
-        assertTrue(json.contains("\"version\":\"1.0.0.202603181541\""));
-        assertTrue(json.contains("\"location\":\"reference:file:plugins/"));
-        assertTrue(json.contains("\"workspace\":\"D:\\\\eclipse-workspace\""));
+        var map = Json.parse(json);
+        assertEquals(12345, Json.getInt(map, "port", 0));
+        assertEquals("abcdef0123456789abcdef0123456789",
+                Json.getString(map, "token"));
+        assertEquals("D:\\eclipse-workspace",
+                Json.getString(map, "workspace"));
+        assertEquals("1.0.0.202603181541",
+                Json.getString(map, "version"));
+        assertTrue(Json.getString(map, "location")
+                .startsWith("reference:file:plugins/"));
     }
 
     @Test
@@ -80,12 +85,13 @@ public class ActivatorTest {
                     .toString() + "\n";
             Files.writeString(tempFile, content);
 
-            String read = Files.readString(tempFile).trim();
-            // Verify round-trip: must contain all fields
-            assertTrue(read.contains("\"port\":54321"));
-            assertTrue(read.contains("\"token\":\"" + token + "\""));
-            assertTrue(read.contains("\"version\":\"1.0.0.qualifier\""));
-            assertTrue(read.contains("\"location\":\"reference:file:dropins/"));
+            var map = Json.parse(Files.readString(tempFile));
+            assertEquals(54321, Json.getInt(map, "port", 0));
+            assertEquals(token, Json.getString(map, "token"));
+            assertEquals("1.0.0.qualifier",
+                    Json.getString(map, "version"));
+            assertTrue(Json.getString(map, "location")
+                    .startsWith("reference:file:dropins/"));
         } finally {
             Files.deleteIfExists(tempFile);
         }
@@ -102,12 +108,13 @@ public class ActivatorTest {
                 .put("location", "file:plugins/bundle.jar")
                 .toString();
 
-        assertTrue(json.contains("\"port\":"), "Must have port");
-        assertTrue(json.contains("\"token\":"), "Must have token");
-        assertTrue(json.contains("\"pid\":"), "Must have pid");
-        assertTrue(json.contains("\"workspace\":"), "Must have workspace");
-        assertTrue(json.contains("\"version\":"), "Must have version");
-        assertTrue(json.contains("\"location\":"), "Must have location");
+        var map = Json.parse(json);
+        assertNotEquals(0, Json.getInt(map, "port", 0), "Must have port");
+        assertNotNull(Json.getString(map, "token"), "Must have token");
+        assertTrue(map.containsKey("pid"), "Must have pid");
+        assertNotNull(Json.getString(map, "workspace"), "Must have workspace");
+        assertNotNull(Json.getString(map, "version"), "Must have version");
+        assertNotNull(Json.getString(map, "location"), "Must have location");
     }
 
     // ---- Helpers ----

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/JsonTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/JsonTest.java
@@ -1,0 +1,336 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Json builder and parser.
+ */
+public class JsonTest {
+
+    // ---- Builder ----
+
+    @Nested
+    class Builder {
+
+        @Test
+        void emptyObject() {
+            assertEquals("{}", Json.object().toString());
+        }
+
+        @Test
+        void emptyArray() {
+            assertEquals("[]", Json.array().toString());
+        }
+
+        @Test
+        void objectWithStringValue() {
+            String json = Json.object().put("name", "test").toString();
+            assertEquals("{\"name\":\"test\"}", json);
+        }
+
+        @Test
+        void objectWithIntValue() {
+            String json = Json.object().put("port", 8080).toString();
+            assertEquals("{\"port\":8080}", json);
+        }
+
+        @Test
+        void objectWithLongValue() {
+            String json = Json.object().put("pid", 12345L).toString();
+            assertEquals("{\"pid\":12345}", json);
+        }
+
+        @Test
+        void objectWithBooleanValue() {
+            String json = Json.object().put("ok", true).toString();
+            assertEquals("{\"ok\":true}", json);
+        }
+
+        @Test
+        void objectWithNullString() {
+            String json = Json.object().put("key", (String) null)
+                    .toString();
+            assertEquals("{\"key\":null}", json);
+        }
+
+        @Test
+        void objectMultipleKeys() {
+            String json = Json.object()
+                    .put("a", "1").put("b", 2).toString();
+            assertEquals("{\"a\":\"1\",\"b\":2}", json);
+        }
+
+        @Test
+        void nestedObject() {
+            String json = Json.object()
+                    .put("inner", Json.object().put("x", 1))
+                    .toString();
+            assertEquals("{\"inner\":{\"x\":1}}", json);
+        }
+
+        @Test
+        void arrayOfStrings() {
+            String json = Json.array().add("a").add("b").toString();
+            assertEquals("[\"a\",\"b\"]", json);
+        }
+
+        @Test
+        void putIfTrue() {
+            String json = Json.object()
+                    .putIf(true, "key", "val").toString();
+            assertEquals("{\"key\":\"val\"}", json);
+        }
+
+        @Test
+        void putIfFalse() {
+            String json = Json.object()
+                    .putIf(false, "key", "val").toString();
+            assertEquals("{}", json);
+        }
+
+        @Test
+        void errorHelper() {
+            String json = Json.error("boom");
+            assertEquals("{\"error\":\"boom\"}", json);
+        }
+    }
+
+    // ---- Escape ----
+
+    @Nested
+    class Escape {
+
+        @Test
+        void plainString() {
+            assertEquals("hello", Json.escape("hello"));
+        }
+
+        @Test
+        void quotes() {
+            assertEquals("say \\\"hi\\\"", Json.escape("say \"hi\""));
+        }
+
+        @Test
+        void backslash() {
+            assertEquals("C:\\\\path", Json.escape("C:\\path"));
+        }
+
+        @Test
+        void newlineAndTab() {
+            assertEquals("a\\nb\\tc", Json.escape("a\nb\tc"));
+        }
+
+        @Test
+        void controlCharacter() {
+            assertEquals("\\u0001", Json.escape("\u0001"));
+        }
+
+        @Test
+        void nullReturnsLiteral() {
+            assertEquals("null", Json.escape(null));
+        }
+    }
+
+    // ---- Parser ----
+
+    @Nested
+    class Parser {
+
+        @Test
+        void parseStringValue() {
+            var map = Json.parse("{\"name\":\"test\"}");
+            assertEquals("test", Json.getString(map, "name"));
+        }
+
+        @Test
+        void parseIntValue() {
+            var map = Json.parse("{\"port\":8080}");
+            assertEquals(8080, Json.getInt(map, "port", 0));
+        }
+
+        @Test
+        void parseLongValue() {
+            var map = Json.parse("{\"pid\":9999999999}");
+            assertEquals(9999999999L, map.get("pid"));
+        }
+
+        @Test
+        void parseBooleanTrue() {
+            var map = Json.parse("{\"ok\":true}");
+            assertTrue(Json.getBool(map, "ok", false));
+        }
+
+        @Test
+        void parseBooleanFalse() {
+            var map = Json.parse("{\"ok\":false}");
+            assertFalse(Json.getBool(map, "ok", true));
+        }
+
+        @Test
+        void parseNullValue() {
+            var map = Json.parse("{\"key\":null}");
+            assertTrue(map.containsKey("key"));
+            assertNull(map.get("key"));
+        }
+
+        @Test
+        void parseMultipleKeys() {
+            var map = Json.parse(
+                    "{\"port\":8080,\"token\":\"abc\",\"ok\":true}");
+            assertEquals(8080, Json.getInt(map, "port", 0));
+            assertEquals("abc", Json.getString(map, "token"));
+            assertTrue(Json.getBool(map, "ok", false));
+        }
+
+        @Test
+        void parseWithWhitespace() {
+            var map = Json.parse(
+                    "{ \"port\" : 8080 , \"name\" : \"test\" }");
+            assertEquals(8080, Json.getInt(map, "port", 0));
+            assertEquals("test", Json.getString(map, "name"));
+        }
+
+        @Test
+        void parseWithNewlines() {
+            String json = """
+                    {
+                      "port": 8080,
+                      "token": "abc"
+                    }
+                    """;
+            var map = Json.parse(json);
+            assertEquals(8080, Json.getInt(map, "port", 0));
+            assertEquals("abc", Json.getString(map, "token"));
+        }
+
+        @Test
+        void parseEscapedString() {
+            var map = Json.parse(
+                    "{\"path\":\"C:\\\\Users\\\\test\"}");
+            assertEquals("C:\\Users\\test",
+                    Json.getString(map, "path"));
+        }
+
+        @Test
+        void parseEscapedQuotes() {
+            var map = Json.parse(
+                    "{\"msg\":\"say \\\"hi\\\"\"}");
+            assertEquals("say \"hi\"", Json.getString(map, "msg"));
+        }
+
+        @Test
+        void parseUnicodeEscape() {
+            var map = Json.parse("{\"ch\":\"\\u0041\"}");
+            assertEquals("A", Json.getString(map, "ch"));
+        }
+
+        @Test
+        void parseMissingKeyReturnsDefault() {
+            var map = Json.parse("{\"a\":1}");
+            assertNull(Json.getString(map, "b"));
+            assertEquals(0, Json.getInt(map, "b", 0));
+            assertFalse(Json.getBool(map, "b", false));
+        }
+
+        @Test
+        void parseEmptyObject() {
+            var map = Json.parse("{}");
+            assertNotNull(map);
+            assertTrue(map.isEmpty());
+        }
+
+        @Test
+        void parseNullInput() {
+            var map = Json.parse(null);
+            assertNotNull(map);
+            assertTrue(map.isEmpty());
+        }
+
+        @Test
+        void parseGarbageInput() {
+            var map = Json.parse("not json");
+            assertNotNull(map);
+            assertTrue(map.isEmpty());
+        }
+
+        @Test
+        void parseNestedObjectAsRawString() {
+            var map = Json.parse(
+                    "{\"deps\":{\"a\":{\"version\":\"1.0\"}}}");
+            Object deps = map.get("deps");
+            assertNotNull(deps);
+            assertTrue(deps instanceof String);
+            assertTrue(((String) deps).contains("version"));
+        }
+
+        @Test
+        void parseNegativeNumber() {
+            var map = Json.parse("{\"offset\":-5}");
+            assertEquals(-5, Json.getInt(map, "offset", 0));
+        }
+
+        @Test
+        void parseDoubleValue() {
+            var map = Json.parse("{\"rate\":3.14}");
+            Object val = map.get("rate");
+            assertTrue(val instanceof Double);
+            assertEquals(3.14, (Double) val, 0.001);
+        }
+
+        // ---- Roundtrip: build then parse ----
+
+        @Test
+        void roundtripBridgeFile() {
+            String json = Json.object()
+                    .put("port", 54321)
+                    .put("token", "abc123")
+                    .put("pid", 9876L)
+                    .put("workspace", "D:\\eclipse-workspace")
+                    .put("version", "1.1.0.qualifier")
+                    .put("location", "file:plugins/bundle.jar")
+                    .toString();
+            var map = Json.parse(json);
+            assertEquals(54321, Json.getInt(map, "port", 0));
+            assertEquals("abc123", Json.getString(map, "token"));
+            assertEquals("D:\\eclipse-workspace",
+                    Json.getString(map, "workspace"));
+            assertEquals("1.1.0.qualifier",
+                    Json.getString(map, "version"));
+            assertEquals("file:plugins/bundle.jar",
+                    Json.getString(map, "location"));
+        }
+
+        @Test
+        void roundtripNpmListOutput() {
+            // Simulate nested npm list --json output
+            String json = """
+                    {
+                      "name": "npm",
+                      "dependencies": {
+                        "@kaluchi/jdtbridge": {
+                          "version": "1.1.1",
+                          "resolved": "file:cli"
+                        }
+                      }
+                    }
+                    """;
+            var outer = Json.parse(json);
+            String depsRaw = (String) outer.get("dependencies");
+            assertNotNull(depsRaw);
+            var deps = Json.parse(depsRaw);
+            String pkgRaw = (String) deps.get("@kaluchi/jdtbridge");
+            assertNotNull(pkgRaw);
+            var pkg = Json.parse(pkgRaw);
+            assertEquals("1.1.1", Json.getString(pkg, "version"));
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/WelcomeHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/WelcomeHandlerTest.java
@@ -1,0 +1,142 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for WelcomeHandler — CLI detection parsing via Json.parse(),
+ * bridge file parsing, and config logic.
+ */
+public class WelcomeHandlerTest {
+
+    // ---- npm list JSON → CLI detection ----
+
+    @Test
+    public void npmListDetectsInstalledPackage() {
+        String npmOutput = """
+                {
+                  "name": "npm",
+                  "dependencies": {
+                    "@kaluchi/jdtbridge": {
+                      "version": "1.1.1",
+                      "resolved": "file:cli"
+                    }
+                  }
+                }
+                """;
+        var outer = Json.parse(npmOutput);
+        String depsRaw = Json.getString(outer, "dependencies");
+        assertNotNull(depsRaw);
+        var deps = Json.parse(depsRaw);
+        String pkgRaw = Json.getString(deps, "@kaluchi/jdtbridge");
+        assertNotNull(pkgRaw);
+        var pkg = Json.parse(pkgRaw);
+        assertEquals("1.1.1", Json.getString(pkg, "version"));
+    }
+
+    @Test
+    public void npmListEmptyDependencies() {
+        var outer = Json.parse("{\"dependencies\":{}}");
+        String depsRaw = Json.getString(outer, "dependencies");
+        assertNotNull(depsRaw);
+        var deps = Json.parse(depsRaw);
+        assertTrue(deps.isEmpty());
+    }
+
+    @Test
+    public void npmListNoDependenciesKey() {
+        var outer = Json.parse("{\"name\":\"npm\"}");
+        String depsRaw = Json.getString(outer, "dependencies");
+        // "dependencies" not present — getString returns null
+        assertEquals(null, depsRaw);
+    }
+
+    // ---- Bridge file parsing ----
+
+    @Test
+    public void bridgeFileExtractsPortAndVersion() {
+        String json = Json.object()
+                .put("port", 54321)
+                .put("token", "abc")
+                .put("pid", 100L)
+                .put("workspace", "/ws")
+                .put("version", "1.1.0.202603231744")
+                .put("location", "file:plugins/bundle.jar")
+                .toString();
+        var map = Json.parse(json);
+        assertEquals(54321, Json.getInt(map, "port", 0));
+        assertEquals("1.1.0.202603231744",
+                Json.getString(map, "version"));
+    }
+
+    @Test
+    public void bridgeFileMissingVersionReturnsNull() {
+        String json = Json.object()
+                .put("port", 8080)
+                .put("token", "abc")
+                .toString();
+        var map = Json.parse(json);
+        assertEquals(8080, Json.getInt(map, "port", 0));
+        assertEquals(null, Json.getString(map, "version"));
+    }
+
+    // ---- Config / dismiss detection ----
+
+    @Test
+    public void configDismissedTrue() {
+        String config = "{\"eclipse\":\"D:/eclipse\","
+                + "\"welcomeDismissed\":true}";
+        var map = Json.parse(config);
+        assertTrue(Json.getBool(map, "welcomeDismissed", false));
+    }
+
+    @Test
+    public void configDismissedFalse() {
+        String config = "{\"welcomeDismissed\":false}";
+        var map = Json.parse(config);
+        assertFalse(Json.getBool(map, "welcomeDismissed", false));
+    }
+
+    @Test
+    public void configDismissedMissing() {
+        String config = "{\"eclipse\":\"D:/eclipse\"}";
+        var map = Json.parse(config);
+        assertFalse(Json.getBool(map, "welcomeDismissed", false));
+    }
+
+    @Test
+    public void configDismissedWithWhitespace() {
+        String config = "{ \"welcomeDismissed\" : true }";
+        var map = Json.parse(config);
+        assertTrue(Json.getBool(map, "welcomeDismissed", false));
+    }
+
+    // ---- Config roundtrip: read → add key → write → read ----
+
+    @Test
+    public void configRoundtripAddDismissed() {
+        String original = "{\"eclipse\":\"D:/eclipse\"}";
+        var config = Json.parse(original);
+        config.put("welcomeDismissed", Boolean.TRUE);
+
+        Json builder = Json.object();
+        for (var entry : config.entrySet()) {
+            Object v = entry.getValue();
+            if (v instanceof String s) builder.put(entry.getKey(), s);
+            else if (v instanceof Boolean b)
+                builder.put(entry.getKey(), b);
+        }
+        String written = builder.toString();
+
+        var reread = Json.parse(written);
+        assertEquals("D:/eclipse",
+                Json.getString(reread, "eclipse"));
+        assertTrue(Json.getBool(reread, "welcomeDismissed", false));
+    }
+}

--- a/plugin/build.properties
+++ b/plugin/build.properties
@@ -3,3 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                plugin.xml,\
                .
+src.includes = **/*.java,\
+               **/*.html

--- a/plugin/src/io/github/kaluchi/jdtbridge/Activator.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/Activator.java
@@ -121,6 +121,10 @@ public class Activator implements BundleActivator {
         }
     }
 
+    static Path getHome() {
+        return resolveHome();
+    }
+
     static String generateToken() {
         byte[] bytes = new byte[TOKEN_BYTES];
         new SecureRandom().nextBytes(bytes);

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -31,6 +31,7 @@ public class HttpServer {
     private final EditorHandler editor = new EditorHandler();
     private final TestHandler testHandler = new TestHandler();
     private final ProjectHandler projectInfo = new ProjectHandler();
+    private final WelcomeHandler welcome = new WelcomeHandler();
     private final ExecutorService executor =
             Executors.newFixedThreadPool(4, r -> {
                 Thread t = new Thread(r, "jdtbridge-req");
@@ -50,6 +51,10 @@ public class HttpServer {
 
         static Response text(String body, Map<String, String> headers) {
             return new Response("text/plain", headers, body);
+        }
+
+        static Response html(String body) {
+            return new Response("text/html", Map.of(), body);
         }
     }
 
@@ -110,27 +115,36 @@ public class HttpServer {
             String[] parts = requestLine.split(" ");
             if (parts.length < 2) return;
 
+            String method = parts[0];
+
             // Read headers
             String authHeader = null;
+            int contentLength = 0;
             String line;
             while ((line = reader.readLine()) != null
                     && !line.isEmpty()) {
                 if (line.regionMatches(true, 0,
                         "Authorization:", 0, 14)) {
                     authHeader = line.substring(14).trim();
+                } else if (line.regionMatches(true, 0,
+                        "Content-Length:", 0, 15)) {
+                    contentLength = Integer.parseInt(
+                            line.substring(15).trim());
                 }
             }
 
-            // Token auth check
-            if (token != null && !token.isEmpty()) {
-                String expected = "Bearer " + token;
-                if (authHeader == null
-                        || !MessageDigest.isEqual(
-                                expected.getBytes(StandardCharsets.UTF_8),
-                                authHeader.getBytes(StandardCharsets.UTF_8))) {
-                    sendError(socket, 401, "Unauthorized");
-                    return;
+            // Read POST body
+            String body = null;
+            if (contentLength > 0) {
+                char[] buf = new char[contentLength];
+                int read = 0;
+                while (read < contentLength) {
+                    int n = reader.read(buf, read,
+                            contentLength - read);
+                    if (n < 0) break;
+                    read += n;
                 }
+                body = new String(buf, 0, read);
             }
 
             String fullPath = parts[1];
@@ -143,6 +157,25 @@ public class HttpServer {
             } else {
                 path = fullPath;
                 params = Map.of();
+            }
+
+            // Status endpoints — no auth required (loopback only)
+            if (path.startsWith("/status")) {
+                Response resp = dispatchStatus(path, method, body);
+                sendResponse(socket, resp);
+                return;
+            }
+
+            // Token auth check
+            if (token != null && !token.isEmpty()) {
+                String expected = "Bearer " + token;
+                if (authHeader == null
+                        || !MessageDigest.isEqual(
+                                expected.getBytes(StandardCharsets.UTF_8),
+                                authHeader.getBytes(StandardCharsets.UTF_8))) {
+                    sendError(socket, 401, "Unauthorized");
+                    return;
+                }
             }
 
             Response resp = dispatch(path, params);
@@ -172,6 +205,23 @@ public class HttpServer {
         out.write(header.toString().getBytes(StandardCharsets.UTF_8));
         out.write(bodyBytes);
         out.flush();
+    }
+
+    private Response dispatchStatus(String path, String method,
+            String body) {
+        try {
+            if ("/status".equals(path) && "GET".equals(method)) {
+                return welcome.handleStatus();
+            }
+            if ("/status/dismiss".equals(path)
+                    && "POST".equals(method)) {
+                return welcome.handleDismiss();
+            }
+            return Response.json(Json.error("Not found: " + path));
+        } catch (Exception e) {
+            Log.error("Status handler error", e);
+            return Response.json(Json.error(e.getMessage()));
+        }
     }
 
     private Response dispatch(String path, Map<String, String> params) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/Json.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/Json.java
@@ -130,6 +130,170 @@ class Json {
         sb.append('"').append(escape(key)).append("\":");
     }
 
+    // ---- Parsing ----
+
+    /** Parse a flat JSON object into a string map. Handles strings, numbers, booleans, null. */
+    static java.util.Map<String, Object> parse(String json) {
+        var map = new java.util.LinkedHashMap<String, Object>();
+        if (json == null) return map;
+        json = json.trim();
+        if (!json.startsWith("{") || !json.endsWith("}")) return map;
+        int pos = 1; // skip '{'
+        int len = json.length() - 1; // skip '}'
+        while (pos < len) {
+            pos = skipWhitespace(json, pos, len);
+            if (pos >= len) break;
+            if (json.charAt(pos) != '"') break;
+            // parse key
+            int keyStart = pos + 1;
+            int keyEnd = findClosingQuote(json, keyStart);
+            if (keyEnd < 0) break;
+            String key = unescape(json, keyStart, keyEnd);
+            pos = keyEnd + 1;
+            // skip : with whitespace
+            pos = skipWhitespace(json, pos, len);
+            if (pos >= len || json.charAt(pos) != ':') break;
+            pos = skipWhitespace(json, pos + 1, len);
+            if (pos >= len) break;
+            // parse value
+            char c = json.charAt(pos);
+            if (c == '"') {
+                int valStart = pos + 1;
+                int valEnd = findClosingQuote(json, valStart);
+                if (valEnd < 0) break;
+                map.put(key, unescape(json, valStart, valEnd));
+                pos = valEnd + 1;
+            } else if (c == 't' || c == 'f') {
+                if (json.startsWith("true", pos)) {
+                    map.put(key, Boolean.TRUE);
+                    pos += 4;
+                } else if (json.startsWith("false", pos)) {
+                    map.put(key, Boolean.FALSE);
+                    pos += 5;
+                } else break;
+            } else if (c == 'n') {
+                if (json.startsWith("null", pos)) {
+                    map.put(key, null);
+                    pos += 4;
+                } else break;
+            } else if (c == '-' || (c >= '0' && c <= '9')) {
+                int numStart = pos;
+                boolean isFloat = false;
+                if (c == '-') pos++;
+                while (pos < len && ((json.charAt(pos) >= '0'
+                        && json.charAt(pos) <= '9')
+                        || json.charAt(pos) == '.')) {
+                    if (json.charAt(pos) == '.') isFloat = true;
+                    pos++;
+                }
+                String num = json.substring(numStart, pos);
+                if (isFloat) {
+                    map.put(key, Double.parseDouble(num));
+                } else {
+                    long val = Long.parseLong(num);
+                    map.put(key, val <= Integer.MAX_VALUE
+                            && val >= Integer.MIN_VALUE
+                            ? (int) val : val);
+                }
+            } else if (c == '{' || c == '[') {
+                // nested object/array — store as raw string
+                int depth = 1;
+                int start = pos;
+                char open = c, close = (c == '{') ? '}' : ']';
+                pos++;
+                boolean inStr = false;
+                while (pos < len && depth > 0) {
+                    char ch = json.charAt(pos);
+                    if (inStr) {
+                        if (ch == '\\') pos++;
+                        else if (ch == '"') inStr = false;
+                    } else {
+                        if (ch == '"') inStr = true;
+                        else if (ch == open) depth++;
+                        else if (ch == close) depth--;
+                    }
+                    pos++;
+                }
+                map.put(key, json.substring(start, pos));
+            } else break;
+            // skip comma
+            pos = skipWhitespace(json, pos, len);
+            if (pos < len && json.charAt(pos) == ',') pos++;
+        }
+        return map;
+    }
+
+    /** Get a string value from parsed map, or null. */
+    static String getString(java.util.Map<String, Object> map,
+            String key) {
+        Object v = map.get(key);
+        return v instanceof String s ? s : null;
+    }
+
+    /** Get an int value from parsed map, or defaultValue. */
+    static int getInt(java.util.Map<String, Object> map,
+            String key, int defaultValue) {
+        Object v = map.get(key);
+        if (v instanceof Integer i) return i;
+        if (v instanceof Long l) return l.intValue();
+        return defaultValue;
+    }
+
+    /** Get a boolean value from parsed map, or defaultValue. */
+    static boolean getBool(java.util.Map<String, Object> map,
+            String key, boolean defaultValue) {
+        Object v = map.get(key);
+        return v instanceof Boolean b ? b : defaultValue;
+    }
+
+    private static int skipWhitespace(String s, int pos, int len) {
+        while (pos < len && Character.isWhitespace(s.charAt(pos)))
+            pos++;
+        return pos;
+    }
+
+    /** Find closing quote, handling escape sequences. */
+    private static int findClosingQuote(String s, int from) {
+        for (int i = from; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\\') { i++; continue; }
+            if (c == '"') return i;
+        }
+        return -1;
+    }
+
+    /** Unescape a JSON string segment between two indices. */
+    private static String unescape(String s, int from, int to) {
+        StringBuilder out = new StringBuilder(to - from);
+        for (int i = from; i < to; i++) {
+            char c = s.charAt(i);
+            if (c == '\\' && i + 1 < to) {
+                char next = s.charAt(++i);
+                switch (next) {
+                    case '"' -> out.append('"');
+                    case '\\' -> out.append('\\');
+                    case '/' -> out.append('/');
+                    case 'n' -> out.append('\n');
+                    case 'r' -> out.append('\r');
+                    case 't' -> out.append('\t');
+                    case 'b' -> out.append('\b');
+                    case 'f' -> out.append('\f');
+                    case 'u' -> {
+                        if (i + 4 < to) {
+                            String hex = s.substring(i + 1, i + 5);
+                            out.append((char) Integer.parseInt(hex, 16));
+                            i += 4;
+                        }
+                    }
+                    default -> { out.append('\\'); out.append(next); }
+                }
+            } else {
+                out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
     /** JSON string escaping — handles all control characters per RFC 8259. */
     static String escape(String s) {
         if (s == null) return "null";

--- a/plugin/src/io/github/kaluchi/jdtbridge/StartupHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/StartupHandler.java
@@ -1,16 +1,81 @@
 package io.github.kaluchi.jdtbridge;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IStartup;
 
 /**
  * Registered via org.eclipse.ui.startup extension point.
- * Forces early activation of the bundle so the Activator runs at Eclipse startup.
+ * Forces early activation of the bundle so the Activator runs at
+ * Eclipse startup. After the workbench is up, checks whether the
+ * CLI is installed and opens the welcome page if not.
  */
 public class StartupHandler implements IStartup {
 
     @Override
     public void earlyStartup() {
-        // Intentionally empty — bundle activation is enough.
-        // The Activator.start() already starts the HTTP server.
+        Job job = Job.create("JDT Bridge welcome check", this::check);
+        job.setSystem(true);
+        job.schedule(5000);
+    }
+
+    private IStatus check(IProgressMonitor monitor) {
+        try {
+            if (WelcomeHandler.isDismissed()) {
+                return Status.OK_STATUS;
+            }
+            if (WelcomeHandler.isCliInstalled()) {
+                return Status.OK_STATUS;
+            }
+            int port = readPortFromBridgeFile();
+            if (port <= 0) {
+                return Status.OK_STATUS;
+            }
+            Display.getDefault().asyncExec(() -> openWelcome(port));
+        } catch (Exception e) {
+            Log.warn("Welcome check failed", e);
+        }
+        return Status.OK_STATUS;
+    }
+
+    private int readPortFromBridgeFile() {
+        try {
+            Path instances = Activator.getHome().resolve("instances");
+            if (!Files.isDirectory(instances)) return 0;
+            try (var files = Files.list(instances)) {
+                return files
+                        .filter(f -> f.toString().endsWith(".json"))
+                        .findFirst()
+                        .map(this::extractPort)
+                        .orElse(0);
+            }
+        } catch (IOException e) {
+            return 0;
+        }
+    }
+
+    private int extractPort(Path file) {
+        try {
+            var map = Json.parse(Files.readString(file,
+                    StandardCharsets.UTF_8));
+            return Json.getInt(map, "port", 0);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private void openWelcome(int port) {
+        String url = "http://localhost:" + port + "/status";
+        Log.info("Opening welcome page: " + url);
+        Program.launch(url);
     }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/WelcomeHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/WelcomeHandler.java
@@ -1,0 +1,168 @@
+package io.github.kaluchi.jdtbridge;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Serves the welcome/status HTML page and handles the dismiss action.
+ * No auth required — loopback only, read-only page + boolean config.
+ *
+ * Reads port/version from the bridge instance files in ~/.jdtbridge/
+ * rather than relying on static state.
+ */
+class WelcomeHandler {
+
+    private static final String CONFIG_FILE = "config.json";
+    private static final String DISMISSED_KEY = "welcomeDismissed";
+
+    HttpServer.Response handleStatus() throws IOException {
+        String template = loadResource("welcome.html");
+        BridgeInfo info = readBridgeInfo();
+        CliInfo cli = detectCli();
+        String html = template
+                .replace("{{version}}", info.version)
+                .replace("{{port}}", String.valueOf(info.port))
+                .replace("{{cliInstalled}}",
+                        String.valueOf(cli.installed))
+                .replace("{{cliVersion}}", cli.version);
+        return HttpServer.Response.html(html);
+    }
+
+    HttpServer.Response handleDismiss() {
+        try {
+            Path configFile = Activator.getHome().resolve(CONFIG_FILE);
+            Map<String, Object> config;
+            if (Files.exists(configFile)) {
+                config = Json.parse(Files.readString(configFile,
+                        StandardCharsets.UTF_8));
+            } else {
+                Files.createDirectories(configFile.getParent());
+                config = new java.util.LinkedHashMap<>();
+            }
+            config.put(DISMISSED_KEY, Boolean.TRUE);
+            // Rebuild JSON from map
+            Json builder = Json.object();
+            for (var entry : config.entrySet()) {
+                Object v = entry.getValue();
+                if (v instanceof String s) builder.put(entry.getKey(), s);
+                else if (v instanceof Boolean b) builder.put(entry.getKey(), b);
+                else if (v instanceof Integer i) builder.put(entry.getKey(), i);
+                else if (v instanceof Long l) builder.put(entry.getKey(), l);
+                else if (v instanceof Double d) builder.put(entry.getKey(), d);
+                else if (v == null) builder.put(entry.getKey(), (String) null);
+            }
+            Files.writeString(configFile, builder.toString() + "\n",
+                    StandardCharsets.UTF_8);
+            return HttpServer.Response.json("{\"ok\":true}");
+        } catch (IOException e) {
+            Log.warn("Failed to save dismiss preference", e);
+            return HttpServer.Response.json(
+                    Json.error("Failed to save: " + e.getMessage()));
+        }
+    }
+
+    static boolean isDismissed() {
+        try {
+            Path configFile = Activator.getHome().resolve(CONFIG_FILE);
+            if (!Files.exists(configFile)) return false;
+            var config = Json.parse(Files.readString(configFile,
+                    StandardCharsets.UTF_8));
+            return Json.getBool(config, DISMISSED_KEY, false);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    static boolean isCliInstalled() {
+        return detectCli().installed;
+    }
+
+    private static CliInfo detectCli() {
+        try {
+            boolean win = System.getProperty("os.name")
+                    .toLowerCase().contains("win");
+            String[] cmd = win
+                    ? new String[]{"cmd", "/c", "npm", "list", "-g",
+                            "@kaluchi/jdtbridge", "--json"}
+                    : new String[]{"npm", "list", "-g",
+                            "@kaluchi/jdtbridge", "--json"};
+            Process p = new ProcessBuilder(cmd)
+                    .redirectErrorStream(true)
+                    .start();
+            String output = new String(
+                    p.getInputStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
+            boolean exited = p.waitFor(10,
+                    java.util.concurrent.TimeUnit.SECONDS);
+            if (!exited) {
+                p.destroyForcibly();
+                return new CliInfo(false, "");
+            }
+            var outer = Json.parse(output);
+            String depsRaw = Json.getString(outer, "dependencies");
+            if (depsRaw == null) return new CliInfo(false, "");
+            var deps = Json.parse(depsRaw);
+            String pkgRaw = Json.getString(deps,
+                    "@kaluchi/jdtbridge");
+            if (pkgRaw == null) return new CliInfo(false, "");
+            var pkg = Json.parse(pkgRaw);
+            String version = Json.getString(pkg, "version");
+            if (version != null && !version.isEmpty()) {
+                return new CliInfo(true, version);
+            }
+            return new CliInfo(false, "");
+        } catch (Exception e) {
+            return new CliInfo(false, "");
+        }
+    }
+
+    private record CliInfo(boolean installed, String version) {
+    }
+
+    /** Read port and version from the first bridge instance file. */
+    private BridgeInfo readBridgeInfo() {
+        try {
+            Path instances = Activator.getHome().resolve("instances");
+            if (!Files.isDirectory(instances)) {
+                return new BridgeInfo(0, "");
+            }
+            try (var files = Files.list(instances)) {
+                return files
+                        .filter(f -> f.toString().endsWith(".json"))
+                        .findFirst()
+                        .map(this::parseBridgeFile)
+                        .orElse(new BridgeInfo(0, ""));
+            }
+        } catch (IOException e) {
+            return new BridgeInfo(0, "");
+        }
+    }
+
+    private BridgeInfo parseBridgeFile(Path file) {
+        try {
+            var map = Json.parse(Files.readString(file,
+                    StandardCharsets.UTF_8));
+            int port = Json.getInt(map, "port", 0);
+            String version = Json.getString(map, "version");
+            return new BridgeInfo(port, version != null ? version : "");
+        } catch (IOException e) {
+            return new BridgeInfo(0, "");
+        }
+    }
+
+    private record BridgeInfo(int port, String version) {
+    }
+
+    private String loadResource(String name) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(name)) {
+            if (is == null) {
+                throw new IOException("Resource not found: " + name);
+            }
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/welcome.html
+++ b/plugin/src/io/github/kaluchi/jdtbridge/welcome.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>JDT Bridge — Welcome</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #1a1a2e; color: #e0e0e0; min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 2rem; }
+  .card { max-width: 600px; background: #16213e; border-radius: 12px; padding: 2.5rem; box-shadow: 0 8px 32px rgba(0,0,0,0.3); }
+  .header { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+  .icon { width: 48px; height: 48px; flex-shrink: 0; }
+  h1 { font-size: 1.6rem; color: #f7941e; }
+  .version { font-size: 0.85rem; color: #888; margin-bottom: 1.5rem; }
+  p { line-height: 1.6; margin-bottom: 1.2rem; color: #ccc; }
+  .status { display: flex; align-items: center; gap: 0.5rem; padding: 0.8rem 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: 0.95rem; }
+  .status.ok { background: #0f3460; border: 1px solid #2ecc7144; color: #2ecc71; }
+  .status.warn { background: #0f3460; border: 1px solid #f7941e44; color: #f7941e; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .dot.green { background: #2ecc71; }
+  .dot.orange { background: #f7941e; }
+  .install-box { background: #0f3460; border: 1px solid #f7941e44; border-radius: 8px; padding: 1rem; margin-bottom: 1.5rem; }
+  .install-box .label { font-size: 0.8rem; color: #888; margin-bottom: 0.5rem; }
+  .install-box .cmd { display: flex; align-items: center; gap: 0.5rem; }
+  .install-box code { font-size: 1rem; color: #f7941e; cursor: pointer; flex: 1; }
+  .install-box code:hover { text-decoration: underline; }
+  .install-box .copied { font-size: 0.8rem; color: #2ecc71; opacity: 0; transition: opacity 0.2s; }
+  .install-box .copied.show { opacity: 1; }
+  .install-box .hint { font-size: 0.75rem; color: #666; margin-top: 0.4rem; }
+  .install-box .refresh { display: inline-block; margin-top: 0.8rem; color: #f7941e; text-decoration: none; font-size: 0.85rem; cursor: pointer; }
+  .install-box .refresh:hover { text-decoration: underline; }
+  .steps { margin-bottom: 1.5rem; padding-left: 1.5rem; }
+  .steps li { margin-bottom: 0.5rem; line-height: 1.5; color: #ccc; }
+  .steps code { background: #0f3460; padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.9rem; color: #e0e0e0; }
+  .dismiss { display: flex; align-items: center; gap: 0.5rem; margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #ffffff15; cursor: pointer; }
+  .dismiss input { cursor: pointer; }
+  .dismiss label { font-size: 0.85rem; color: #888; cursor: pointer; }
+  .dismiss.saved label { color: #2ecc71; }
+  .links { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 1.5rem; }
+  .links a { color: #f7941e; text-decoration: none; padding: 0.4rem 0.8rem; border: 1px solid #f7941e44; border-radius: 6px; font-size: 0.85rem; transition: all 0.2s; }
+  .links a:hover { background: #f7941e; color: #1a1a2e; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="header">
+    <svg class="icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+      <rect width="32" height="32" rx="6" fill="#2C2255"/>
+      <path d="M6 22 L6 14 A 10 10 0 0 1 26 14 L26 22" stroke="#F7941E" stroke-width="3" fill="none" stroke-linecap="round"/>
+      <circle cx="6" cy="22" r="2.5" fill="#F7941E"/>
+      <circle cx="26" cy="22" r="2.5" fill="#F7941E"/>
+    </svg>
+    <h1>JDT Bridge</h1>
+  </div>
+  <div class="version">Plugin {{version}}</div>
+
+  <div class="status ok">
+    <div class="dot green"></div>
+    Bridge running on port {{port}}
+  </div>
+
+  <div id="cli-ok" class="status ok" style="display:none">
+    <div class="dot green"></div>
+    <span>CLI <span id="cli-ver"></span> installed</span>
+  </div>
+
+  <div id="cli-missing" style="display:none">
+    <p>The Eclipse plugin is running. Install the CLI to get semantic Java analysis in your terminal and AI coding assistants.</p>
+    <div class="install-box">
+      <div class="label">Install the CLI</div>
+      <div class="cmd">
+        <code id="install-cmd">npm install -g @kaluchi/jdtbridge</code>
+        <span class="copied" id="copied">Copied!</span>
+      </div>
+      <div class="hint">Click to copy &middot; requires Node.js 20+</div>
+      <a class="refresh" href="/status">Installed? Check again</a>
+    </div>
+  </div>
+
+  <div id="cli-ready" style="display:none">
+    <p>Everything is set up. Try these commands in your terminal:</p>
+  </div>
+
+  <ol class="steps">
+    <li>Run <code>jdt setup --check</code> to verify the connection</li>
+    <li>Run <code>jdt projects</code> to list workspace projects</li>
+    <li>Run <code>jdt find "*Test*"</code> to search for types</li>
+  </ol>
+
+  <div class="links">
+    <a href="https://github.com/kaluchi/jdtbridge">GitHub</a>
+    <a href="https://github.com/kaluchi/jdtbridge#getting-started">Getting Started</a>
+    <a href="https://github.com/kaluchi/jdtbridge/releases">Releases</a>
+  </div>
+
+  <div class="dismiss" id="dismiss">
+    <input type="checkbox" id="dismiss-check">
+    <label for="dismiss-check">Don't show this on startup</label>
+  </div>
+</div>
+
+<script>
+(function() {
+  var installed = {{cliInstalled}};
+  var version = "{{cliVersion}}";
+
+  if (installed) {
+    document.getElementById('cli-ok').style.display = 'flex';
+    document.getElementById('cli-ver').textContent = version;
+    document.getElementById('cli-ready').style.display = 'block';
+  } else {
+    document.getElementById('cli-missing').style.display = 'block';
+  }
+
+  document.getElementById('install-cmd').addEventListener('click', function() {
+    navigator.clipboard.writeText('npm install -g @kaluchi/jdtbridge');
+    var el = document.getElementById('copied');
+    el.classList.add('show');
+    setTimeout(function() { el.classList.remove('show'); }, 2000);
+  });
+
+  document.getElementById('dismiss-check').addEventListener('change', function() {
+    if (this.checked) {
+      fetch('/status/dismiss', { method: 'POST' })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (data.ok) {
+            document.getElementById('dismiss').classList.add('saved');
+          }
+        });
+    }
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve welcome/status page at `/status` endpoint — shows plugin version, bridge port, CLI install status
- Opens in system browser on first startup if CLI is not detected (`npm list -g`)
- "Don't show again" checkbox persists via POST `/status/dismiss` to `~/.jdtbridge/config.json`
- Add JSON parser to `Json.java` (`parse`, `getString`, `getInt`, `getBool`) — replaces all ad-hoc substring-based JSON reading
- `/status` and `/status/dismiss` exempt from auth (loopback only, no sensitive data)
- Migrate `ActivatorTest` from `contains()` assertions to `Json.parse()`

## New tests (50)
- `JsonTest` (40): builder, escape, parser — roundtrip, whitespace, escapes, nested objects, edge cases
- `WelcomeHandlerTest` (10): npm list parsing, bridge file parsing, config dismiss logic

## Total: 168 plugin tests, 220 CLI tests — all green