### PR TITLE
Fix CI status spinners, upgrade labeler to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,19 @@ jobs:
           MAVEN_OPTS: >-
             -Djdk.xml.totalEntitySizeLimit=0
             -Djdk.xml.maxGeneralEntitySizeLimit=0
+
+  all-green:
+    name: All checks passed
+    if: always()
+    needs: [cli, plugin]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no failures
+        run: |
+          if [[ "${{ needs.cli.result }}" == "failure" || \
+                "${{ needs.cli.result }}" == "cancelled" || \
+                "${{ needs.plugin.result }}" == "failure" || \
+                "${{ needs.plugin.result }}" == "cancelled" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,4 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6


### PR DESCRIPTION
## Summary

- Add gate job "All checks passed" that always runs — fixes pending spinners on merge commits when paths-filter skips jobs
- Upgrade actions/labeler v5 → v6 (Node 24, fixes deprecation warning)

## After merge

Update branch protection required checks: remove "CLI tests" + "Plugin build", add "All checks passed".