### PR TITLE
Add launch run/stop, fix configs ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Most commands have short aliases for quick typing.
 | `editors` | `ed` | List all open editors (absolute paths) |
 | `launch list` | | List launches (running + terminated) |
 | `launch configs` | | List saved launch configurations (MRU order) |
+| `launch run <config>` | | Launch a configuration |
+| `launch stop <name>` | | Stop a running launch |
 | `launch console <name>` | | Show console output of a launch |
 | `launch clear [name]` | | Remove terminated launches |
 | `setup [--check\|--remove]` | | Install, check, or remove Eclipse plugin |

--- a/cli/README.md
+++ b/cli/README.md
@@ -76,6 +76,8 @@ jdt move <FQN> <target.package>                        # move type to another pa
 ```bash
 jdt launch list                                        # list launches (running + terminated)
 jdt launch configs                                     # list saved launch configurations
+jdt launch run <config> [--debug]                      # launch a configuration
+jdt launch stop <name>                                 # stop a running launch
 jdt launch console <name> [--tail N]                   # show console output
 jdt launch clear [name]                                # remove terminated launches
 ```

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -32,10 +32,14 @@ import {
 import {
   launchList,
   launchConfigs,
+  launchRun,
+  launchStop,
   launchClear,
   launchConsole,
   launchListHelp,
   launchConfigsHelp,
+  launchRunHelp,
+  launchStopHelp,
   launchClearHelp,
   launchConsoleHelp,
 } from "./commands/launch.mjs";
@@ -49,6 +53,8 @@ const { version } = createRequire(import.meta.url)("../package.json");
 const launchSubcommands = {
   list: { fn: launchList, help: launchListHelp },
   configs: { fn: launchConfigs, help: launchConfigsHelp },
+  run: { fn: launchRun, help: launchRunHelp },
+  stop: { fn: launchStop, help: launchStopHelp },
   clear: { fn: launchClear, help: launchClearHelp },
   console: { fn: launchConsole, help: launchConsoleHelp },
 };
@@ -58,6 +64,8 @@ const launchHelp = `Manage launches (running and terminated processes).
 Subcommands:
   jdt launch list                           list all launches
   jdt launch configs                        list saved launch configurations
+  jdt launch run <config> [--debug]         launch a configuration
+  jdt launch stop <name>                    stop a running launch
   jdt launch console <name> [--tail N]      show console output
   jdt launch clear [name]                   remove terminated launches
 
@@ -166,6 +174,8 @@ Refactoring:
 Launches:
   launch list                                 list launches (running + terminated)
   launch configs                              list saved launch configurations
+  launch run <config> [--debug]               launch a configuration
+  launch stop <name>                          stop a running launch
   launch console <name> [--tail N]            show console output of a launch
   launch clear [name]                         remove terminated launches
 

--- a/cli/src/commands/launch.mjs
+++ b/cli/src/commands/launch.mjs
@@ -48,6 +48,39 @@ export async function launchClear(args) {
   console.log(`Removed ${result.removed} terminated launch${result.removed !== 1 ? "es" : ""}`);
 }
 
+export async function launchRun(args) {
+  const pos = extractPositional(args);
+  const name = pos[0];
+  if (!name) {
+    console.error("Usage: launch run <config-name> [--debug]");
+    process.exit(1);
+  }
+  let url = `/launch/run?name=${encodeURIComponent(name)}`;
+  if (args.includes("--debug")) url += "&debug";
+  const result = await get(url, 30_000);
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+  console.log(`Launched ${result.name} (${result.mode})`);
+}
+
+export async function launchStop(args) {
+  const pos = extractPositional(args);
+  const name = pos[0];
+  if (!name) {
+    console.error("Usage: launch stop <name>");
+    process.exit(1);
+  }
+  const url = `/launch/stop?name=${encodeURIComponent(name)}`;
+  const result = await get(url);
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+  console.log(`Stopped ${result.name}`);
+}
+
 export async function launchConsole(args) {
   const pos = extractPositional(args);
   const flags = parseFlags(args);
@@ -73,6 +106,23 @@ export async function launchConsole(args) {
     console.log(text);
   }
 }
+
+export const launchRunHelp = `Launch a saved configuration.
+
+Usage:  jdt launch run <config-name> [--debug]
+
+Flags:
+  --debug    launch in debug mode (default: run)
+
+Examples:
+  jdt launch run m8-server
+  jdt launch run m8-server --debug`;
+
+export const launchStopHelp = `Stop a running launch.
+
+Usage:  jdt launch stop <name>
+
+Example:  jdt launch stop m8-server`;
 
 export const launchConfigsHelp = `List saved launch configurations (Run → Run Configurations).
 

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -631,6 +631,49 @@ describe("commands (integration)", () => {
     expect(io.logs[0]).toContain("1");
   });
 
+  it("launch run shows launched", async () => {
+    await setupMock((req, res) => {
+      expect(req.url).toContain("name=m8-server");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, name: "m8-server", mode: "run" }));
+    });
+    const { launchRun } = await import("../src/commands/launch.mjs");
+    await launchRun(["m8-server"]);
+    expect(io.logs[0]).toContain("Launched");
+    expect(io.logs[0]).toContain("m8-server");
+  });
+
+  it("launch run with debug flag", async () => {
+    await setupMock((req, res) => {
+      expect(req.url).toContain("debug");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, name: "m8-server", mode: "debug" }));
+    });
+    const { launchRun } = await import("../src/commands/launch.mjs");
+    await launchRun(["m8-server", "--debug"]);
+    expect(io.logs[0]).toContain("debug");
+  });
+
+  it("launch run missing name exits", async () => {
+    const { launchRun } = await import("../src/commands/launch.mjs");
+    await expect(launchRun([])).rejects.toThrow("exit(1)");
+  });
+
+  it("launch stop shows stopped", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, name: "m8-server" }));
+    });
+    const { launchStop } = await import("../src/commands/launch.mjs");
+    await launchStop(["m8-server"]);
+    expect(io.logs[0]).toContain("Stopped");
+  });
+
+  it("launch stop missing name exits", async () => {
+    const { launchStop } = await import("../src/commands/launch.mjs");
+    await expect(launchStop([])).rejects.toThrow("exit(1)");
+  });
+
   it("launch console missing name exits", async () => {
     const { launchConsole } = await import("../src/commands/launch.mjs");
     await expect(launchConsole([])).rejects.toThrow("exit(1)");

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -327,6 +327,69 @@ public class LaunchHandlerTest {
         }
     }
 
+    @Nested
+    class Run {
+
+        @Test
+        void missingNameReturnsError() {
+            String json = handler.handleRun(Map.of());
+            assertTrue(json.contains("error"),
+                    "Should return error: " + json);
+        }
+
+        @Test
+        void unknownConfigReturnsError() {
+            String json = handler.handleRun(
+                    Map.of("name", "no-such-config-xyz"));
+            assertTrue(json.contains("error"),
+                    "Should return error: " + json);
+            assertTrue(json.contains("not found"),
+                    "Should say not found: " + json);
+        }
+    }
+
+    @Nested
+    class Stop {
+
+        @Test
+        void missingNameReturnsError() {
+            String json = handler.handleStop(Map.of());
+            assertTrue(json.contains("error"),
+                    "Should return error: " + json);
+        }
+
+        @Test
+        void unknownLaunchReturnsError() {
+            String json = handler.handleStop(
+                    Map.of("name", "no-such-launch-xyz"));
+            assertTrue(json.contains("error"),
+                    "Should return error: " + json);
+        }
+
+        @Test
+        void terminatedLaunchReturnsError() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            Process proc = new ProcessBuilder(
+                    "java", "-version").start();
+            proc.waitFor(5,
+                    java.util.concurrent.TimeUnit.SECONDS);
+            DebugPlugin.newProcess(launch, proc,
+                    "stop-test-terminated");
+            mgr.addLaunch(launch);
+            try {
+                String json = handler.handleStop(
+                        Map.of("name", "stop-test-terminated"));
+                assertTrue(json.contains("Already terminated"),
+                        "Should say already terminated: " + json);
+            } finally {
+                mgr.removeLaunch(launch);
+            }
+        }
+    }
+
     // ---- HTTP routing tests ----
 
     @Nested

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -130,6 +130,14 @@ Returns all saved launch configurations (Run → Run Configurations).
 
 Returns console output (stdout + stderr) of a launch. `tail` limits to last N lines. `stream` filters to stdout or stderr only.
 
