### PR TITLE
Auto-create GitHub Release on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: cli/package-lock.json
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: cli/package-lock.json
           registry-url: https://registry.npmjs.org
@@ -144,3 +144,19 @@ jobs:
           folder: site-content
           branch: gh-pages
           clean: false
+
+  release:
+    name: Create GitHub Release
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Add `release` job to deploy workflow — after build and p2 deploy succeed, creates a GitHub Release with auto-generated notes from merged PRs.

## Full release flow after this PR
```
node scripts/release.mjs 1.2.0    # bump + build + commit + tag + push
```
CI does the rest:
1. Build + test (CLI + plugin)
2. Publish CLI to npm
3. Deploy p2 site to GitHub Pages
4. Update landing page version
5. Create GitHub Release with auto-generated notes ← NEW