### PR TITLE
Add --follow streaming to launch console and run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,17 +78,18 @@ See [README.md](README.md) for full overview. Key directories:
 
 ## Development workflow
 
-### `jdt build` vs `mvn verify`
+### `jdt build` vs full verify
 
-| | `jdt build` | `mvn clean verify` |
+| | `jdt build` | `jdt launch run jdtbridge-verify -f` |
 |---|---|---|
-| What | Eclipse incremental compiler | Tycho full build |
+| What | Eclipse incremental compiler | Tycho full build (via Eclipse) |
 | Speed | 1-3 seconds | 40-60 seconds |
 | Tests | No | Unit + integration |
 | Output | Compiled classes in Eclipse | p2 site in `site/target/` |
 | When | Quick iteration while coding | Before commit, before `jdt setup` |
 
-For CI without local Eclipse: `mvn clean verify -Pci` (uses p2 target platform).
+The `-f` (follow) flag streams output in real-time and exits with the
+process exit code. For CI without local Eclipse: `mvn clean verify -Pci`.
 
 ### Making changes
 
@@ -100,7 +101,7 @@ For CI without local Eclipse: `mvn clean verify -Pci` (uses p2 target platform).
    jdt build --project io.github.kaluchi.jdtbridge.tests
    jdt test --project io.github.kaluchi.jdtbridge.tests
    ```
-4. **Full Tycho build** — `mvn clean verify`
+4. **Full Tycho build** — `jdt launch run jdtbridge-verify -f`
 5. **Install and verify live** — `jdt setup --skip-build`, then test
 6. **Check ALL docs** if CLI syntax or API changed:
    - `cli/src/cli.mjs` (`jdt help` output)
@@ -117,13 +118,14 @@ For CI without local Eclipse: `mvn clean verify -Pci` (uses p2 target platform).
 - **`jdt setup --skip-build` restarts Eclipse.** Port changes. `jdt` commands
   auto-discover the new port, but raw `curl` URLs break.
 - **`jdt setup` without `--skip-build` runs Maven internally.**
-  After `mvn clean verify`, always add `--skip-build` — never build twice.
+  After `jdt launch run jdtbridge-verify -f`, always add `--skip-build`
+  — never build twice.
 
 ### Test infrastructure
 
 - **CLI tests:** `cd cli && npm test` (vitest)
 - **Plugin unit tests:** `jdt test --project io.github.kaluchi.jdtbridge.tests`
-- **Integration tests:** `mvn clean verify` only — use `@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")`
+- **Integration tests:** `jdt launch run jdtbridge-verify -f` (full Tycho build) — use `@EnabledIfSystemProperty(named = "jdtbridge.integration-tests", matches = "true")`
 - **Test fixture:** `TestFixture.java` creates a project with known classes —
   `test.model.Animal`, `Dog`, `Cat`, `test.edge.Calculator` (overloads),
   `Repository` (generics). Add new test types there.

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Most commands have short aliases for quick typing.
 | `editors` | `ed` | List all open editors (absolute paths) |
 | `launch list` | | List launches (running + terminated) |
 | `launch configs` | | List saved launch configurations (MRU order) |
-| `launch run <config>` | | Launch a configuration |
+| `launch run <config> [-f]` | | Launch a configuration (`-f` to follow) |
 | `launch stop <name>` | | Stop a running launch |