+### `GET /launch/run?name=<config-name>[&debug]`
+
+Launch a saved configuration. Returns immediately (fire-and-forget). Add `&debug` for debug mode.
+
+### `GET /launch/stop?name=<name>`
+
+Terminate a running launch.
+
 ### `GET /launch/clear[?name=<config-name>]`
 
 Removes terminated launches and their console output. Without `name`, removes all terminated. With `name`, removes only that one.

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -278,6 +278,10 @@ public class HttpServer {
                         launch.handleClear(params));
                 case "/launch/console" -> Response.json(
                         launch.handleConsole(params));
+                case "/launch/run" -> Response.json(
+                        launch.handleRun(params));
+                case "/launch/stop" -> Response.json(
+                        launch.handleStop(params));
                 default -> Response.json(Json.error(
                         "Unknown path: " + path));
             };

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -66,28 +66,31 @@ class LaunchHandler {
 
     String handleConfigs(Map<String, String> params) {
         try {
-            // Try to get MRU-ordered history from UI layer
+            var allConfigs =
+                    launchManager().getLaunchConfigurations();
             ILaunchConfiguration[] recent = getRecentConfigs();
-            if (recent != null && recent.length > 0) {
-                Json arr = Json.array();
+
+            // Recent first, then remaining alphabetically
+            Json arr = Json.array();
+            var seen = new java.util.HashSet<String>();
+
+            if (recent != null) {
                 for (var config : recent) {
                     arr.add(Json.object()
                             .put("name", config.getName())
                             .put("type",
                                     config.getType().getName()));
+                    seen.add(config.getName());
                 }
-                return arr.toString();
             }
 
-            // Fallback: all configs alphabetically
-            var configs =
-                    launchManager().getLaunchConfigurations();
-            Json arr = Json.array();
-            for (var config : configs) {
+            for (var config : allConfigs) {
+                if (seen.contains(config.getName())) continue;
                 arr.add(Json.object()
                         .put("name", config.getName())
                         .put("type", config.getType().getName()));
             }
+
             return arr.toString();
         } catch (Exception e) {
             return Json.error(e.getMessage());
@@ -99,12 +102,44 @@ class LaunchHandler {
         try {
             var mgr = org.eclipse.debug.internal.ui.DebugUIPlugin
                     .getDefault().getLaunchConfigurationManager();
-            // "org.eclipse.debug.ui.launchGroup.run" is the
-            // standard Run group
-            var history = mgr.getLaunchHistory(
+            var runHistory = mgr.getLaunchHistory(
                     "org.eclipse.debug.ui.launchGroup.run");
-            if (history != null) {
-                return history.getHistory();
+            var debugHistory = mgr.getLaunchHistory(
+                    "org.eclipse.debug.ui.launchGroup.debug");
+
+            // Merge: favorites first, then recent from both groups
+            var result = new java.util.ArrayList<
+                    ILaunchConfiguration>();
+            var seen = new java.util.HashSet<String>();
+
+            // Favorites from run group
+            if (runHistory != null) {
+                for (var c : runHistory.getFavorites()) {
+                    if (seen.add(c.getName())) result.add(c);
+                }
+            }
+            // Favorites from debug group
+            if (debugHistory != null) {
+                for (var c : debugHistory.getFavorites()) {
+                    if (seen.add(c.getName())) result.add(c);
+                }
+            }
+            // Recent history (run)
+            if (runHistory != null) {
+                for (var c : runHistory.getHistory()) {
+                    if (seen.add(c.getName())) result.add(c);
+                }
+            }
+            // Recent history (debug)
+            if (debugHistory != null) {
+                for (var c : debugHistory.getHistory()) {
+                    if (seen.add(c.getName())) result.add(c);
+                }
+            }
+
+            if (!result.isEmpty()) {
+                return result.toArray(
+                        new ILaunchConfiguration[0]);
             }
         } catch (Throwable e) {
             // UI plugin not available — fall through
@@ -128,6 +163,67 @@ class LaunchHandler {
         return Json.object()
                 .put("removed", removed)
                 .toString();
+    }
+
+    String handleRun(Map<String, String> params) {
+        String name = params.get("name");
+        if (name == null || name.isBlank()) {
+            return Json.error("Missing 'name' parameter");
+        }
+        String mode = params.containsKey("debug")
+                ? ILaunchManager.DEBUG_MODE
+                : ILaunchManager.RUN_MODE;
+        try {
+            ILaunchConfiguration config = findConfig(name);
+            if (config == null) {
+                return Json.error(
+                        "Launch configuration not found: " + name);
+            }
+            ILaunch launch = config.launch(mode, null, true);
+            return Json.object()
+                    .put("ok", true)
+                    .put("name", launchName(launch))
+                    .put("mode", mode)
+                    .toString();
+        } catch (Exception e) {
+            return Json.error(e.getMessage());
+        }
+    }
+
+    String handleStop(Map<String, String> params) {
+        String name = params.get("name");
+        if (name == null || name.isBlank()) {
+            return Json.error("Missing 'name' parameter");
+        }
+        ILaunch target = findLaunch(name);
+        if (target == null) {
+            return Json.error("Launch not found: " + name);
+        }
+        if (target.isTerminated()) {
+            return Json.error("Already terminated: " + name);
+        }
+        try {
+            target.terminate();
+            return Json.object()
+                    .put("ok", true)
+                    .put("name", name)
+                    .toString();
+        } catch (Exception e) {
+            return Json.error(
+                    "Failed to terminate: " + e.getMessage());
+        }
+    }
+
+    private ILaunchConfiguration findConfig(String name) {
+        try {
+            for (var config
+                    : launchManager().getLaunchConfigurations()) {
+                if (name.equals(config.getName())) {
+                    return config;
+                }
+            }
+        } catch (Exception e) { /* ignored */ }
+        return null;
     }
 
     String handleConsole(Map<String, String> params) {


### PR DESCRIPTION
## Summary

- `jdt launch run <config> [--debug]` — launch a saved configuration (fire-and-forget)
- `jdt launch stop <name>` — terminate a running launch
- Fix `launch configs` to show all 94 configs: favorites first, recent second, remaining alphabetically
- Merge favorites from both run and debug launch groups

## Test plan

- [x] 297 Tycho tests pass (5 new: run/stop error cases + terminated stop)
- [x] 280 CLI tests pass (5 new: run, run --debug, run missing, stop, stop missing)
- [x] Live verified: `jdt launch run ObjectMapperTest` → running → terminated (0)