### PR TITLE
Extract ConfigService, fix welcome dismiss

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ConfigServiceTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ConfigServiceTest.java
@@ -1,0 +1,231 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for ConfigService — config.json read/write/roundtrip.
+ */
+public class ConfigServiceTest {
+
+    @TempDir
+    Path tempDir;
+    ConfigService config;
+
+    @BeforeEach
+    void setUp() {
+        config = new ConfigService(tempDir);
+    }
+
+    @Nested
+    class GetBoolean {
+
+        @Test
+        void defaultWhenNoFile() {
+            assertFalse(config.getBoolean("key", false));
+            assertTrue(config.getBoolean("key", true));
+        }
+
+        @Test
+        void defaultWhenKeyMissing() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"other\":true}");
+            assertFalse(config.getBoolean("key", false));
+        }
+
+        @Test
+        void readsTrue() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"flag\":true}");
+            assertTrue(config.getBoolean("flag", false));
+        }
+
+        @Test
+        void readsFalse() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"flag\":false}");
+            assertFalse(config.getBoolean("flag", true));
+        }
+    }
+
+    @Nested
+    class GetString {
+
+        @Test
+        void nullWhenNoFile() {
+            assertNull(config.getString("key"));
+        }
+
+        @Test
+        void nullWhenKeyMissing() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"other\":\"val\"}");
+            assertNull(config.getString("key"));
+        }
+
+        @Test
+        void readsValue() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"path\":\"D:/eclipse\"}");
+            assertEquals("D:/eclipse", config.getString("path"));
+        }
+    }
+
+    @Nested
+    class PutBoolean {
+
+        @Test
+        void createsFileIfMissing() throws IOException {
+            config.putBoolean("dismissed", true);
+            assertTrue(Files.exists(tempDir.resolve("config.json")));
+            assertTrue(config.getBoolean("dismissed", false));
+        }
+
+        @Test
+        void preservesExistingKeys() throws Exception {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"eclipse\":\"D:/eclipse\"}");
+            config.putBoolean("dismissed", true);
+            assertEquals("D:/eclipse", config.getString("eclipse"));
+            assertTrue(config.getBoolean("dismissed", false));
+        }
+
+        @Test
+        void overwritesExistingValue() throws Exception {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"dismissed\":true}");
+            config.putBoolean("dismissed", false);
+            assertFalse(config.getBoolean("dismissed", true));
+        }
+    }
+
+    @Nested
+    class PutString {
+
+        @Test
+        void createsFileIfMissing() throws IOException {
+            config.putString("eclipse", "/opt/eclipse");
+            assertEquals("/opt/eclipse",
+                    config.getString("eclipse"));
+        }
+
+        @Test
+        void preservesExistingKeys() throws Exception {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "{\"dismissed\":true}");
+            config.putString("eclipse", "/opt/eclipse");
+            assertTrue(config.getBoolean("dismissed", false));
+            assertEquals("/opt/eclipse",
+                    config.getString("eclipse"));
+        }
+    }
+
+    @Nested
+    class ReadBridgeInfo {
+
+        @Test
+        void noInstancesDir() {
+            var info = config.readBridgeInfo();
+            assertEquals(0, info.port());
+            assertEquals("", info.version());
+        }
+
+        @Test
+        void emptyInstancesDir() throws IOException {
+            Files.createDirectories(tempDir.resolve("instances"));
+            var info = config.readBridgeInfo();
+            assertEquals(0, info.port());
+        }
+
+        @Test
+        void readsPortAndVersion() throws IOException {
+            Path instances = Files.createDirectories(
+                    tempDir.resolve("instances"));
+            Files.writeString(instances.resolve("test.json"),
+                    "{\"port\":54321,\"version\":\"1.2.0\","
+                            + "\"token\":\"abc\"}");
+            var info = config.readBridgeInfo();
+            assertEquals(54321, info.port());
+            assertEquals("1.2.0", info.version());
+        }
+
+        @Test
+        void corruptInstanceFile() throws IOException {
+            Path instances = Files.createDirectories(
+                    tempDir.resolve("instances"));
+            Files.writeString(instances.resolve("bad.json"),
+                    "not json");
+            var info = config.readBridgeInfo();
+            assertEquals(0, info.port());
+        }
+
+        @Test
+        void ignoresNonJsonFiles() throws IOException {
+            Path instances = Files.createDirectories(
+                    tempDir.resolve("instances"));
+            Files.writeString(instances.resolve("notes.txt"),
+                    "not a bridge file");
+            var info = config.readBridgeInfo();
+            assertEquals(0, info.port());
+        }
+    }
+
+    @Nested
+    class Roundtrip {
+
+        @Test
+        void multipleKeyTypes() throws Exception {
+            config.putString("eclipse", "D:/eclipse");
+            config.putBoolean("dismissed", true);
+            config.putString("theme", "dark");
+
+            assertEquals("D:/eclipse",
+                    config.getString("eclipse"));
+            assertTrue(config.getBoolean("dismissed", false));
+            assertEquals("dark", config.getString("theme"));
+        }
+
+        @Test
+        void validJsonOnDisk() throws Exception {
+            config.putString("path", "C:/test");
+            config.putBoolean("flag", true);
+
+            String raw = Files.readString(
+                    tempDir.resolve("config.json"),
+                    StandardCharsets.UTF_8).trim();
+            assertTrue(raw.startsWith("{"),
+                    "Should be JSON object: " + raw);
+            assertTrue(raw.contains("\"path\":\"C:/test\""),
+                    "Should contain path: " + raw);
+            assertTrue(raw.contains("\"flag\":true"),
+                    "Should contain flag: " + raw);
+        }
+
+        @Test
+        void corruptFileReturnsDefaults() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"),
+                    "not json at all");
+            assertFalse(config.getBoolean("key", false));
+            assertNull(config.getString("key"));
+        }
+
+        @Test
+        void emptyFileReturnsDefaults() throws IOException {
+            Files.writeString(tempDir.resolve("config.json"), "");
+            assertFalse(config.getBoolean("key", false));
+            assertNull(config.getString("key"));
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/WelcomeHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/WelcomeHandlerTest.java
@@ -117,26 +117,6 @@ public class WelcomeHandlerTest {
         assertTrue(Json.getBool(map, "welcomeDismissed", false));
     }
 
-    // ---- Config roundtrip: read → add key → write → read ----
-
-    @Test
-    public void configRoundtripAddDismissed() {
-        String original = "{\"eclipse\":\"D:/eclipse\"}";
-        var config = Json.parse(original);
-        config.put("welcomeDismissed", Boolean.TRUE);
-
-        Json builder = Json.object();
-        for (var entry : config.entrySet()) {
-            Object v = entry.getValue();
-            if (v instanceof String s) builder.put(entry.getKey(), s);
-            else if (v instanceof Boolean b)
-                builder.put(entry.getKey(), b);
-        }
-        String written = builder.toString();
-
-        var reread = Json.parse(written);
-        assertEquals("D:/eclipse",
-                Json.getString(reread, "eclipse"));
-        assertTrue(Json.getBool(reread, "welcomeDismissed", false));
-    }
+    // ---- Config roundtrip via ConfigService ----
+    // (Detailed roundtrip tests are in ConfigServiceTest)
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/ConfigService.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/ConfigService.java
@@ -1,0 +1,114 @@
+package io.github.kaluchi.jdtbridge;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Manages persistent configuration stored in {@code config.json}
+ * under the JDT Bridge home directory ({@code ~/.jdtbridge/}).
+ *
+ * <p>All config access goes through this service — no other class
+ * should read or write config.json directly.
+ */
+class ConfigService {
+
+    private final Path homeDir;
+    private final Path configFile;
+
+    ConfigService(Path homeDir) {
+        this.homeDir = homeDir;
+        this.configFile = homeDir.resolve("config.json");
+    }
+
+    boolean getBoolean(String key, boolean defaultValue) {
+        return Json.getBool(load(), key, defaultValue);
+    }
+
+    String getString(String key) {
+        return Json.getString(load(), key);
+    }
+
+    void putBoolean(String key, boolean value) throws IOException {
+        Map<String, Object> config = load();
+        config.put(key, value);
+        save(config);
+    }
+
+    void putString(String key, String value) throws IOException {
+        Map<String, Object> config = load();
+        config.put(key, value);
+        save(config);
+    }
+
+    private Map<String, Object> load() {
+        try {
+            if (Files.exists(configFile)) {
+                return Json.parse(Files.readString(configFile,
+                        StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            Log.warn("Failed to read config", e);
+        }
+        return new LinkedHashMap<>();
+    }
+
+    record BridgeInfo(int port, String version) {
+    }
+
+    BridgeInfo readBridgeInfo() {
+        try {
+            Path instances = homeDir.resolve("instances");
+            if (!Files.isDirectory(instances)) {
+                return new BridgeInfo(0, "");
+            }
+            try (var files = Files.list(instances)) {
+                return files
+                        .filter(f -> f.toString().endsWith(".json"))
+                        .findFirst()
+                        .map(this::parseBridgeFile)
+                        .orElse(new BridgeInfo(0, ""));
+            }
+        } catch (IOException e) {
+            return new BridgeInfo(0, "");
+        }
+    }
+
+    private BridgeInfo parseBridgeFile(Path file) {
+        try {
+            var map = Json.parse(Files.readString(file,
+                    StandardCharsets.UTF_8));
+            int port = Json.getInt(map, "port", 0);
+            String version = Json.getString(map, "version");
+            return new BridgeInfo(port,
+                    version != null ? version : "");
+        } catch (IOException e) {
+            return new BridgeInfo(0, "");
+        }
+    }
+
+    private void save(Map<String, Object> config) throws IOException {
+        Files.createDirectories(configFile.getParent());
+        Json builder = Json.object();
+        for (var entry : config.entrySet()) {
+            Object v = entry.getValue();
+            if (v instanceof String s)
+                builder.put(entry.getKey(), s);
+            else if (v instanceof Boolean b)
+                builder.put(entry.getKey(), b);
+            else if (v instanceof Integer i)
+                builder.put(entry.getKey(), i);
+            else if (v instanceof Long l)
+                builder.put(entry.getKey(), l);
+            else if (v instanceof Double d)
+                builder.put(entry.getKey(), d);
+            else if (v == null)
+                builder.put(entry.getKey(), (String) null);
+        }
+        Files.writeString(configFile, builder.toString() + "\n",
+                StandardCharsets.UTF_8);
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -31,7 +31,10 @@ public class HttpServer {
     private final EditorHandler editor = new EditorHandler();
     private final TestHandler testHandler = new TestHandler();
     private final ProjectHandler projectInfo = new ProjectHandler();
-    private final WelcomeHandler welcome = new WelcomeHandler();
+    private final ConfigService configService =
+            new ConfigService(Activator.getHome());
+    private final WelcomeHandler welcome =
+            new WelcomeHandler(configService);
     private final ExecutorService executor =
             Executors.newFixedThreadPool(4, r -> {
                 Thread t = new Thread(r, "jdtbridge-req");
@@ -216,6 +219,10 @@ public class HttpServer {
             if ("/status/dismiss".equals(path)
                     && "POST".equals(method)) {
                 return welcome.handleDismiss();
+            }
+            if ("/status/undismiss".equals(path)
+                    && "POST".equals(method)) {
+                return welcome.handleUndismiss();
             }
             return Response.json(Json.error("Not found: " + path));
         } catch (Exception e) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/StartupHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/StartupHandler.java
@@ -1,8 +1,5 @@
 package io.github.kaluchi.jdtbridge;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -30,13 +27,17 @@ public class StartupHandler implements IStartup {
 
     private IStatus check(IProgressMonitor monitor) {
         try {
-            if (WelcomeHandler.isDismissed()) {
+            Path home = Activator.getHome();
+            ConfigService config = new ConfigService(home);
+            WelcomeHandler welcome = new WelcomeHandler(config);
+
+            if (welcome.isDismissed()) {
                 return Status.OK_STATUS;
             }
-            if (WelcomeHandler.isCliInstalled()) {
+            if (welcome.isCliInstalled()) {
                 return Status.OK_STATUS;
             }
-            int port = readPortFromBridgeFile();
+            int port = config.readBridgeInfo().port();
             if (port <= 0) {
                 return Status.OK_STATUS;
             }
@@ -45,32 +46,6 @@ public class StartupHandler implements IStartup {
             Log.warn("Welcome check failed", e);
         }
         return Status.OK_STATUS;
-    }
-
-    private int readPortFromBridgeFile() {
-        try {
-            Path instances = Activator.getHome().resolve("instances");
-            if (!Files.isDirectory(instances)) return 0;
-            try (var files = Files.list(instances)) {
-                return files
-                        .filter(f -> f.toString().endsWith(".json"))
-                        .findFirst()
-                        .map(this::extractPort)
-                        .orElse(0);
-            }
-        } catch (IOException e) {
-            return 0;
-        }
-    }
-
-    private int extractPort(Path file) {
-        try {
-            var map = Json.parse(Files.readString(file,
-                    StandardCharsets.UTF_8));
-            return Json.getInt(map, "port", 0);
-        } catch (Exception e) {
-            return 0;
-        }
     }
 
     private void openWelcome(int port) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/WelcomeHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/WelcomeHandler.java
@@ -3,9 +3,6 @@ package io.github.kaluchi.jdtbridge;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
 
 /**
  * Serves the welcome/status HTML page and handles the dismiss action.
@@ -16,47 +13,40 @@ import java.util.Map;
  */
 class WelcomeHandler {
 
-    private static final String CONFIG_FILE = "config.json";
     private static final String DISMISSED_KEY = "welcomeDismissed";
+
+    private final ConfigService config;
+
+    WelcomeHandler(ConfigService config) {
+        this.config = config;
+    }
 
     HttpServer.Response handleStatus() throws IOException {
         String template = loadResource("welcome.html");
-        BridgeInfo info = readBridgeInfo();
+        ConfigService.BridgeInfo info = config.readBridgeInfo();
         CliInfo cli = detectCli();
         String html = template
-                .replace("{{version}}", info.version)
-                .replace("{{port}}", String.valueOf(info.port))
+                .replace("{{version}}", info.version())
+                .replace("{{port}}", String.valueOf(info.port()))
                 .replace("{{cliInstalled}}",
                         String.valueOf(cli.installed))
-                .replace("{{cliVersion}}", cli.version);
+                .replace("{{cliVersion}}", cli.version)
+                .replace("{{dismissed}}",
+                        String.valueOf(isDismissed()));
         return HttpServer.Response.html(html);
     }
 
     HttpServer.Response handleDismiss() {
+        return setDismissed(true);
+    }
+
+    HttpServer.Response handleUndismiss() {
+        return setDismissed(false);
+    }
+
+    private HttpServer.Response setDismissed(boolean value) {
         try {
-            Path configFile = Activator.getHome().resolve(CONFIG_FILE);
-            Map<String, Object> config;
-            if (Files.exists(configFile)) {
-                config = Json.parse(Files.readString(configFile,
-                        StandardCharsets.UTF_8));
-            } else {
-                Files.createDirectories(configFile.getParent());
-                config = new java.util.LinkedHashMap<>();
-            }
-            config.put(DISMISSED_KEY, Boolean.TRUE);
-            // Rebuild JSON from map
-            Json builder = Json.object();
-            for (var entry : config.entrySet()) {
-                Object v = entry.getValue();
-                if (v instanceof String s) builder.put(entry.getKey(), s);
-                else if (v instanceof Boolean b) builder.put(entry.getKey(), b);
-                else if (v instanceof Integer i) builder.put(entry.getKey(), i);
-                else if (v instanceof Long l) builder.put(entry.getKey(), l);
-                else if (v instanceof Double d) builder.put(entry.getKey(), d);
-                else if (v == null) builder.put(entry.getKey(), (String) null);
-            }
-            Files.writeString(configFile, builder.toString() + "\n",
-                    StandardCharsets.UTF_8);
+            config.putBoolean(DISMISSED_KEY, value);
             return HttpServer.Response.json("{\"ok\":true}");
         } catch (IOException e) {
             Log.warn("Failed to save dismiss preference", e);
@@ -65,19 +55,11 @@ class WelcomeHandler {
         }
     }
 
-    static boolean isDismissed() {
-        try {
-            Path configFile = Activator.getHome().resolve(CONFIG_FILE);
-            if (!Files.exists(configFile)) return false;
-            var config = Json.parse(Files.readString(configFile,
-                    StandardCharsets.UTF_8));
-            return Json.getBool(config, DISMISSED_KEY, false);
-        } catch (IOException e) {
-            return false;
-        }
+    boolean isDismissed() {
+        return config.getBoolean(DISMISSED_KEY, false);
     }
 
-    static boolean isCliInstalled() {
+    boolean isCliInstalled() {
         return detectCli().installed;
     }
 
@@ -121,40 +103,6 @@ class WelcomeHandler {
     }
 
     private record CliInfo(boolean installed, String version) {
-    }
-
-    /** Read port and version from the first bridge instance file. */
-    private BridgeInfo readBridgeInfo() {
-        try {
-            Path instances = Activator.getHome().resolve("instances");
-            if (!Files.isDirectory(instances)) {
-                return new BridgeInfo(0, "");
-            }
-            try (var files = Files.list(instances)) {
-                return files
-                        .filter(f -> f.toString().endsWith(".json"))
-                        .findFirst()
-                        .map(this::parseBridgeFile)
-                        .orElse(new BridgeInfo(0, ""));
-            }
-        } catch (IOException e) {
-            return new BridgeInfo(0, "");
-        }
-    }
-
-    private BridgeInfo parseBridgeFile(Path file) {
-        try {
-            var map = Json.parse(Files.readString(file,
-                    StandardCharsets.UTF_8));
-            int port = Json.getInt(map, "port", 0);
-            String version = Json.getString(map, "version");
-            return new BridgeInfo(port, version != null ? version : "");
-        } catch (IOException e) {
-            return new BridgeInfo(0, "");
-        }
-    }
-
-    private record BridgeInfo(int port, String version) {
     }
 
     private String loadResource(String name) throws IOException {

--- a/plugin/src/io/github/kaluchi/jdtbridge/welcome.html
+++ b/plugin/src/io/github/kaluchi/jdtbridge/welcome.html
@@ -103,6 +103,12 @@
 (function() {
   var installed = {{cliInstalled}};
   var version = "{{cliVersion}}";
+  var dismissed = {{dismissed}};
+
+  if (dismissed) {
+    document.getElementById('dismiss-check').checked = true;
+    document.getElementById('dismiss').classList.add('saved');
+  }
 
   if (installed) {
     document.getElementById('cli-ok').style.display = 'flex';
@@ -120,15 +126,19 @@
   });
 
   document.getElementById('dismiss-check').addEventListener('change', function() {
-    if (this.checked) {
-      fetch('/status/dismiss', { method: 'POST' })
-        .then(function(r) { return r.json(); })
-        .then(function(data) {
-          if (data.ok) {
-            document.getElementById('dismiss').classList.add('saved');
+    var action = this.checked ? '/status/dismiss' : '/status/undismiss';
+    var el = document.getElementById('dismiss');
+    fetch(action, { method: 'POST' })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.ok) {
+          if (action === '/status/dismiss') {
+            el.classList.add('saved');
+          } else {
+            el.classList.remove('saved');
           }
-        });
-    }
+        }
+      });
   });
 })();
 </script>


### PR DESCRIPTION
## Summary

- Extract `ConfigService` to encapsulate all config.json read/write and bridge instance file reading
- Eliminates inline JSON serialization, duplicated file I/O, and static state from `WelcomeHandler`
- Fix welcome checkbox not reflecting saved dismissed state on page load
- Support unchecking to re-enable welcome page on next startup
- Remove duplicated `readBridgeInfo`/`readPortFromBridgeFile` — both `WelcomeHandler` and `StartupHandler` use `ConfigService` now

## Test plan

- [x] 15 new unit tests (`ConfigServiceTest.java`) — roundtrip, edge cases, corrupt files
- [x] 267 total Tycho tests pass (0 failures)
- [x] Live verified: dismiss/undismiss roundtrip via HTTP endpoints
- [x] Checkbox renders checked state correctly on page load