-| `launch console <name>` | | Show console output of a launch |
+| `launch console <name> [-f]` | | Show console output (`-f` to stream) |
 | `launch clear [name]` | | Remove terminated launches |
 | `setup [--check\|--remove]` | | Install, check, or remove Eclipse plugin |
 

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -64,7 +64,7 @@ const launchHelp = `Manage launches (running and terminated processes).
 Subcommands:
   jdt launch list                           list all launches
   jdt launch configs                        list saved launch configurations
-  jdt launch run <config> [--debug]         launch a configuration
+  jdt launch run <config> [--debug] [-f]    launch a configuration
   jdt launch stop <name>                    stop a running launch
   jdt launch console <name> [--tail N]      show console output
   jdt launch clear [name]                   remove terminated launches
@@ -174,9 +174,9 @@ Refactoring:
 Launches:
   launch list                                 list launches (running + terminated)
   launch configs                              list saved launch configurations
-  launch run <config> [--debug]               launch a configuration
+  launch run <config> [--debug] [-f]           launch a configuration
   launch stop <name>                          stop a running launch
-  launch console <name> [--tail N]            show console output of a launch
+  launch console <name> [-f] [--tail N]        show console output of a launch
   launch clear [name]                         remove terminated launches
 
 Editor:

--- a/cli/src/client.mjs
+++ b/cli/src/client.mjs
@@ -159,6 +159,44 @@ export function getRaw(path, timeoutMs = 10_000) {
 }
 
 /**
+ * HTTP GET with streaming response. Pipes text/plain chunks to
+ * the provided writable stream (typically process.stdout).
+ * Resolves when the server closes the connection.
+ * Rejects on non-200 status or connection error.
+ * @param {string} path
+ * @param {import('stream').Writable} dest
+ * @returns {Promise<void>}
+ */
+export function getStream(path, dest) {
+  const inst = connect();
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port: inst.port,
+        path,
+        method: "GET",
+        timeout: 0, // no timeout for streaming
+        headers: authHeaders(),
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => reject(new Error(data.trim())));
+          return;
+        }
+        res.pipe(dest, { end: false });
+        res.on("end", resolve);
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/**
  * Check if error is a connection refused error.
  * @param {Error} e
  * @returns {boolean}

--- a/cli/src/commands/launch.mjs
+++ b/cli/src/commands/launch.mjs
@@ -1,4 +1,4 @@
-import { get } from "../client.mjs";
+import { get, getStream } from "../client.mjs";
 import { extractPositional, parseFlags } from "../args.mjs";
 
 export async function launchList() {
@@ -52,7 +52,7 @@ export async function launchRun(args) {
   const pos = extractPositional(args);
   const name = pos[0];
   if (!name) {
-    console.error("Usage: launch run <config-name> [--debug]");
+    console.error("Usage: launch run <config-name> [--debug] [-f|--follow]");
     process.exit(1);
   }
   let url = `/launch/run?name=${encodeURIComponent(name)}`;
@@ -62,7 +62,17 @@ export async function launchRun(args) {
     console.error(result.error);
     process.exit(1);
   }
-  console.log(`Launched ${result.name} (${result.mode})`);
+
+  const follow = args.includes("-f") || args.includes("--follow");
+  if (!follow) {
+    console.log(`Launched ${result.name} (${result.mode})`);
+    return;
+  }
+
+  // Launch + follow: stream console output, exit with process code
+  console.error(`Launched ${result.name} (${result.mode})`);
+  const exitCode = await followConsole(result.name, args);
+  process.exit(exitCode);
 }
 
 export async function launchStop(args) {
@@ -86,9 +96,19 @@ export async function launchConsole(args) {
   const flags = parseFlags(args);
   const name = pos[0];
   if (!name) {
-    console.error("Usage: launch console <name> [--tail N] [--stderr|--stdout]");
+    console.error(
+      "Usage: launch console <name> [-f|--follow] [--tail N] [--stderr|--stdout]",
+    );
     process.exit(1);
   }
+
+  const follow = args.includes("-f") || args.includes("--follow");
+  if (follow) {
+    const exitCode = await followConsole(name, args);
+    process.exit(exitCode);
+  }
+
+  // Snapshot mode (existing behavior)
   let url = `/launch/console?name=${encodeURIComponent(name)}`;
   if (flags.tail !== undefined && flags.tail !== true)
     url += `&tail=${flags.tail}`;
@@ -107,16 +127,69 @@ export async function launchConsole(args) {
   }
 }
 
+/**
+ * Stream console output until process terminates or Ctrl+C.
+ * Returns the process exit code (0 on detach).
+ */
+async function followConsole(name, args) {
+  const flags = parseFlags(args);
+  let url = `/launch/console/stream?name=${encodeURIComponent(name)}`;
+  if (flags.tail !== undefined && flags.tail !== true)
+    url += `&tail=${flags.tail}`;
+  if (args.includes("--stderr")) url += "&stream=stderr";
+  else if (args.includes("--stdout")) url += "&stream=stdout";
+
+  // Ctrl+C = detach, not kill
+  let detached = false;
+  const onSigint = () => {
+    detached = true;
+    process.stdout.write("\n");
+    process.exit(0);
+  };
+  process.on("SIGINT", onSigint);
+
+  try {
+    await getStream(url, process.stdout);
+  } catch (e) {
+    if (!detached) {
+      console.error(e.message);
+      return 1;
+    }
+    return 0;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+  }
+
+  // Stream ended (process terminated) — fetch exit code
+  try {
+    const info = await get(
+      `/launch/console?name=${encodeURIComponent(name)}`,
+    );
+    if (info && info.terminated) {
+      const list = await get("/launch/list");
+      const entry = Array.isArray(list)
+        ? list.find((l) => l.name === name && l.terminated)
+        : null;
+      return entry?.exitCode ?? 0;
+    }
+  } catch {
+    // best effort
+  }
+  return 0;
+}
+
 export const launchRunHelp = `Launch a saved configuration.
 
