### PR TITLE
List all workspace projects, not just Java

### DIFF
--- a/plugin/src/io/github/kaluchi/jdtbridge/SearchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/SearchHandler.java
@@ -36,10 +36,11 @@ class SearchHandler {
 
     String handleProjects() throws Exception {
         Json arr = Json.array();
-        for (IJavaProject p : JavaCore.create(
-                ResourcesPlugin.getWorkspace().getRoot())
-                .getJavaProjects()) {
-            arr.add(p.getElementName());
+        for (var p : ResourcesPlugin.getWorkspace().getRoot()
+                .getProjects()) {
+            if (p.isOpen() && !p.getName().startsWith(".")) {
+                arr.add(p.getName());
+            }
         }
         return arr.toString();
     }


### PR DESCRIPTION
## Summary
- `jdt projects` now shows all open workspace projects (feature, site, branding) — not just Java projects
- Filters out hidden dot-prefixed projects (`.BndtoolsJAREditorTempFiles` etc)

## Test plan
- [x] 322 Tycho tests pass
- [x] Verified live: 37 projects listed (was 31)