### PR TITLE
Add jdt refresh + PostToolUse hook for Eclipse sync

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const d=JSON.parse(require('fs').readFileSync(0,'utf8'));const f=d.tool_input?.file_path;if(f){try{require('child_process').execSync('jdt refresh '+JSON.stringify(f),{timeout:5000,stdio:'ignore',shell:true})}catch{}}\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 *.iml
 *.swp
 *.swo
+branding/.tycho-consumer-pom.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ jdt type-info <FQN>              # class overview without reading 600 lines
 jdt test run <FQN>#<method> -f   # run one test, stream progress
 jdt errors --project <name>      # instant compilation check
 jdt build --project <name>       # incremental build (1-3s, not 40s Maven)
+jdt refresh <file>               # explicitly notify Eclipse of file changes
 ```
 
 ### `jdt source` — hypertext navigation
@@ -163,6 +164,30 @@ For CI without local Eclipse: `mvn clean verify -Pci`.
    - `cli/src/commands/*.mjs` (per-command help)
    - `README.md`, `cli/README.md`, `plugin/README.md`, this file
 7. **Commit → push → PR → squash merge → delete branch**
+
+### Pull requests
+
+Use `gh pr create` / `gh pr edit` / `gh pr merge`. **Always pass `--body`
+via HEREDOC** to avoid shell escaping issues. Do NOT use markdown formatting
+characters (`*`, `#`, `` ` ``) in `--body` — they break `gh` argument parsing.
+Use plain text or `- [x]` checklists only.
+
+```bash
+# Create
+gh pr create --title "Short title" --body "$(cat <<'EOF'
+Summary line.
+
+- [x] Tests pass
+- [x] Docs updated
+EOF
+)"
+
+# Edit (ignore GraphQL Projects Classic deprecation warning)
+gh pr edit 55 --body "new body text" 2>&1 | grep -v GraphQL
+
+# Merge + cleanup
+gh pr merge 55 --squash --delete-branch
+```
 
 ### Important details
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Most commands have short aliases for quick typing.
 | `build [--project <name>]` | `b` | Build project (incremental or clean) |
 | `test run <FQN> [-f]` | | Run JUnit tests with progress streaming |
 | `errors [--project <name>]` | `err` | Compilation errors and diagnostics |
+| `refresh [<file>] [--project <name>]` | `r` | Manually notify Eclipse of file changes |
 | `organize-imports <file>` | `oi` | Organize imports (Eclipse settings) |
 | `format <file>` | `fmt` | Format code (Eclipse settings) |
 | `rename <FQMN> <new>` | | Rename type, method, or field across workspace |

--- a/cli/README.md
+++ b/cli/README.md
@@ -58,9 +58,16 @@ All commands auto-refresh from disk. `build` is the only command that triggers e
 ```bash
 jdt errors [--project <name>] [--file <path>]          # (alias: err) compilation errors
 jdt errors --warnings --all                            # include warnings and all marker types
+jdt refresh <file> [<file> ...]                        # (alias: r) notify Eclipse of file changes
+jdt refresh --project <name>                           # refresh entire project
+jdt refresh                                            # refresh entire workspace
 ```
 
-File paths are workspace-relative: `my-app/src/main/java/.../Foo.java`.
+`errors` file paths are workspace-relative: `my-app/src/main/java/.../Foo.java`.
+`refresh` accepts absolute paths (converted to workspace resources automatically).
+
+A PostToolUse hook (`jdt setup --claude`) calls `jdt refresh` automatically
+after every Edit/Write — Eclipse stays in sync without manual intervention.
 
 ### Refactoring
 

--- a/cli/src/claude-setup.mjs
+++ b/cli/src/claude-setup.mjs
@@ -6,6 +6,8 @@ import { execSync } from "node:child_process";
 
 const JDT_HOOK_COMMAND = `node -e "d=JSON.parse(require('fs').readFileSync(0,'utf8'));d.tool_input?.command?.startsWith('jdt ')&&process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PreToolUse',permissionDecision:'allow'}}))"`;
 
+const JDT_REFRESH_HOOK_COMMAND = `node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8'));const f=d.tool_input?.file_path;if(f){try{require('child_process').execSync('jdt refresh '+JSON.stringify(f),{timeout:5000,stdio:'ignore',shell:true})}catch{}}"`;
+
 /**
  * Find the project root (git root or cwd).
  * @returns {string}
@@ -49,6 +51,19 @@ export function mergeJdtSettings(settings) {
     });
   }
 
+  // PostToolUse: refresh Eclipse on Edit/Write of .java files
+  if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
+  // Remove any old jdt refresh hooks (command may have changed)
+  settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(
+    (h) =>
+      !(h.matcher === "Edit|Write" &&
+        h.hooks?.some((hk) => hk.command?.includes("jdt") && hk.command?.includes("refresh"))),
+  );
+  settings.hooks.PostToolUse.push({
+    matcher: "Edit|Write",
+    hooks: [{ type: "command", command: JDT_REFRESH_HOOK_COMMAND }],
+  });
+
   return settings;
 }
 
@@ -80,4 +95,54 @@ export function installClaudeSettings(root) {
   writeFileSync(file, JSON.stringify(settings, null, 2) + "\n");
 
   return { file, settings };
+}
+
+/**
+ * Remove JDT Bridge settings from Claude Code.
+ * Removes permission rules and hooks, preserves unrelated settings.
+ * @param {string} [root] project root (default: git root or cwd)
+ * @returns {{ file: string, removed: boolean }}
+ */
+export function uninstallClaudeSettings(root) {
+  if (!root) root = findProjectRoot();
+
+  const file = join(root, ".claude", "settings.json");
+  if (!existsSync(file)) return { file, removed: false };
+
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return { file, removed: false };
+  }
+
+  // Remove jdt permission
+  if (settings.permissions?.allow) {
+    settings.permissions.allow = settings.permissions.allow
+      .filter((r) => r !== "Bash(jdt *)");
+  }
+
+  // Remove PreToolUse jdt hooks
+  if (settings.hooks?.PreToolUse) {
+    settings.hooks.PreToolUse = settings.hooks.PreToolUse
+      .filter((h) => !h.hooks?.some(
+        (hk) => hk.command?.includes("jdt ")));
+  }
+
+  // Remove PostToolUse jdt refresh hooks
+  if (settings.hooks?.PostToolUse) {
+    settings.hooks.PostToolUse = settings.hooks.PostToolUse
+      .filter((h) => !h.hooks?.some(
+        (hk) => hk.command?.includes("jdt") && hk.command?.includes("refresh")));
+  }
+
+  // Clean empty arrays
+  if (settings.hooks?.PreToolUse?.length === 0) delete settings.hooks.PreToolUse;
+  if (settings.hooks?.PostToolUse?.length === 0) delete settings.hooks.PostToolUse;
+  if (settings.hooks && Object.keys(settings.hooks).length === 0) delete settings.hooks;
+  if (settings.permissions?.allow?.length === 0) delete settings.permissions.allow;
+  if (settings.permissions && Object.keys(settings.permissions).length === 0) delete settings.permissions;
+
+  writeFileSync(file, JSON.stringify(settings, null, 2) + "\n");
+  return { file, removed: true };
 }

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -15,6 +15,7 @@ import { testRun, help as testRunHelp } from "./commands/test-run.mjs";
 import { testStatus, help as testStatusHelp } from "./commands/test-status.mjs";
 import { testSessions, help as testSessionsHelp } from "./commands/test-sessions.mjs";
 import { errors, help as errorsHelp } from "./commands/errors.mjs";