-Usage:  jdt launch run <config-name> [--debug]
+Usage:  jdt launch run <config-name> [--debug] [-f|--follow]
 
 Flags:
-  --debug    launch in debug mode (default: run)
+  --debug        launch in debug mode (default: run)
+  -f, --follow   stream console output until process terminates
 
 Examples:
   jdt launch run m8-server
-  jdt launch run m8-server --debug`;
+  jdt launch run jdtbridge-verify --follow
+  jdt launch run m8-server --debug -f | grep ERROR`;
 
 export const launchStopHelp = `Stop a running launch.
 
@@ -144,17 +217,19 @@ Output: name, type, mode, status — one launch per line.`;
 
 export const launchConsoleHelp = `Show console output (stdout/stderr) of a launch.
 
-Returns the full unbounded output. Pipe through tail/grep/head to filter.
+Without --follow, returns the full output as a snapshot.
+With --follow, streams output in real-time until the process terminates.
 
-Usage:  jdt launch console <name> [--tail N] [--stderr] [--stdout]
+Usage:  jdt launch console <name> [-f|--follow] [--tail N] [--stderr] [--stdout]
 
 Flags:
-  --tail <N>    last N lines only (or use: jdt launch console m8-server | tail -50)
-  --stderr      stderr only
-  --stdout      stdout only
+  -f, --follow   stream output until process terminates (Ctrl+C to detach)
+  --tail <N>     last N lines only (snapshot), or start N lines back (follow)
+  --stderr       stderr only
+  --stdout       stdout only
 
 Examples:
   jdt launch console m8-server
-  jdt launch console m8-server | tail -20
-  jdt launch console m8-server | grep ERROR
-  jdt launch console ObjectMapperTest --stderr`;
+  jdt launch console m8-server --follow
+  jdt launch console m8-server -f --tail 20
+  jdt launch console m8-server -f --stdout | grep ERROR`;

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -691,6 +691,118 @@ describe("commands (integration)", () => {
     await expect(launchList()).rejects.toThrow("exit(1)");
   });
 
+  it("launch console --follow streams text/plain", async () => {
+    let requestCount = 0;
+    await setupMock((req, res) => {
+      requestCount++;
+      if (req.url.includes("/launch/console/stream")) {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.write("line1\n");
+        res.write("line2\n");
+        res.end();
+      } else {
+        // Exit code fetch after stream ends
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ name: "test", terminated: true, output: "" }));
+      }
+    });
+    // Capture stdout writes instead of console.log
+    const chunks = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = (chunk) => { chunks.push(chunk.toString()); return true; };
+    try {
+      const { launchConsole } = await import("../src/commands/launch.mjs");
+      await expect(launchConsole(["test", "--follow"])).rejects.toThrow("exit(0)");
+      const output = chunks.join("");
+      expect(output).toContain("line1");
+      expect(output).toContain("line2");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  it("launch console --follow passes stream filter", async () => {
+    await setupMock((req, res) => {
+      if (req.url.includes("/launch/console/stream")) {
+        expect(req.url).toContain("stream=stderr");
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("error output");
+      } else {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ name: "test", terminated: true, output: "" }));
+      }
+    });
+    const origWrite = process.stdout.write;
+    process.stdout.write = () => true;
+    try {
+      const { launchConsole } = await import("../src/commands/launch.mjs");
+      await expect(launchConsole(["test", "-f", "--stderr"])).rejects.toThrow("exit(0)");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  it("launch console --follow passes tail param", async () => {
+    await setupMock((req, res) => {
+      if (req.url.includes("/launch/console/stream")) {
+        expect(req.url).toContain("tail=20");
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("tail output");
+      } else {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ name: "test", terminated: true, output: "" }));
+      }
+    });
+    const origWrite = process.stdout.write;
+    process.stdout.write = () => true;
+    try {
+      const { launchConsole } = await import("../src/commands/launch.mjs");
+      await expect(launchConsole(["test", "--follow", "--tail", "20"])).rejects.toThrow("exit(0)");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  it("launch run --follow launches then streams", async () => {
+    let urls = [];
+    await setupMock((req, res) => {
+      urls.push(req.url);
+      if (req.url.includes("/launch/run")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, name: "my-build", mode: "run" }));
+      } else if (req.url.includes("/launch/console/stream")) {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("BUILD SUCCESS\n");
+      } else {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ name: "my-build", terminated: true, output: "" }));
+      }
+    });
+    const origWrite = process.stdout.write;
+    process.stdout.write = () => true;
+    try {
+      const { launchRun } = await import("../src/commands/launch.mjs");
+      await expect(launchRun(["my-build", "--follow"])).rejects.toThrow("exit(0)");
+      // Should have called run first, then stream
+      expect(urls[0]).toContain("/launch/run");
+      expect(urls[1]).toContain("/launch/console/stream");
+      // "Launched" message goes to stderr, not stdout
+      expect(io.errors[0]).toContain("Launched");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  it("launch run without --follow prints launched", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, name: "m8-server", mode: "run" }));
+    });
+    const { launchRun } = await import("../src/commands/launch.mjs");
+    await launchRun(["m8-server"]);
+    expect(io.logs[0]).toContain("Launched");
+  });
+
   it("editors exits on server error", async () => {
     await setupMock(errorServer());
     const { editors } = await import("../src/commands/editor.mjs");

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ConsoleStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ConsoleStreamerTest.java
@@ -1,0 +1,160 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.eclipse.debug.core.ILaunch;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Tests for {@link ConsoleStreamer} — streaming console output
+ * and the tail utility.
+ */
+public class ConsoleStreamerTest {
+
+    @Nested
+    class Tail {
+
+        @Test
+        void tailLastLine() {
+            assertEquals("c",
+                    ConsoleStreamer.tail("a\nb\nc", 1));
+        }
+
+        @Test
+        void tailLastTwoLines() {
+            assertEquals("b\nc",
+                    ConsoleStreamer.tail("a\nb\nc", 2));
+        }
+
+        @Test
+        void tailMoreThanAvailable() {
+            assertEquals("a\nb",
+                    ConsoleStreamer.tail("a\nb", 10));
+        }
+
+        @Test
+        void tailEmptyString() {
+            assertEquals("",
+                    ConsoleStreamer.tail("", 5));
+        }
+
+        @Test
+        void tailZeroReturnsAll() {
+            assertEquals("a\nb\nc",
+                    ConsoleStreamer.tail("a\nb\nc", 0));
+        }
+    }
+
+    @Nested
+    @EnabledIfSystemProperty(
+            named = "jdtbridge.integration-tests",
+            matches = "true")
+    class Stream {
+
+        @Test
+        void streamsAccumulatedContentForTerminated()
+                throws Exception {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("line1\nline2\n");
+            tl.terminated = true;
+
+            var out = new ByteArrayOutputStream();
+            ConsoleStreamer.stream(tl, out, null, -1);
+            assertEquals("line1\nline2\n", out.toString());
+        }
+
+        @Test
+        void streamsWithTail() throws Exception {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("a\nb\nc\nd\n");
+            tl.terminated = true;
+
+            // tail=3 because trailing \n counts as a line
+            var out = new ByteArrayOutputStream();
+            ConsoleStreamer.stream(tl, out, null, 3);
+            String result = out.toString();
+            assertTrue(result.contains("c"),
+                    "Should have line c: " + result);
+            assertTrue(result.contains("d"),
+                    "Should have line d: " + result);
+            assertFalse(result.contains("a"),
+                    "Should not have line a: " + result);
+        }
+
+        @Test
+        void filtersStdoutOnly() throws Exception {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("stdout-data");
+            tl.appendErr("stderr-data");
+            tl.terminated = true;
+
+            var out = new ByteArrayOutputStream();
+            ConsoleStreamer.stream(tl, out, "stdout", -1);
+            assertEquals("stdout-data", out.toString());
+        }
+
+        @Test
+        void filtersStderrOnly() throws Exception {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            tl.appendOut("stdout-data");
+            tl.appendErr("stderr-data");
+            tl.terminated = true;
+
+            var out = new ByteArrayOutputStream();
+            ConsoleStreamer.stream(tl, out, "stderr", -1);
+            assertEquals("stderr-data", out.toString());
+        }
+
+        @Test
+        void liveOutputDeliveredOnTermination()
+                throws Exception {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+
+            var out = new ByteArrayOutputStream();
+
+            // Stream in background, terminate after adding content
+            var streamThread = new Thread(() -> {
+                try {
+                    ConsoleStreamer.stream(tl, out, null, -1);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            streamThread.start();
+
+            // Let streamer register listener
+            Thread.sleep(100);
+
+            // Add content while streaming
+            tl.appendOut("live-data\n");
+
+            // Terminate
+            tl.terminated = true;
+
+            streamThread.join(5000);
+            assertFalse(streamThread.isAlive(),
+                    "Stream should have ended");
+
+            String result = out.toString();
+            assertTrue(result.contains("live-data"),
+                    "Should have live data: " + result);
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchTrackerTest.java
@@ -75,6 +75,51 @@ public class LaunchTrackerTest {
             var tl = new LaunchTracker.TrackedLaunch(launch);
             assertFalse(tl.terminated);
         }
+
+        @Test
+        void outputListenerReceivesAppendOut() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            var received = new java.util.ArrayList<String>();
+            tl.addOutputListener(
+                    (text, stderr) -> received.add(text));
+            tl.appendOut("hello");
+            tl.appendErr("world");
+            assertEquals(2, received.size());
+            assertEquals("hello", received.get(0));
+            assertEquals("world", received.get(1));
+        }
+
+        @Test
+        void removeOutputListenerStopsNotifications() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            var received = new java.util.ArrayList<String>();
+            LaunchTracker.OutputListener l =
+                    (text, stderr) -> received.add(text);
+            tl.addOutputListener(l);
+            tl.appendOut("before");
+            tl.removeOutputListener(l);
+            tl.appendOut("after");
+            assertEquals(1, received.size());
+            assertEquals("before", received.get(0));
+        }
+
+        @Test
+        void outputListenerDistinguishesStdoutStderr() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            var tl = new LaunchTracker.TrackedLaunch(launch);
+            var flags = new java.util.ArrayList<Boolean>();
+            tl.addOutputListener(
+                    (text, stderr) -> flags.add(stderr));
+            tl.appendOut("out");
+            tl.appendErr("err");
+            assertFalse(flags.get(0));
+            assertTrue(flags.get(1));
+        }
     }
 
     @Nested

--- a/plugin/src/io/github/kaluchi/jdtbridge/ConsoleStreamer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/ConsoleStreamer.java
@@ -1,0 +1,93 @@
+package io.github.kaluchi.jdtbridge;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Streams console output from a {@link LaunchTracker.TrackedLaunch}
+ * to an {@link OutputStream}. Writes accumulated content first,
+ * then live output via listener until the process terminates or
+ * the stream is closed.
+ */
+class ConsoleStreamer {
+
+    /**
+     * Stream console output. Blocks until terminated or IOException.
+     *
+     * @param tl      tracked launch to read from
+     * @param out     destination stream (socket, pipe, etc.)
+     * @param stream  filter: "stdout", "stderr", or null for both
+     * @param tail    number of tail lines for initial dump, -1 for all
+     */
+    static void stream(LaunchTracker.TrackedLaunch tl,
+            OutputStream out, String stream, int tail)
+            throws IOException {
+        // Write accumulated content
+        String existing = tl.getOutput(stream);
+        if (tail >= 0) {
+            existing = tail(existing, tail);
+        }
+        writeFlush(out, existing);
+
+        if (tl.terminated) return;
+
+        // Live stream via listener
+        LaunchTracker.OutputListener listener = (text, stderr) -> {
+            if (!matches(stream, stderr)) return;
+            try {
+                writeFlush(out, text);
+            } catch (IOException e) {
+                throw new StreamClosedException(e);
+            }
+        };
+
+        tl.addOutputListener(listener);
+        try {
+            awaitTermination(tl);
+            synchronized (out) { out.flush(); }
+        } finally {
+            tl.removeOutputListener(listener);
+        }
+    }
+
+    private static boolean matches(String filter, boolean stderr) {
+        if (filter == null) return true;
+        return "stderr".equals(filter) == stderr;
+    }
+
+    private static void writeFlush(OutputStream out, String text)
+            throws IOException {
+        if (text.isEmpty()) return;
+        synchronized (out) {
+            out.write(text.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
+    }
+
+    private static void awaitTermination(
+            LaunchTracker.TrackedLaunch tl) throws IOException {
+        while (!tl.terminated) {
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    static String tail(String text, int lines) {
+        if (lines <= 0 || text.isEmpty()) return text;
+        int pos = text.length();
+        for (int i = 0; i < lines && pos > 0; i++) {
+            pos = text.lastIndexOf('\n', pos - 1);
+        }
+        return pos <= 0 ? text : text.substring(pos + 1);
+    }
+
+    /** Thrown by listener when output stream is closed. */
+    static class StreamClosedException extends RuntimeException {
+        StreamClosedException(IOException cause) { super(cause); }
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -186,11 +186,78 @@ public class HttpServer {
                 }
             }
 
+            // Streaming endpoint — bypasses dispatch, owns socket
+            if ("/launch/console/stream".equals(path)) {
+                handleConsoleStream(socket, params);
+                return;
+            }
+
             Response resp = dispatch(path, params);
             sendResponse(socket, resp);
         } catch (Exception e) {
             Log.error("Request error", e);
         }
+    }
+
+    /**
+     * Streaming console — bypasses dispatch, writes directly to
+     * socket. HTTP protocol only; business logic in ConsoleStreamer.
+     */
+    private void handleConsoleStream(Socket socket,
+            Map<String, String> params) {
+        String name = params.get("name");
+        if (name == null || name.isBlank()) {
+            try { sendError(socket, 400, "Missing name"); }
+            catch (IOException e) { /* ignore */ }
+            return;
+        }
+
+        LaunchTracker.TrackedLaunch tl = awaitLaunch(name);
+        if (tl == null) {
+            try {
+                sendError(socket, 404,
+                        "Launch not found: " + name);
+            } catch (IOException e) { /* ignore */ }
+            return;
+        }
+
+        String stream = params.get("stream");
+        int tail = -1;
+        String tailStr = params.get("tail");
+        if (tailStr != null) {
+            try { tail = Integer.parseInt(tailStr); }
+            catch (NumberFormatException e) { /* full */ }
+        }
+
+        try {
+            socket.setSoTimeout(0);
+            OutputStream out = socket.getOutputStream();
+            out.write(("HTTP/1.1 200 OK\r\n"
+                    + "Content-Type: text/plain; charset=utf-8\r\n"
+                    + "Connection: close\r\n"
+                    + "Cache-Control: no-cache\r\n\r\n")
+                    .getBytes(StandardCharsets.UTF_8));
+
+            ConsoleStreamer.stream(tl, out, stream, tail);
+        } catch (IOException
+                | ConsoleStreamer.StreamClosedException e) {
+            // Client disconnected — normal for Ctrl+C
+        }
+    }
+
+    /** Wait briefly for a launch to appear in the tracker. */
+    private LaunchTracker.TrackedLaunch awaitLaunch(String name) {
+        for (int i = 0; i < 10; i++) {
+            LaunchTracker.TrackedLaunch tl =
+                    launchTracker.get(name);
+            if (tl != null) return tl;
+            try { Thread.sleep(500); }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+        return null;
     }
 
     private void sendResponse(Socket socket, Response resp)

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -301,7 +301,7 @@ class LaunchHandler {
         if (tailStr != null) {
             try {
                 int tailLines = Integer.parseInt(tailStr);
-                result = tail(result, tailLines);
+                result = ConsoleStreamer.tail(result, tailLines);
             } catch (NumberFormatException e) { /* use full */ }
         }
 
@@ -321,15 +321,6 @@ class LaunchHandler {
             }
         }
         return null;
-    }
-
-    private String tail(String text, int lines) {
-        if (lines <= 0) return text;
-        int pos = text.length();
-        for (int i = 0; i < lines && pos > 0; i++) {
-            pos = text.lastIndexOf('\n', pos - 1);
-        }
-        return pos <= 0 ? text : text.substring(pos + 1);
     }
 
     static String launchName(ILaunch launch) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchTracker.java
@@ -1,7 +1,9 @@
 package io.github.kaluchi.jdtbridge;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -18,6 +20,12 @@ import org.eclipse.debug.core.model.IStreamsProxy;
  */
 class LaunchTracker implements ILaunchesListener2 {
 
+    interface OutputListener {
+        /** @param text chunk of output
+         *  @param stderr true if stderr, false if stdout */
+        void onOutput(String text, boolean stderr);
+    }
+
     static class TrackedLaunch {
         final ILaunch launch;
         private final Object lock = new Object();
@@ -26,18 +34,30 @@ class LaunchTracker implements ILaunchesListener2 {
         volatile boolean terminated;
         final Set<IStreamMonitor> attached =
                 ConcurrentHashMap.newKeySet();
+        private final List<OutputListener> listeners =
+                new CopyOnWriteArrayList<>();
 
         TrackedLaunch(ILaunch launch) {
             this.launch = launch;
             this.terminated = launch.isTerminated();
         }
 
+        void addOutputListener(OutputListener l) {
+            listeners.add(l);
+        }
+
+        void removeOutputListener(OutputListener l) {
+            listeners.remove(l);
+        }
+
         void appendOut(String text) {
             synchronized (lock) { stdout.append(text); }
+            for (var l : listeners) l.onOutput(text, false);
         }
 
         void appendErr(String text) {
             synchronized (lock) { stderr.append(text); }
+            for (var l : listeners) l.onOutput(text, true);
         }
 
         String getOutput(String stream) {


### PR DESCRIPTION
## Summary
- Add `/launch/console/stream` HTTP endpoint — streams text/plain output in real-time, connection closes on termination
- Add `ConsoleStreamer` utility — writes accumulated content then pipes live output via `OutputListener` on `TrackedLaunch`
- Add `-f` / `--follow` flag to `launch console` and `launch run` CLI commands
- Ctrl+C detaches without killing the Eclipse process; exit code propagated
- Update AGENTS.md: `jdt launch run jdtbridge-verify -f` replaces `mvn clean verify` workflow
- Update `jdt help`, README.md

## Test plan
- [x] 322 Tycho tests pass (`jdt launch run jdtbridge-verify -f`)
- [x] 285 CLI tests pass (`cd cli && npm test`) — 5 new tests for `--follow`
- [x] New `ConsoleStreamerTest` — tail utility (5), streaming (5: accumulated, tail, filters, live output)
- [x] New `LaunchTrackerTest` output listener tests (3: add/remove/stderr flag)
- [x] Live tested: `jdt launch run jdtbridge-verify -f --stdout` streams real-time Maven output
- [x] `jdt launch console X -f` on terminated launch dumps all output and exits immediately