### PR TITLE
Fix real-time console output for Maven builds

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -22,7 +24,18 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
         matches = "true")
 public class LaunchHandlerTest {
 
-    private final LaunchHandler handler = new LaunchHandler();
+    private final LaunchTracker tracker = new LaunchTracker();
+    private final LaunchHandler handler = new LaunchHandler(tracker);
+
+    @BeforeEach
+    void startTracker() {
+        tracker.start();
+    }
+
+    @AfterEach
+    void stopTracker() {
+        tracker.stop();
+    }
 
     @Nested
     class List {
@@ -276,11 +289,11 @@ public class LaunchHandlerTest {
                 assertTrue(listJson.contains("\"terminated\""),
                         "Should have terminated: " + listJson);
 
-                // Console should have output
-                // Launch has no config name, so label is
-                // process label
+                // Console should return valid JSON
                 String consoleJson = handler.handleConsole(
                         Map.of("name", "java -version"));
+                assertFalse(consoleJson.contains("error"),
+                        "Should not error: " + consoleJson);
                 assertTrue(
                         consoleJson.contains("\"output\""),
                         "Should have output: " + consoleJson);
@@ -331,8 +344,8 @@ public class LaunchHandlerTest {
     class ConsoleWithEmptyStreams {
 
         @Test
-        void emptyStreamsDoNotCrash() throws Exception {
-            // Launch with no process — "No process for launch"
+        void launchWithNoProcessReturnsEmptyOutput()
+                throws Exception {
             ILaunchManager mgr =
                     DebugPlugin.getDefault().getLaunchManager();
             ILaunch launch = new org.eclipse.debug.core.Launch(
@@ -341,8 +354,10 @@ public class LaunchHandlerTest {
             try {
                 String json = handler.handleConsole(
                         Map.of("name", "(unknown)"));
-                assertTrue(json.contains("No process"),
-                        "Should say no process: " + json);
+                assertFalse(json.contains("error"),
+                        "Should not error: " + json);
+                assertTrue(json.contains("\"output\":\"\""),
+                        "Should have empty output: " + json);
             } finally {
                 mgr.removeLaunch(launch);
             }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchTrackerTest.java
@@ -1,0 +1,183 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Tests for LaunchTracker — stream output buffering via
+ * IStreamMonitor listeners.
+ */
+@EnabledIfSystemProperty(
+        named = "jdtbridge.integration-tests",
+        matches = "true")
+public class LaunchTrackerTest {
+
+    @Nested
+    class TrackedLaunchOutput {
+
+        @Test
+        void stdoutOnlyReturnsStdout() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("hello stdout");
+            tl.appendErr("hello stderr");
+            assertEquals("hello stdout",
+                    tl.getOutput("stdout"));
+        }
+
+        @Test
+        void stderrOnlyReturnsStderr() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("out");
+            tl.appendErr("err");
+            assertEquals("err", tl.getOutput("stderr"));
+        }
+
+        @Test
+        void nullStreamReturnsBoth() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("OUT");
+            tl.appendErr("ERR");
+            assertEquals("OUTERR", tl.getOutput(null));
+        }
+
+        @Test
+        void emptyBuffersReturnEmpty() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            assertEquals("", tl.getOutput(null));
+            assertEquals("", tl.getOutput("stdout"));
+            assertEquals("", tl.getOutput("stderr"));
+        }
+
+        @Test
+        void terminatedFlagFromLaunch() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            assertFalse(tl.terminated);
+        }
+    }
+
+    @Nested
+    class Lifecycle {
+
+        private LaunchTracker tracker;
+
+        @BeforeEach
+        void setUp() {
+            tracker = new LaunchTracker();
+            tracker.start();
+        }
+
+        @AfterEach
+        void tearDown() {
+            tracker.stop();
+        }
+
+        @Test
+        void launchesAddedTracksNewLaunch() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            Process proc = new ProcessBuilder(
+                    "java", "-version").start();
+            proc.waitFor(5,
+                    java.util.concurrent.TimeUnit.SECONDS);
+            DebugPlugin.newProcess(launch, proc,
+                    "tracker-add-test");
+            mgr.addLaunch(launch);
+            try {
+                var tl = tracker.get("tracker-add-test");
+                assertNotNull(tl,
+                        "Tracker should have the launch");
+                assertTrue(tl.terminated,
+                        "Process should be terminated");
+            } finally {
+                mgr.removeLaunch(launch);
+            }
+        }
+
+        @Test
+        void trackerAttachesStreamListeners() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            Process proc = new ProcessBuilder(
+                    "java", "-version").start();
+            proc.waitFor(5,
+                    java.util.concurrent.TimeUnit.SECONDS);
+            DebugPlugin.newProcess(launch, proc,
+                    "tracker-attach-test");
+            mgr.addLaunch(launch);
+            try {
+                var tl = tracker.get("tracker-attach-test");
+                assertNotNull(tl);
+                // Stream monitors should be attached
+                assertEquals(2, tl.attached.size(),
+                        "Should attach stdout+stderr monitors");
+            } finally {
+                mgr.removeLaunch(launch);
+            }
+        }
+
+        @Test
+        void launchesRemovedKeepsEntry() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            Process proc = new ProcessBuilder(
+                    "java", "-version").start();
+            proc.waitFor(5,
+                    java.util.concurrent.TimeUnit.SECONDS);
+            DebugPlugin.newProcess(launch, proc,
+                    "tracker-remove-test");
+            mgr.addLaunch(launch);
+
+            assertNotNull(tracker.get("tracker-remove-test"));
+
+            // Remove from manager — tracker should keep entry
+            mgr.removeLaunch(launch);
+
+            assertNotNull(tracker.get("tracker-remove-test"),
+                    "Should survive removal from manager");
+        }
+
+        @Test
+        void removeByName() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            mgr.addLaunch(launch);
+            try {
+                assertNotNull(tracker.get("(unknown)"));
+                tracker.remove("(unknown)");
+                assertNull(tracker.get("(unknown)"));
+            } finally {
+                mgr.removeLaunch(launch);
+            }
+        }
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/Activator.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/Activator.java
@@ -1,5 +1,6 @@
 package io.github.kaluchi.jdtbridge;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -25,6 +26,15 @@ public class Activator implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
+        // Skip server in test environments (Tycho surefire)
+        String workspace = ResourcesPlugin.getWorkspace().getRoot()
+                .getLocation().toOSString();
+        if (workspace.contains("target" + File.separator
+                + "work")) {
+            Log.info("Test environment detected — skipping server");
+            return;
+        }
+
         String token = generateToken();
 
         server = new HttpServer();

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -29,7 +29,9 @@ public class HttpServer {
     private final RefactoringHandler refactoring =
             new RefactoringHandler();
     private final EditorHandler editor = new EditorHandler();
-    private final LaunchHandler launch = new LaunchHandler();
+    private final LaunchTracker launchTracker = new LaunchTracker();
+    private final LaunchHandler launch =
+            new LaunchHandler(launchTracker);
     private final TestHandler testHandler = new TestHandler();
     private final ProjectHandler projectInfo = new ProjectHandler();
     private final ConfigService configService =
@@ -63,6 +65,7 @@ public class HttpServer {
     }
 
     public void start() throws IOException {
+        launchTracker.start();
         serverSocket = new ServerSocket(
                 0, 50, InetAddress.getLoopbackAddress());
         running = true;
@@ -81,6 +84,7 @@ public class HttpServer {
     }
 
     public void stop() {
+        launchTracker.stop();
         running = false;
         try {
             if (serverSocket != null) serverSocket.close();
@@ -282,6 +286,8 @@ public class HttpServer {
                         launch.handleRun(params));
                 case "/launch/stop" -> Response.json(
                         launch.handleStop(params));
+                case "/launch/diag" -> Response.json(
+                        launchTracker.handleDiag());
                 default -> Response.json(Json.error(
                         "Unknown path: " + path));
             };

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -7,13 +7,17 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IProcess;
-import org.eclipse.debug.core.model.IStreamMonitor;
-import org.eclipse.debug.core.model.IStreamsProxy;
 
 /**
  * Handlers for launch management: list launches, read console output.
  */
 class LaunchHandler {
+
+    private final LaunchTracker tracker;
+
+    LaunchHandler(LaunchTracker tracker) {
+        this.tracker = tracker;
+    }
 
     private ILaunchManager launchManager() {
         return DebugPlugin.getDefault().getLaunchManager();
@@ -22,46 +26,62 @@ class LaunchHandler {
     String handleList(Map<String, String> params) {
         ILaunch[] launches = launchManager().getLaunches();
         Json arr = Json.array();
+        var seen = new java.util.HashSet<String>();
+
+        // Launches from the manager (newest first)
         for (int i = launches.length - 1; i >= 0; i--) {
             ILaunch launch = launches[i];
             String name = launchName(launch);
-            String type = launchType(launch);
-            String mode = launch.getLaunchMode();
-            boolean terminated = launch.isTerminated();
-
-            Json entry = Json.object()
-                    .put("name", name)
-                    .put("type", type)
-                    .put("mode", mode)
-                    .put("terminated", terminated);
-
-            String startedAt = launch.getAttribute(
-                    DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
-            if (startedAt != null) {
-                try {
-                    entry.put("started",
-                            Long.parseLong(startedAt));
-                } catch (NumberFormatException e) { /* skip */ }
-            }
-
-            IProcess[] processes = launch.getProcesses();
-            if (processes.length > 0) {
-                IProcess proc = processes[0];
-                if (terminated) {
-                    try {
-                        entry.put("exitCode", proc.getExitValue());
-                    } catch (Exception e) { /* ignored */ }
-                }
-                String pid = proc.getAttribute(
-                        IProcess.ATTR_PROCESS_ID);
-                if (pid != null) {
-                    entry.put("pid", pid);
-                }
-            }
-
-            arr.add(entry);
+            seen.add(name);
+            arr.add(launchEntry(launch, name));
         }
+
+        // Tracked launches not in the manager (disappeared)
+        for (var entry : tracker.all().entrySet()) {
+            if (seen.contains(entry.getKey())) continue;
+            LaunchTracker.TrackedLaunch tl = entry.getValue();
+            arr.add(launchEntry(tl.launch, entry.getKey()));
+        }
+
         return arr.toString();
+    }
+
+    private Json launchEntry(ILaunch launch, String name) {
+        String type = launchType(launch);
+        String mode = launch.getLaunchMode();
+        boolean terminated = launch.isTerminated();
+
+        Json entry = Json.object()
+                .put("name", name)
+                .put("type", type)
+                .put("mode", mode)
+                .put("terminated", terminated);
+
+        String startedAt = launch.getAttribute(
+                DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
+        if (startedAt != null) {
+            try {
+                entry.put("started",
+                        Long.parseLong(startedAt));
+            } catch (NumberFormatException e) { /* skip */ }
+        }
+
+        IProcess[] processes = launch.getProcesses();
+        if (processes.length > 0) {
+            IProcess proc = processes[0];
+            if (terminated) {
+                try {
+                    entry.put("exitCode", proc.getExitValue());
+                } catch (Exception e) { /* ignored */ }
+            }
+            String pid = proc.getAttribute(
+                    IProcess.ATTR_PROCESS_ID);
+            if (pid != null) {
+                entry.put("pid", pid);
+            }
+        }
+
+        return entry;
     }
 
     String handleConfigs(Map<String, String> params) {
@@ -151,15 +171,35 @@ class LaunchHandler {
         String name = params.get("name");
         ILaunch[] launches = launchManager().getLaunches();
         int removed = 0;
+        var cleared = new java.util.HashSet<String>();
+
+        // Remove terminated launches from the manager
         for (ILaunch launch : launches) {
             if (!launch.isTerminated()) continue;
+            String lName = launchName(launch);
             if (name != null && !name.isBlank()
-                    && !name.equals(launchName(launch))) {
+                    && !name.equals(lName)) {
                 continue;
             }
             launchManager().removeLaunch(launch);
+            tracker.remove(lName);
+            cleared.add(lName);
             removed++;
         }
+
+        // Remove tracked entries not in the manager
+        for (var entry : tracker.all().entrySet()) {
+            if (cleared.contains(entry.getKey())) continue;
+            if (name != null && !name.isBlank()
+                    && !name.equals(entry.getKey())) {
+                continue;
+            }
+            if (entry.getValue().terminated) {
+                tracker.remove(entry.getKey());
+                removed++;
+            }
+        }
+
         return Json.object()
                 .put("removed", removed)
                 .toString();
@@ -226,6 +266,12 @@ class LaunchHandler {
         return null;
     }
 
+    /**
+     * Read console output for a launch. The tracker (IStreamMonitor
+     * listeners) is the primary source — it survives ILaunch removal
+     * from the manager and works even when IStreamsProxy.getContents()
+     * is empty (ProcessConsole calls setBuffered(false)).
+     */
     String handleConsole(Map<String, String> params) {
         String name = params.get("name");
         if (name == null || name.isBlank()) {
@@ -235,42 +281,23 @@ class LaunchHandler {
         String tailStr = params.get("tail");
         String stream = params.get("stream");
 
-        ILaunch target = findLaunch(name);
-        if (target == null) {
-            return Json.error("Launch not found: " + name);
-        }
-
-        IProcess[] processes = target.getProcesses();
-        if (processes.length == 0) {
-            return Json.error("No process for launch: " + name);
-        }
-
-        StringBuilder output = new StringBuilder();
-        for (IProcess proc : processes) {
-            IStreamsProxy proxy = proc.getStreamsProxy();
-            if (proxy != null) {
-                if (!"stderr".equals(stream)) {
-                    appendStream(
-                            proxy.getOutputStreamMonitor(),
-                            output);
-                }
-                if (!"stdout".equals(stream)) {
-                    appendStream(
-                            proxy.getErrorStreamMonitor(),
-                            output);
-                }
+        // Primary: tracker (survives ILaunch removal from manager)
+        LaunchTracker.TrackedLaunch tl = tracker.get(name);
+        if (tl == null) {
+            // Launch exists in manager but tracker missed it?
+            ILaunch target = findLaunch(name);
+            if (target == null) {
+                return Json.error("Launch not found: " + name);
             }
+            return Json.object()
+                    .put("name", name)
+                    .put("terminated", target.isTerminated())
+                    .put("output", "")
+                    .toString();
         }
 
-        // Fallback: read from UI console if streams were empty
-        if (output.isEmpty()) {
-            String consoleText = readProcessConsole(processes[0]);
-            if (consoleText != null) {
-                output.append(consoleText);
-            }
-        }
-
-        String result = output.toString();
+        String output = tl.getOutput(stream);
+        String result = output;
         if (tailStr != null) {
             try {
                 int tailLines = Integer.parseInt(tailStr);
@@ -279,8 +306,8 @@ class LaunchHandler {
         }
 
         return Json.object()
-                .put("name", launchName(target))
-                .put("terminated", target.isTerminated())
+                .put("name", name)
+                .put("terminated", tl.terminated)
                 .put("output", result)
                 .toString();
     }
@@ -296,38 +323,6 @@ class LaunchHandler {
         return null;
     }
 
-    @SuppressWarnings("restriction")
-    private String readProcessConsole(IProcess process) {
-        try {
-            var consoles = org.eclipse.ui.console.ConsolePlugin
-                    .getDefault().getConsoleManager().getConsoles();
-            for (var console : consoles) {
-                if (console instanceof
-                        org.eclipse.debug.internal.ui.views
-                                .console.ProcessConsole pc) {
-                    if (pc.getProcess() == process) {
-                        var doc = pc.getDocument();
-                        if (doc != null) {
-                            return doc.get();
-                        }
-                    }
-                }
-            }
-        } catch (Throwable e) {
-            // UI console not available
-        }
-        return null;
-    }
-
-    private void appendStream(IStreamMonitor monitor,
-            StringBuilder sb) {
-        if (monitor == null) return;
-        String contents = monitor.getContents();
-        if (contents != null && !contents.isEmpty()) {
-            sb.append(contents);
-        }
-    }
-
     private String tail(String text, int lines) {
         if (lines <= 0) return text;
         int pos = text.length();
@@ -337,7 +332,7 @@ class LaunchHandler {
         return pos <= 0 ? text : text.substring(pos + 1);
     }
 
-    private static String launchName(ILaunch launch) {
+    static String launchName(ILaunch launch) {
         ILaunchConfiguration config =
                 launch.getLaunchConfiguration();
         if (config != null) return config.getName();

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchTracker.java
@@ -1,0 +1,194 @@
+package io.github.kaluchi.jdtbridge;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.ILaunchesListener2;
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.debug.core.model.IStreamMonitor;
+import org.eclipse.debug.core.model.IStreamsProxy;
+
+/**
+ * Tracks launches and accumulates stream output via
+ * {@link IStreamMonitor} listeners. Survives ILaunch removal
+ * from the launch manager (which happens during Maven builds).
+ */
+class LaunchTracker implements ILaunchesListener2 {
+
+    static class TrackedLaunch {
+        final ILaunch launch;
+        private final Object lock = new Object();
+        final StringBuilder stdout = new StringBuilder();
+        final StringBuilder stderr = new StringBuilder();
+        volatile boolean terminated;
+        final Set<IStreamMonitor> attached =
+                ConcurrentHashMap.newKeySet();
+
+        TrackedLaunch(ILaunch launch) {
+            this.launch = launch;
+            this.terminated = launch.isTerminated();
+        }
+
+        void appendOut(String text) {
+            synchronized (lock) { stdout.append(text); }
+        }
+
+        void appendErr(String text) {
+            synchronized (lock) { stderr.append(text); }
+        }
+
+        String getOutput(String stream) {
+            synchronized (lock) {
+                if ("stderr".equals(stream)) {
+                    return stderr.toString();
+                }
+                if ("stdout".equals(stream)) {
+                    return stdout.toString();
+                }
+                if (stdout.isEmpty() && stderr.isEmpty()) {
+                    return "";
+                }
+                return stdout.toString() + stderr.toString();
+            }
+        }
+
+        int outLen() { synchronized (lock) { return stdout.length(); } }
+        int errLen() { synchronized (lock) { return stderr.length(); } }
+    }
+
+    private final ConcurrentHashMap<String, TrackedLaunch> tracked =
+            new ConcurrentHashMap<>();
+
+    void start() {
+        ILaunchManager mgr = launchManager();
+        if (mgr == null) return;
+        mgr.addLaunchListener(this);
+        // Retroactively track existing launches
+        for (ILaunch launch : mgr.getLaunches()) {
+            track(launch);
+        }
+    }
+
+    void stop() {
+        ILaunchManager mgr = launchManager();
+        if (mgr != null) {
+            mgr.removeLaunchListener(this);
+        }
+        tracked.clear();
+    }
+
+    TrackedLaunch get(String name) {
+        return tracked.get(name);
+    }
+
+    void remove(String name) {
+        tracked.remove(name);
+    }
+
+    ConcurrentHashMap<String, TrackedLaunch> all() {
+        return tracked;
+    }
+
+    String handleDiag() {
+        Json result = Json.object()
+                .put("trackedCount", tracked.size());
+        Json entries = Json.array();
+        for (var e : tracked.entrySet()) {
+            TrackedLaunch tl = e.getValue();
+            entries.add(Json.object()
+                    .put("name", e.getKey())
+                    .put("terminated", tl.terminated)
+                    .put("outLen", tl.outLen())
+                    .put("errLen", tl.errLen())
+                    .put("attached", tl.attached.size()));
+        }
+        result.put("tracked", entries);
+        return result.toString();
+    }
+
+    // -- ILaunchesListener2 --
+
+    @Override
+    public void launchesAdded(ILaunch[] launches) {
+        for (ILaunch launch : launches) {
+            track(launch);
+        }
+    }
+
+    @Override
+    public void launchesChanged(ILaunch[] launches) {
+        for (ILaunch launch : launches) {
+            track(launch);
+        }
+    }
+
+    @Override
+    public void launchesTerminated(ILaunch[] launches) {
+        for (ILaunch launch : launches) {
+            String name = LaunchHandler.launchName(launch);
+            TrackedLaunch tl = tracked.get(name);
+            if (tl != null && tl.launch == launch) {
+                tl.terminated = true;
+            }
+        }
+    }
+
+    @Override
+    public void launchesRemoved(ILaunch[] launches) {
+        // Intentionally keep tracked data — the whole point is
+        // to survive removal from the launch manager.
+    }
+
+    // -- internals --
+
+    private void track(ILaunch launch) {
+        String name = LaunchHandler.launchName(launch);
+        TrackedLaunch tl = tracked.compute(name, (k, existing) -> {
+            if (existing != null && existing.launch == launch) {
+                return existing;
+            }
+            // New launch or different launch with same name
+            return new TrackedLaunch(launch);
+        });
+        attachStreams(launch, tl);
+    }
+
+    private void attachStreams(ILaunch launch, TrackedLaunch tl) {
+        for (IProcess proc : launch.getProcesses()) {
+            IStreamsProxy proxy = proc.getStreamsProxy();
+            if (proxy == null) continue;
+
+            IStreamMonitor outMon = proxy.getOutputStreamMonitor();
+            if (outMon != null && tl.attached.add(outMon)) {
+                // Listener first — so no content is lost between
+                // getContents() and addListener().  Duplicate
+                // delivery (listener re-delivers buffered content)
+                // is harmless; a gap is not.
+                outMon.addListener(
+                        (text, monitor) -> tl.appendOut(text));
+                String existing = outMon.getContents();
+                if (existing != null && !existing.isEmpty()) {
+                    tl.appendOut(existing);
+                }
+            }
+
+            IStreamMonitor errMon = proxy.getErrorStreamMonitor();
+            if (errMon != null && tl.attached.add(errMon)) {
+                errMon.addListener(
+                        (text, monitor) -> tl.appendErr(text));
+                String existing = errMon.getContents();
+                if (existing != null && !existing.isEmpty()) {
+                    tl.appendErr(existing);
+                }
+            }
+        }
+    }
+
+    private static ILaunchManager launchManager() {
+        var debug = DebugPlugin.getDefault();
+        return debug != null ? debug.getLaunchManager() : null;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LaunchTracker` — buffers stream output via `IStreamMonitor.addListener()`, survives `ILaunch` removal from the manager during Maven builds
- Simplify `handleConsole` — tracker is the single source of truth, removed dead `readProcessConsole`/`appendStream`/`IStreamsProxy.getContents()` fallbacks
- Skip HTTP server in Tycho test environments to prevent CLI from connecting to the wrong Eclipse instance
- `handleList` merges tracked launches not in the manager; `handleClear` cleans both

## Test plan
- [x] 309 tests pass (`mvn clean verify`)
- [x] New `LaunchTrackerTest` — `TrackedLaunch.getOutput()` filtering, lifecycle (add/attach/remove/clear)
- [x] Updated `LaunchHandlerTest` — tracker lifecycle in `@BeforeEach`/`@AfterEach`
- [x] Live tested: `jdt launch run jdtbridge-verify` + `jdt launch console --stdout --tail 3` shows real-time Maven output during entire build