### PR TITLE
Replace active-editor with editors command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Most commands have short aliases for quick typing.
 | `rename <FQMN> <new>` | | Rename type, method, or field across workspace |
 | `move <FQN> <package>` | | Move type to another package |
 | `open <FQMN>` | | Open in Eclipse editor |
-| `active-editor` | `ae` | Current file and cursor position |
+| `editors` | `ed` | List all open editors (absolute paths) |
 | `setup [--check\|--remove]` | | Install, check, or remove Eclipse plugin |
 
 Run `jdt help <command>` for detailed flags and options.

--- a/cli/README.md
+++ b/cli/README.md
@@ -74,7 +74,7 @@ jdt move <FQN> <target.package>                        # move type to another pa
 ### Editor
 
 ```bash
-jdt active-editor                                      # (alias: ae) current file and cursor line
+jdt editors                                             # (alias: ed) list all open editors (absolute paths)
 jdt open <FQMN>                                        # open in Eclipse editor
 ```
 

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -24,9 +24,9 @@ import {
   moveHelp,
 } from "./commands/refactoring.mjs";
 import {
-  activeEditor,
+  editors,
   open,
-  activeEditorHelp,
+  editorsHelp,
   openHelp,
 } from "./commands/editor.mjs";
 import { setup, help as setupHelp } from "./commands/setup.mjs";
@@ -53,7 +53,7 @@ const commands = {
   format: { fn: format, help: formatHelp },
   rename: { fn: rename, help: renameHelp },
   move: { fn: move, help: moveHelp },
-  "active-editor": { fn: activeEditor, help: activeEditorHelp },
+  editors: { fn: editors, help: editorsHelp },
   open: { fn: open, help: openHelp },
   setup: { fn: setup, help: setupHelp },
 };