+import { refresh, help as refreshHelp } from "./commands/refresh.mjs";
 import {
   organizeImports,
   format,
@@ -138,6 +139,7 @@ const commands = {
   build: { fn: build, help: buildHelp },
   test: { fn: testDispatch, help: testHelp },
   errors: { fn: errors, help: errorsHelp },
+  refresh: { fn: refresh, help: refreshHelp },
   "organize-imports": { fn: organizeImports, help: organizeImportsHelp },
   format: { fn: format, help: formatHelp },
   rename: { fn: rename, help: renameHelp },
@@ -161,6 +163,7 @@ const aliases = {
   src: "source",
   b: "build",
   err: "errors",
+  r: "refresh",
   fmt: "format",
 };
 
@@ -204,6 +207,7 @@ Testing & building:
 
 Diagnostics:
   errors${fmtAliases("errors")} [--file <path>] [--project <name>]   compilation errors
+  refresh${fmtAliases("refresh")} [<file> ...] [--project <name>]  explicitly notify Eclipse of file changes
 
 Refactoring:
   organize-imports${fmtAliases("organize-imports")} <file>                     organize imports

--- a/cli/src/commands/refresh.mjs
+++ b/cli/src/commands/refresh.mjs
@@ -1,0 +1,104 @@
+import { get } from "../client.mjs";
+import { extractPositional } from "../args.mjs";
+
+export async function refresh(args) {
+  const quiet = args.includes("-q") || args.includes("--quiet");
+  const projectFlag = args.indexOf("--project");
+  const projectName = projectFlag >= 0 ? args[projectFlag + 1] : null;
+  const pos = extractPositional(args).filter(
+    (a) => a !== "-q" && a !== "--quiet");
+
+  try {
+    if (pos.length > 0) {
+      // File mode: refresh each file
+      let refreshed = 0;
+      for (const filePath of pos) {
+        const result = await get(
+          `/refresh?file=${encodeURIComponent(filePath)}`,
+          10_000,
+        );
+        if (result.refreshed) refreshed++;
+      }
+      if (refreshed > 0) {
+        console.log(`Refreshed ${refreshed} file${refreshed > 1 ? "s" : ""}`);
+      }
+    } else if (projectName) {
+      // Project mode
+      const result = await get(
+        `/refresh?project=${encodeURIComponent(projectName)}`,
+        30_000,
+      );
+      if (result.error) {
+        console.error(result.error);
+        process.exit(1);
+      }
+      console.log(`Refreshed project ${projectName}`);
+    } else {
+      // Workspace mode
+      const result = await get("/refresh", 60_000);
+      if (result.error) {
+        console.error(result.error);
+        process.exit(1);
+      }
+      console.log("Refreshed workspace");
+    }
+
+    if (!quiet) {
+      console.log(refreshGuide());
+    }
+  } catch {
+    // Eclipse not running — silent
+  }
+}
+
+function refreshGuide() {
+  return `
+  Eclipse auto-build will compile changes in the background.
+  To check compilation results after build completes:
+
+    jdt errors                            all workspace errors
+    jdt errors --project <name>           errors in one project
+    jdt errors --file <workspace-path>    errors in one file
+
+  When to use \`jdt refresh\`:
+  - After any file-mutating operation outside Edit/Write — Bash commands
+    (mv, sed, git checkout/pull/merge/rebase), MCP tools, scripts, etc.
+  - After modifying non-.java files that affect compilation
+    (pom.xml, .classpath, .project, resource files)
+  - To sync an entire project or workspace after bulk changes
+
+  When NOT needed:
+  - After Edit/Write — the PostToolUse hook refreshes every edited
+    file automatically (\`jdt setup --claude\` to install)
+  - Between individual edits in a series — wait until the series is
+    done, then check \`jdt errors\` once
+
+  The hook covers all Edit/Write operations. File-mutating operations
+  outside Edit/Write (Bash, MCP tools, scripts) still need explicit
+  \`jdt refresh\`.
+
+  Add -q to suppress this guide.`;
+}
+
+export const help = `Explicitly notify Eclipse that files changed on disk.
+
+No build wait, no error checking — Eclipse auto-build picks up changes.
+The PostToolUse hook (jdt setup --claude) does this automatically for
+every Edit/Write. Use this command for manual refresh
+(e.g. after Bash commands, non-.java files, or project-wide sync).
+
+Usage:
+  jdt refresh <file> [<file> ...]       refresh specific files
+  jdt refresh --project <name>           refresh entire project
+  jdt refresh                            refresh entire workspace
+
+Flags:
+  -q, --quiet    suppress onboarding guide
+
+Accepts absolute paths for files. Files outside workspace are silently ignored.
+When Eclipse is not running, exits silently.
+
+Examples:
+  jdt refresh /path/to/Foo.java
+  jdt refresh --project m8-server
+  jdt refresh`;

--- a/cli/src/commands/setup.mjs
+++ b/cli/src/commands/setup.mjs
@@ -1,6 +1,6 @@
 // Setup command — install/update/remove the Eclipse JDT Bridge plugin.
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
@@ -168,6 +168,31 @@ async function runCheck(config) {
     (built ? ok : info)(built ? "p2 site: built" : "Not built yet");
   } else {
     info("Repo not found (CLI not in cloned repo)");
+  }
+  console.log();
+
+  // Claude Code hooks
+  console.log(bold("Claude Code"));
+  try {
+    const cwd = process.cwd();
+    const settingsPath = join(cwd, ".claude", "settings.json");
+    if (existsSync(settingsPath)) {
+      const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+      const hasPre = settings.hooks?.PreToolUse?.some(
+        (h) => h.hooks?.some((hk) => hk.command?.includes("jdt ")));
+      const hasPost = settings.hooks?.PostToolUse?.some(
+        (h) => h.hooks?.some(
+          (hk) => hk.command?.includes("jdt") && hk.command?.includes("refresh")));
+      (hasPre ? ok : info)(`PreToolUse hook: ${hasPre ? "installed" : "not installed"}`);
+      (hasPost ? ok : info)(`PostToolUse hook: ${hasPost ? "installed" : "not installed"}`);
+      if (!hasPre || !hasPost) {
+        info("Run: jdt setup --claude");
+      }
+    } else {
+      info("No .claude/settings.json — run: jdt setup --claude");
+    }
+  } catch {
+    info("Could not read .claude/settings.json");
   }
   console.log();
 }
@@ -357,10 +382,24 @@ export async function setup(args) {
     await runCheck(config);
   } else if (args.includes("--remove")) {
     await runRemove(config);
+  } else if (args.includes("--remove-claude")) {
+    await removeClaude();
   } else if (args.includes("--claude")) {
     await setupClaude();
   } else {
     await runInstall(config, flags);
+  }
+}
+
+async function removeClaude() {
+  const { uninstallClaudeSettings } = await import("../claude-setup.mjs");
+  const { file, removed } = uninstallClaudeSettings();
+  if (removed) {
+    console.log(`${green("✓")} JDT Bridge hooks removed from ${file}`);
+    console.log();
+    console.log("  Restart Claude Code to apply.");
+  } else {
+    console.log("No Claude Code settings found.");
   }
 }
 
