### PR TITLE
Upgrade GitHub Actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -31,15 +31,15 @@ jobs:
     name: Plugin build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ jobs:
     name: Build release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -20,13 +20,13 @@ jobs:
 
       - run: cd cli && npm ci && npm test
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
@@ -40,7 +40,7 @@ jobs:
             -Djdk.xml.maxGeneralEntitySizeLimit=0
 
       - name: Upload p2 repository
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: p2-repository
           path: site/target/repository/
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch gh-pages history
         run: |
@@ -69,7 +69,7 @@ jobs:
           mkdir -p site-content
           git worktree add site-content gh-pages || true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: p2-repository
           path: new-release
@@ -152,7 +152,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -111,5 +111,4 @@ console.log("\nPushing...");
 run(`git push origin master ${tag}`);
 
 console.log(`\n✓ Released ${version}`);
-console.log(`  CI will deploy the p2 site to GitHub Pages.`);
-console.log(`  Create GitHub release: gh release create ${tag} --generate-notes`);
+console.log(`  CI will: build, test, npm publish, deploy p2 site, create GitHub Release.`);


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions from v4 to v5: checkout, setup-node, setup-java, cache, upload-artifact, download-artifact
- Removes Node.js 20 deprecation warnings
- Update release script message (GitHub Release is now created by CI)