@@ -67,7 +67,7 @@ const aliases = {
   pi: "project-info",
   ti: "type-info",
   oi: "organize-imports",
-  ae: "active-editor",
+  ed: "editors",
   src: "source",
   b: "build",
   err: "errors",
@@ -121,7 +121,7 @@ Refactoring:
   move <FQN> <target.package>                 move type to another package
 
 Editor:
-  active-editor${fmtAliases("active-editor")}                               current file and cursor line
+  editors${fmtAliases("editors")}                                    list open editors (absolute paths)
   open <FQMN>                                 open in Eclipse editor
 
 Setup:

--- a/cli/src/commands/editor.mjs
+++ b/cli/src/commands/editor.mjs
@@ -1,17 +1,18 @@
 import { get } from "../client.mjs";
 import { extractPositional, parseFlags, parseFqmn } from "../args.mjs";
-import { stripProject } from "../paths.mjs";
 
-export async function activeEditor() {
-  const result = await get("/active-editor");
-  if (result.error) {
-    console.error(result.error);
+export async function editors() {
+  const results = await get("/editors");
+  if (results.error) {
+    console.error(results.error);
     process.exit(1);
   }
-  if (result.file === null) {
-    console.log("(no file open)");
-  } else {
-    console.log(`${stripProject(result.file)}:${result.line}`);
+  if (results.length === 0) {
+    console.log("(no open editors)");
+    return;
+  }
+  for (const r of results) {
+    console.log(r.file);
   }
 }
 
@@ -38,9 +39,11 @@ export async function open(args) {
   console.log("Opened");
 }
 
-export const activeEditorHelp = `Show the file and cursor line of the active Eclipse editor.
+export const editorsHelp = `List all open editors in Eclipse. Active editor first.
 
-Usage:  jdt active-editor`;
+Usage:  jdt editors
+
+Output: absolute file paths, one per line.`;
 
 export const openHelp = `Open a type or method in the Eclipse editor.
 

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -195,24 +195,28 @@ describe("commands (integration)", () => {
     expect(io.logs[0]).toBe("Moved");
   });
 
-  it("active-editor shows file:line", async () => {
+  it("editors lists open files", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ file: "/m8-server/src/Foo.java", line: 42 }));
+      res.end(JSON.stringify([
+        { file: "D:/projects/src/Foo.java" },
+        { file: "D:/projects/src/Bar.java" },
+      ]));
     });
-    const { activeEditor } = await import("../src/commands/editor.mjs");
-    await activeEditor();
-    expect(io.logs[0]).toBe("m8-server/src/Foo.java:42");
+    const { editors } = await import("../src/commands/editor.mjs");
+    await editors();
+    expect(io.logs[0]).toBe("D:/projects/src/Foo.java");
+    expect(io.logs[1]).toBe("D:/projects/src/Bar.java");
   });
 
-  it("active-editor shows no file open", async () => {
+  it("editors shows empty message", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ file: null }));
+      res.end("[]");
     });
-    const { activeEditor } = await import("../src/commands/editor.mjs");
-    await activeEditor();
-    expect(io.logs[0]).toBe("(no file open)");
+    const { editors } = await import("../src/commands/editor.mjs");
+    await editors();
+    expect(io.logs[0]).toBe("(no open editors)");
   });
 
   it("open shows Opened", async () => {
@@ -527,10 +531,10 @@ describe("commands (integration)", () => {
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
-  it("active-editor exits on server error", async () => {
+  it("editors exits on server error", async () => {
     await setupMock(errorServer());
-    const { activeEditor } = await import("../src/commands/editor.mjs");
-    await expect(activeEditor()).rejects.toThrow("exit(1)");
+    const { editors } = await import("../src/commands/editor.mjs");
+    await expect(editors()).rejects.toThrow("exit(1)");
     expect(io.errors[0]).toContain("Something went wrong");
   });
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpIntegrationTest.java
@@ -215,6 +215,8 @@ public class HttpIntegrationTest {
         return response;
     }
 
+    // /editors requires Display thread — tested live, not in headless CI
+
     private String rawRequest(String requestLine, String... headers)
             throws Exception {
         try (Socket socket = new Socket("localhost", port)) {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -108,9 +108,9 @@ Move a type to another package. Creates the target package if it doesn't exist. 
 
 ## Editor
 
-### `GET /active-editor`
+### `GET /editors`
 
-Returns the file and cursor line of the currently active Eclipse editor.
+Returns all open editors as a JSON array. Active editor first, then tab order. Files are absolute OS paths.
 
 ### `GET /open?class=<FQN>[&method=<name>][&paramTypes=<types>]`
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
@@ -2,69 +2,79 @@ package io.github.kaluchi.jdtbridge;
 
 import java.util.Map;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.ui.JavaUI;
-import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
 /**
- * Handlers for Eclipse editor interaction: active-editor, open.
+ * Handlers for Eclipse editor interaction: editors list, open.
  */
 class EditorHandler {
 
-    String handleActiveEditor(Map<String, String> params) throws Exception {
-        String[] result = {Json.error("Failed to query editor")};
-        Display.getDefault().syncExec(() -> {
+    String handleEditors(Map<String, String> params) throws Exception {
+        String[] result = {"[]"};
+        Runnable query = () -> {
             try {
-                var window = PlatformUI.getWorkbench()
+                IWorkbenchWindow window = PlatformUI.getWorkbench()
                         .getActiveWorkbenchWindow();
                 if (window == null
                         || window.getActivePage() == null) {
-                    result[0] = Json.object()
-                            .put("file", (String) null).toString();
-                    return;
-                }
-                IEditorPart editor =
-                        window.getActivePage().getActiveEditor();
-                if (editor == null) {
-                    result[0] = Json.object()
-                            .put("file", (String) null).toString();
                     return;
                 }
 
-                String file = null;
-                var input = editor.getEditorInput();
-                if (input instanceof IFileEditorInput fileInput) {
-                    file = fileInput.getFile().getFullPath().toString();
-                }
+                IWorkbenchPage page = window.getActivePage();
+                IEditorReference[] refs =
+                        page.getEditorReferences();
+                IEditorPart active = page.getActiveEditor();
 
-                int line = -1;
-                var sp = editor.getSite().getSelectionProvider();
-                if (sp != null) {
-                    var sel = sp.getSelection();
-                    if (sel instanceof ITextSelection ts) {
-                        line = ts.getStartLine() + 1;
+                Json arr = Json.array();
+                if (active != null) {
+                    addEditorEntry(active.getEditorInput(), arr);
+                }
+                for (IEditorReference ref : refs) {
+                    IEditorPart editor = ref.getEditor(false);
+                    if (editor != null && editor == active)
+                        continue;
+                    try {
+                        addEditorEntry(ref.getEditorInput(), arr);
+                    } catch (Exception ignored) {
+                        // Skip editors that can't provide input
                     }
                 }
-
-                if (file != null) {
-                    result[0] = Json.object()
-                            .put("file", file)
-                            .put("line", line).toString();
-                } else {
-                    result[0] = Json.object()
-                            .put("file", (String) null).toString();
-                }
+                result[0] = arr.toString();
             } catch (Exception e) {
-                result[0] = Json.error(e.getMessage());
+                // No workbench — return empty array
             }
-        });
+        };
+        Display display = Display.getCurrent();
+        if (display != null) {
+            query.run();
+        } else {
+            try {
+                Display.getDefault().syncExec(query);
+            } catch (Exception e) {
+                // Headless — no Display thread
+            }
+        }
         return result[0];
+    }
+
+    private void addEditorEntry(
+            org.eclipse.ui.IEditorInput input, Json arr) {
+        if (!(input instanceof IFileEditorInput fi)) return;
+        IFile file = fi.getFile();
+        if (file.getLocation() == null) return;
+        arr.add(Json.object()
+                .put("file", file.getLocation().toOSString()));
     }
 
     String handleOpen(Map<String, String> params) throws Exception {

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -265,8 +265,8 @@ public class HttpServer {
                         refactoring.handleMove(params));
                 case "/test" -> Response.json(
                         testHandler.handleTest(params));
-                case "/active-editor" -> Response.json(
-                        editor.handleActiveEditor(params));
+                case "/editors" -> Response.json(
+                        editor.handleEditors(params));
                 case "/open" -> Response.json(
                         editor.handleOpen(params));
                 default -> Response.json(Json.error(


### PR DESCRIPTION
## Summary

- Add `jdt editors` — lists all open Eclipse editors as absolute file paths, active first
- Remove `active-editor` — was unstable with multi-monitor (focus-dependent)
- Alias: `ed`

## Test plan

- [x] 264 CLI tests pass (3 editors tests replace 3 active-editor tests)
- [x] 272 Tycho tests pass
- [x] Live verified — shows absolute paths from multiple workspace projects