### PR TITLE
Auto-update landing page version on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,13 @@ jobs:
           artifact.repository.factory.order=compositeArtifacts.xml,\!
           IDXEOF
 
+      - name: Update landing page version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [ -f site-content/index.html ]; then
+            sed -i "s|<div class=\"version\">v[^<]*</div>|<div class=\"version\">v${VERSION}</div>|" site-content/index.html
+          fi
+
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
## Summary
- Add `sed` step to deploy workflow that updates the version in `index.html` on gh-pages before deploying
- Landing page on gh-pages already updated manually to v1.1.0

Future releases will update the landing page automatically when the deploy workflow runs on `v*` tags.