@@ -373,6 +412,7 @@ async function setupClaude() {
   console.log("  Installed:");
   console.log("  - Bash(jdt *) permission rule");
   console.log("  - PreToolUse hook for # workaround (issue #34061)");
+  console.log("  - PostToolUse hook for Eclipse refresh on Edit/Write");
   console.log();
   console.log("  Restart Claude Code to apply.");
 }
@@ -386,6 +426,7 @@ Modes:
   --check         show status of all components (diagnostic only)
   --remove        uninstall the plugin from Eclipse
   --claude        configure Claude Code for this project (permissions + hooks)
+  --remove-claude remove JDT Bridge hooks from Claude Code settings
 
 Options:
   --eclipse <path>    Eclipse installation directory

--- a/cli/test/claude-setup.test.mjs
+++ b/cli/test/claude-setup.test.mjs
@@ -27,7 +27,9 @@ describe("mergeJdtSettings", () => {
         PostToolUse: [{ matcher: "Write", hooks: [] }],
       },
     });
-    expect(result.hooks.PostToolUse).toHaveLength(1);
+    // Existing Write hook + new jdt refresh hook
+    expect(result.hooks.PostToolUse).toHaveLength(2);
+    expect(result.hooks.PostToolUse[0].matcher).toBe("Write");
     expect(result.hooks.PreToolUse).toHaveLength(1);
   });
 
