### PR TITLE
Update docs for pre-release cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Most commands have short aliases for quick typing.
 | `editors` | `ed` | List all open editors (absolute paths) |
 | `launch list` | | List launches (running + terminated) |
 | `launch configs` | | List saved launch configurations (MRU order) |
-| `launch run <config> [-f]` | | Launch a configuration (`-f` to stream) |
-| `launch debug <config> [-f]` | | Launch in debug mode |
+| `launch run <config> [-f] [-q]` | | Launch a configuration (`-f` to stream) |
+| `launch debug <config> [-f] [-q]` | | Launch in debug mode |
 | `launch logs <name> [-f]` | | Show console output (`-f` to stream) |
 | `launch stop <name>` | | Stop a running launch |
 | `launch clear [name]` | | Remove terminated launches |

--- a/cli/README.md
+++ b/cli/README.md
@@ -76,11 +76,16 @@ jdt move <FQN> <target.package>                        # move type to another pa
 ```bash
 jdt launch list                                        # list launches (running + terminated)
 jdt launch configs                                     # list saved launch configurations
-jdt launch run <config> [--debug]                      # launch a configuration
+jdt launch run <config> [-f] [-q]                      # launch a configuration
+jdt launch debug <config> [-f] [-q]                    # launch in debug mode
+jdt launch logs <name> [-f] [--tail N]                 # show console output
 jdt launch stop <name>                                 # stop a running launch
-jdt launch console <name> [--tail N]                   # show console output
 jdt launch clear [name]                                # remove terminated launches
 ```
+
+`-f` streams output in real-time until the process terminates.
+Without `-f`, `launch run` prints an onboarding guide with available commands (`-q` to suppress).
+Console output persists in Eclipse and is available via `launch logs` at any time.
 
 ### Editor
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -128,11 +128,23 @@ Returns all saved launch configurations (Run → Run Configurations).
 
 ### `GET /launch/console?name=<config-name>[&tail=<N>][&stream=stdout|stderr]`
 
-Returns console output (stdout + stderr) of a launch. `tail` limits to last N lines. `stream` filters to stdout or stderr only.
+Returns console output (stdout + stderr) of a launch as JSON.
+`tail` limits to last N lines. `stream` filters to stdout or stderr only.
+Returns `{name, terminated, output}`.
+
+### `GET /launch/console/stream?name=<config-name>[&tail=<N>][&stream=stdout|stderr]`
+
+Streams console output as `text/plain`. Connection stays open until the
+process terminates. Writes accumulated content first, then live output.
+Used by `jdt launch logs -f`.
 
 ### `GET /launch/run?name=<config-name>[&debug]`
 
-Launch a saved configuration. Returns immediately (fire-and-forget). Add `&debug` for debug mode.
+Launch a saved configuration. Returns immediately.
+Add `&debug` for debug mode.
+Returns `{ok, name, mode, type, pid, cmdline, workingDir}` — metadata
+fields (`pid`, `cmdline`, `workingDir`) are present when the process
+has started.
 
 ### `GET /launch/stop?name=<name>`
 
@@ -140,7 +152,8 @@ Terminate a running launch.
 
 ### `GET /launch/clear[?name=<config-name>]`
 
-Removes terminated launches and their console output. Without `name`, removes all terminated. With `name`, removes only that one.
+Removes terminated launches and their console output. Without `name`,
+removes all terminated. With `name`, removes only that one.
 
 ## Connection details
 


### PR DESCRIPTION
## Summary
Documentation sync after launch UX rework (PRs #37-41):
- `cli/README.md`: `launch debug`, `logs` (was `console`), `-f`/`-q` flags, streaming explanation
- `plugin/README.md`: `/launch/console/stream` endpoint, `handleRun` metadata fields (pid, cmdline, workingDir)
- `README.md`: `-q` flag on run/debug

## Test plan
- [x] Docs-only change, no code modified