@@ -37,6 +39,15 @@ describe("mergeJdtSettings", () => {
     mergeJdtSettings(settings);
     expect(settings.permissions.allow.filter((r) => r === "Bash(jdt *)")).toHaveLength(1);
     expect(settings.hooks.PreToolUse).toHaveLength(1);
+    expect(settings.hooks.PostToolUse).toHaveLength(1);
+  });
+
+  it("adds PostToolUse refresh hook for Edit|Write", () => {
+    const result = mergeJdtSettings({});
+    expect(result.hooks.PostToolUse).toHaveLength(1);
+    expect(result.hooks.PostToolUse[0].matcher).toBe("Edit|Write");
+    expect(result.hooks.PostToolUse[0].hooks[0].command).toContain("jdt");
+    expect(result.hooks.PostToolUse[0].hooks[0].command).toContain("refresh");
   });
 
   it("does not duplicate if exact hook already exists", () => {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
@@ -113,4 +113,64 @@ public class DiagnosticsIntegrationTest {
         assertTrue(json.contains("error"),
                 "Should return error: " + json);
     }
+
+    // ---- handleRefresh ----
+
+    @Test
+    public void refreshWorkspaceFile() throws Exception {
+        // Get absolute path of a file in the test project
+        var root = org.eclipse.core.resources.ResourcesPlugin
+                .getWorkspace().getRoot();
+        var file = root.getProject(TestFixture.PROJECT_NAME)
+                .getFile("src/test/model/Dog.java");
+        assertTrue(file.exists(), "Dog.java should exist");
+        String absPath = file.getLocation().toOSString();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("file", absPath);
+        String json = handler.handleRefresh(params);
+        assertTrue(json.contains("\"refreshed\":true"),
+                "Should refresh: " + json);
+    }
+
+    @Test
+    public void refreshNonWorkspaceFile() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("file", "C:/nonexistent/Foo.java");
+        String json = handler.handleRefresh(params);
+        assertTrue(json.contains("\"refreshed\":false"),
+                "Should not refresh: " + json);
+        assertTrue(json.contains("not in workspace"),
+                "Reason: " + json);
+    }
+
+    @Test
+    public void refreshProject() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("project", TestFixture.PROJECT_NAME);
+        String json = handler.handleRefresh(params);
+        assertTrue(json.contains("\"refreshed\":true"),
+                "Should refresh project: " + json);
+        assertTrue(json.contains(TestFixture.PROJECT_NAME),
+                "Should name project: " + json);
+    }
+
+    @Test
+    public void refreshProjectNotFound() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("project", "nonexistent-xyz");
+        String json = handler.handleRefresh(params);
+        assertTrue(json.contains("error"),
+                "Should return error: " + json);
+    }
+
+    @Test
+    public void refreshWorkspace() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        String json = handler.handleRefresh(params);
+        assertTrue(json.contains("\"refreshed\":true"),
+                "Should refresh workspace: " + json);
+        assertTrue(json.contains("workspace"),
+                "Should say workspace scope: " + json);
+    }
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -92,6 +92,18 @@ Compilation diagnostics. Refreshes from disk and waits for auto-build before rea
 | `warnings` | Include warnings (default: errors only) |
 | `all` | All marker types (jdt + checkstyle + maven + ...) |
 
+### `GET /refresh?[file=<path>][&project=<name>]`
+
+Explicitly notify Eclipse that files changed on disk. No build wait, no markers. Automatic for `.java` edits when the PostToolUse hook is installed (`jdt setup --claude`).
+
+| Parameter | Description |
+|-----------|-------------|
+| `file` | Absolute filesystem path to refresh (DEPTH_ZERO) |
+| `project` | Project name to refresh (DEPTH_INFINITE) |
+| _(none)_ | Refresh entire workspace (DEPTH_INFINITE) |
+
+Returns `{"refreshed":true, ...}` or `{"refreshed":false, "reason":"not in workspace"}`.
+
 ## Refactoring
 
 ### `GET /organize-imports?file=<path>`

--- a/plugin/src/io/github/kaluchi/jdtbridge/DiagnosticsHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/DiagnosticsHandler.java
@@ -156,6 +156,75 @@ class DiagnosticsHandler {
         return result.toString();
     }
 
+    /**
+     * Lightweight refresh: notify Eclipse that files changed on disk.
+     * No build wait, no markers — just refreshLocal.
+     *
+     * Scope (pick one or omit for workspace):
+     *   file=<absolute-path>   single file (DEPTH_ZERO)
+     *   project=<name>         entire project (DEPTH_INFINITE)
+     *   (none)                 entire workspace (DEPTH_INFINITE)
+     */
+    String handleRefresh(Map<String, String> params)
+            throws Exception {
+        String filePath = params.get("file");
+        String projectName = params.get("project");
+
+        IWorkspaceRoot root =
+                ResourcesPlugin.getWorkspace().getRoot();
+
+        if (filePath != null && !filePath.isBlank()) {
+            // Absolute path → workspace file
+            var path = org.eclipse.core.runtime.Path
+                    .fromOSString(filePath);
+            IFile[] files = root.findFilesForLocationURI(
+                    path.toFile().toURI());
+
+            if (files.length == 0) {
+                var result = new JsonObject();
+                result.addProperty("refreshed", false);
+                result.addProperty("reason",
+                        "not in workspace");
+                return result.toString();
+            }
+
+            for (IFile file : files) {
+                file.refreshLocal(
+                        IResource.DEPTH_ZERO, null);
+            }
+
+            var result = new JsonObject();
+            result.addProperty("refreshed", true);
+            result.addProperty("files", files.length);
+            return result.toString();
+
+        } else if (projectName != null
+                && !projectName.isBlank()) {
+            IProject project = root.getProject(projectName);
+            if (!project.exists()) {
+                return HttpServer.jsonError(
+                        "Project not found: " + projectName);
+            }
+            project.refreshLocal(
+                    IResource.DEPTH_INFINITE, null);
+
+            var result = new JsonObject();
+            result.addProperty("refreshed", true);
+            result.addProperty("project", projectName);
+            return result.toString();
+
+        } else {
+            // Workspace-wide
+            root.refreshLocal(
+                    IResource.DEPTH_INFINITE, null);
+
+            var result = new JsonObject();
+            result.addProperty("refreshed", true);
+            result.addProperty("scope", "workspace");
+            return result.toString();
+        }
+    }
+
     String shortMarkerType(String type) {
         if (type == null) return "unknown";
         if (type.contains("jdt")) return "jdt";

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -379,6 +379,8 @@ public class HttpServer {
                         diagnostics.handleErrors(params));
                 case "/build" -> Response.json(
                         diagnostics.handleBuild(params));
+                case "/refresh" -> Response.json(
+                        diagnostics.handleRefresh(params));
                 case "/type-info" -> Response.json(
                         search.handleTypeInfo(params));
                 case "/source" -> search.handleSource(params);


### PR DESCRIPTION
## Summary

- **`jdt refresh`** — lightweight notify Eclipse of file changes. Three scopes: file (absolute path, DEPTH_ZERO), project (DEPTH_INFINITE), workspace (DEPTH_INFINITE). No build wait, no markers — just `refreshLocal`. Eclipse auto-build picks up changes in background.
- **PostToolUse hook** on `Edit|Write` — calls `jdt refresh` on `.java` files after every edit. Silent on failure, 5-second timeout. Eclipse stays in sync without manual intervention.
- **`jdt setup --claude`** now installs both PreToolUse (jdt permission) and PostToolUse (refresh) hooks.

## Test plan

- [x] 600 Java tests, 383 CLI tests — all pass
- [x] Plugin: refresh file (absolute path), non-workspace file (silent), project, project not found, workspace
- [x] CLI: PostToolUse hook registered, idempotent merge
- [x] Live: `jdt refresh /path/Foo.java`, `jdt refresh --project m8-server`, `jdt refresh` — all work
- [x] Hook tolerates Eclipse not running