### PR TITLE
Add jdt maven update command (Alt+F5 equivalent)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ jdt test run <FQN>#<method> -f   # run one test, stream progress
 jdt errors --project <name>      # instant compilation check
 jdt build --project <name>       # incremental build (1-3s, not 40s Maven)
 jdt refresh <file>               # explicitly notify Eclipse of file changes
+jdt maven update --project <name> -f  # update Maven project (Alt+F5)
 ```
 
 ### `jdt source` — hypertext navigation

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Most commands have short aliases for quick typing.
 | `test run <FQN> [-f]` | | Run JUnit tests with progress streaming |
 | `errors [--project <name>]` | `err` | Compilation errors and diagnostics |
 | `refresh [<file>] [--project <name>]` | `r` | Manually notify Eclipse of file changes |
+| `maven update [--project <name>]` | | Update Maven project (Alt+F5 equivalent) |
 | `organize-imports <file>` | `oi` | Organize imports (Eclipse settings) |
 | `format <file>` | `fmt` | Format code (Eclipse settings) |
 | `rename <FQMN> <new>` | | Rename type, method, or field across workspace |

--- a/cli/README.md
+++ b/cli/README.md
@@ -69,6 +69,15 @@ jdt refresh                                            # refresh entire workspac
 A PostToolUse hook (`jdt setup --claude`) calls `jdt refresh` automatically
 after every Edit/Write — Eclipse stays in sync without manual intervention.
 
+### Maven
+
+```bash
+jdt maven update                                       # update all Maven projects (Alt+F5)
+jdt maven update --project m8-server                   # update specific project
+jdt maven update -f                                    # wait for auto-build, show error count
+jdt maven update --force --offline                     # force snapshots, offline mode
+```
+
 ### Refactoring
 
 ```bash

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -16,6 +16,7 @@ import { testStatus, help as testStatusHelp } from "./commands/test-status.mjs";
 import { testSessions, help as testSessionsHelp } from "./commands/test-sessions.mjs";
 import { errors, help as errorsHelp } from "./commands/errors.mjs";
 import { refresh, help as refreshHelp } from "./commands/refresh.mjs";
+import { maven, help as mavenHelp } from "./commands/maven.mjs";
 import {
   organizeImports,
   format,
@@ -140,6 +141,7 @@ const commands = {
   test: { fn: testDispatch, help: testHelp },
   errors: { fn: errors, help: errorsHelp },
   refresh: { fn: refresh, help: refreshHelp },
+  maven: { fn: maven, help: mavenHelp },
   "organize-imports": { fn: organizeImports, help: organizeImportsHelp },
   format: { fn: format, help: formatHelp },
   rename: { fn: rename, help: renameHelp },
@@ -208,6 +210,9 @@ Testing & building:
 Diagnostics:
   errors${fmtAliases("errors")} [--file <path>] [--project <name>]   compilation errors
   refresh${fmtAliases("refresh")} [<file> ...] [--project <name>]  explicitly notify Eclipse of file changes
+
+Maven:
+  maven update [--project <name>]             update Maven project (Alt+F5)
 
 Refactoring:
   organize-imports${fmtAliases("organize-imports")} <file>                     organize imports

--- a/cli/src/commands/maven.mjs
+++ b/cli/src/commands/maven.mjs
@@ -1,0 +1,96 @@
+import { get } from "../client.mjs";
+import { extractPositional } from "../args.mjs";
+
+export async function maven(args) {
+  const sub = args[0];
+  if (sub === "update" || sub === "up") {
+    return mavenUpdate(args.slice(1));
+  }
+  console.error("Usage: jdt maven update [--project <name>] [options]");
+  process.exit(1);
+}
+
+async function mavenUpdate(args) {
+  const quiet = args.includes("-q") || args.includes("--quiet");
+  const projectFlag = args.indexOf("--project");
+  const projectName = projectFlag >= 0 ? args[projectFlag + 1] : null;
+
+  let url = "/maven/update?";
+  if (projectName) url += `project=${encodeURIComponent(projectName)}&`;
+  if (args.includes("--offline")) url += "offline&";
+  if (args.includes("--force")) url += "force&";
+  if (args.includes("--no-config")) url += "no-config&";
+  if (args.includes("--no-clean")) url += "no-clean&";
+  if (args.includes("--no-refresh")) url += "no-refresh&";
+  if (args.includes("-f") || args.includes("--follow")) url += "wait&";
+
+  const result = await get(url, 300_000);
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  if (result.ok) {
+    let msg = `Updated ${result.updated} Maven project${result.updated > 1 ? "s" : ""}`;
+    if (result.errors !== undefined) {
+      msg += ` (${result.errors} error${result.errors !== 1 ? "s" : ""})`;
+    }
+    console.log(msg);
+  } else {
+    console.error(`Maven update failed: ${result.message || "unknown error"}`);
+    process.exit(1);
+  }
+
+  if (!quiet) {
+    console.log(mavenUpdateGuide());
+  }
+}
+
+function mavenUpdateGuide() {
+  return `
+  Equivalent to Alt+F5 in Eclipse (Update Maven Project).
+  Updates dependencies, project configuration, and classpath.
+
+  Options:
+    --project <name>   update specific project (default: all)
+    -f                 wait for auto-build to finish, show error count
+    --offline          offline mode (no network)
+    --force            force update of snapshots/releases
+    --no-config        skip updating project configuration from pom.xml
+    --no-clean         skip clean projects
+    --no-refresh       skip refresh workspace resources
+
+  Without -f, returns immediately — auto-build runs in background.
+  With -f, waits until all projects are compiled and reports errors.
+
+  When to use:
+  - After changing pom.xml (dependencies, plugins, properties)
+  - After git pull/merge that modifies pom.xml files
+  - When Eclipse classpath is out of sync with Maven dependencies
+  - After adding/removing Maven modules
+
+  Add -q to suppress this guide.`;
+}
+
+export const help = `Maven project operations.
+
+Usage:  jdt maven update [--project <name>] [options]
+
+Subcommands:
+  update (up)    update Maven project (Alt+F5 equivalent)
+
+Options for update:
+  --project <name>   update specific project (default: all)
+  --offline          offline mode
+  --force            force update of snapshots/releases
+  --no-config        skip project configuration update
+  --no-clean         skip clean projects
+  --no-refresh       skip workspace refresh
+  -f, --follow       wait for auto-build to finish, show error count
+  -q, --quiet        suppress onboarding guide
+
+Examples:
+  jdt maven update
+  jdt maven update --project m8-server
+  jdt maven update --force
+  jdt maven up -q`;

--- a/jdtbridge-ci.target
+++ b/jdtbridge-ci.target
@@ -10,5 +10,11 @@
             <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
             <unit id="com.google.gson" version="0.0.0"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true"
+                  includeMode="planner" includeSource="false"
+                  type="InstallableUnit">
+            <repository location="https://download.eclipse.org/technology/m2e/releases/latest/"/>
+            <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+        </location>
     </locations>
 </target>

--- a/plugin.tests/pom.xml
+++ b/plugin.tests/pom.xml
@@ -45,6 +45,15 @@
                             <type>eclipse-plugin</type>
                             <artifactId>org.eclipse.core.resources.source</artifactId>
                         </dependency>
+                        <!-- m2e core for MavenIntegrationTest -->
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>org.eclipse.m2e.core</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>eclipse-plugin</type>
+                            <artifactId>org.eclipse.m2e.maven.runtime</artifactId>
+                        </dependency>
                     </dependencies>
                 </configuration>
             </plugin>

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/MavenIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/MavenIntegrationTest.java
@@ -1,0 +1,303 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Integration tests for Maven operations.
+ * Creates its own Maven projects (broken + clean) to test
+ * success paths, error detection, and all response fields.
+ */
+@EnabledIfSystemProperty(
+        named = "jdtbridge.integration-tests",
+        matches = "true")
+public class MavenIntegrationTest {
+
+    private static final String MAVEN_PROJECT =
+            "jdtbridge-maven-test";
+    private static final String CLEAN_PROJECT =
+            "jdtbridge-maven-clean";
+    private static final MavenHandler handler =
+            new MavenHandler();
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        createMavenProject(MAVEN_PROJECT,
+                "jdtbridge-maven-test", "test.maven",
+                new String[]{
+                        "Good.java", """
+                        package test.maven;
+                        public class Good {
+                            public String hello() {
+                                return "hi";
+                            }
+                        }
+                        """,
+                        "Broken.java", """
+                        package test.maven;
+                        public class Broken {
+                            UnknownType x;
+                        }
+                        """
+                });
+
+        createMavenProject(CLEAN_PROJECT,
+                "clean", "test.clean",
+                new String[]{
+                        "Valid.java", """
+                        package test.clean;
+                        public class Valid {
+                            public int value() { return 42; }
+                        }
+                        """
+                });
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        deleteProject(MAVEN_PROJECT);
+        deleteProject(CLEAN_PROJECT);
+    }
+
+    // ---- fixture helpers ----
+
+    private static void createMavenProject(String name,
+            String artifactId, String pkg,
+            String[] sources) throws Exception {
+        IWorkspaceRoot root =
+                ResourcesPlugin.getWorkspace().getRoot();
+        IProject project = root.getProject(name);
+        if (project.exists()) {
+            project.delete(true, true, null);
+        }
+
+        project.create(null);
+        project.open(null);
+
+        IProjectDescription desc = project.getDescription();
+        desc.setNatureIds(new String[]{
+                JavaCore.NATURE_ID,
+                "org.eclipse.m2e.core.maven2Nature"});
+        project.setDescription(desc, null);
+
+        IFile pom = project.getFile("pom.xml");
+        pom.create(new ByteArrayInputStream((
+                "<project xmlns=\"http://maven.apache.org"
+                + "/POM/4.0.0\">"
+                + "<modelVersion>4.0.0</modelVersion>"
+                + "<groupId>test</groupId>"
+                + "<artifactId>" + artifactId
+                + "</artifactId>"
+                + "<version>0.0.1</version>"
+                + "</project>")
+                .getBytes()), true, null);
+
+        IJavaProject jp = JavaCore.create(project);
+        IFolder src = project.getFolder("src");
+        src.create(true, true, null);
+        jp.setRawClasspath(new IClasspathEntry[]{
+                JavaCore.newSourceEntry(src.getFullPath()),
+                JavaCore.newContainerEntry(new Path(
+                        "org.eclipse.jdt.launching"
+                        + ".JRE_CONTAINER"))
+        }, null);
+
+        IPackageFragmentRoot srcRoot =
+                jp.getPackageFragmentRoot(src);
+        IPackageFragment pkgFrag =
+                srcRoot.createPackageFragment(
+                        pkg, true, null);
+        for (int i = 0; i < sources.length; i += 2) {
+            pkgFrag.createCompilationUnit(
+                    sources[i], sources[i + 1], true, null);
+        }
+
+        Job.getJobManager().join(
+                ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+    }
+
+    private static void deleteProject(String name)
+            throws Exception {
+        IProject p = ResourcesPlugin.getWorkspace()
+                .getRoot().getProject(name);
+        if (p.exists()) p.delete(true, true, null);
+    }
+
+    // ---- test helpers ----
+
+    private JsonObject update(Map<String, String> params)
+            throws Exception {
+        return JsonParser.parseString(
+                handler.handleUpdate(params))
+                .getAsJsonObject();
+    }
+
+    private Map<String, String> params(String... kvs) {
+        var m = new HashMap<String, String>();
+        for (int i = 0; i < kvs.length; i += 2) {
+            m.put(kvs[i], kvs[i + 1]);
+        }
+        return m;
+    }
+
+    // ---- update single project ----
+
+    @Test
+    public void updateReturnsOk() throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", ""));
+        assertTrue(r.get("ok").getAsBoolean(),
+                "Should be ok: " + r);
+    }
+
+    @Test
+    public void updateReturnsProjectCount() throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", ""));
+        assertEquals(1, r.get("updated").getAsInt());
+    }
+
+    @Test
+    public void updateReturnsProjectName() throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", ""));
+        var projects = r.getAsJsonArray("projects");
+        assertNotNull(projects, "Should have projects array");
+        assertEquals(1, projects.size());
+        assertEquals(MAVEN_PROJECT,
+                projects.get(0).getAsString());
+    }
+
+    @Test
+    public void updateWithoutWaitHasNoErrorField()
+            throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", ""));
+        assertFalse(r.has("errors"),
+                "Without wait should not have errors: " + r);
+    }
+
+    // ---- wait + error detection ----
+
+    @Test
+    public void waitFindsCompilationErrors() throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", "", "wait", ""));
+        assertTrue(r.has("errors"),
+                "With wait should have errors: " + r);
+        int errors = r.get("errors").getAsInt();
+        assertTrue(errors > 0,
+                "Broken.java has UnknownType — expect errors: "
+                + errors);
+    }
+
+    @Test
+    public void waitStillReportsOk() throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", "", "wait", ""));
+        assertTrue(r.get("ok").getAsBoolean(),
+                "Maven update ok even with compile errors: "
+                + r);
+    }
+
+    @Test
+    public void waitErrorCountMatchesJdtErrors()
+            throws Exception {
+        var r = update(params("project", MAVEN_PROJECT,
+                "no-clean", "", "wait", ""));
+        int fromUpdate = r.get("errors").getAsInt();
+
+        IProject p = ResourcesPlugin.getWorkspace()
+                .getRoot().getProject(MAVEN_PROJECT);
+        int fromMarkers = JdtUtils.countErrors(p);
+
+        assertEquals(fromMarkers, fromUpdate,
+                "Error count should match JdtUtils.countErrors");
+    }
+
+    // ---- clean project (no errors) ----
+
+    @Test
+    public void cleanProjectHasZeroErrors() throws Exception {
+        var r = update(params("project", CLEAN_PROJECT,
+                "no-clean", "", "wait", ""));
+        assertTrue(r.get("ok").getAsBoolean());
+        assertEquals(0, r.get("errors").getAsInt(),
+                "Clean project should have 0 errors");
+        assertEquals(CLEAN_PROJECT,
+                r.getAsJsonArray("projects")
+                        .get(0).getAsString());
+    }
+
+    // ---- error paths ----
+
+    @Test
+    public void projectNotFound() throws Exception {
+        var r = update(params("project", "nonexistent-xyz"));
+        assertTrue(r.has("error"),
+                "Should return error: " + r);
+        assertTrue(r.get("error").getAsString()
+                .contains("not found"),
+                "Error should say not found: " + r);
+    }
+
+    @Test
+    public void nonMavenProject() throws Exception {
+        TestFixture.createNonJavaProject();
+        var r = update(params("project",
+                TestFixture.NON_JAVA_PROJECT_NAME));
+        assertTrue(r.has("error"),
+                "Non-maven should error: " + r);
+        assertTrue(r.get("error").getAsString()
+                .contains("Not a Maven"),
+                "Error should say not maven: " + r);
+    }
+
+    // ---- all maven projects ----
+
+    @Test
+    public void updateAllMavenProjects() throws Exception {
+        var r = update(params("no-clean", ""));
+        assertTrue(r.get("ok").getAsBoolean());
+        int updated = r.get("updated").getAsInt();
+        assertTrue(updated >= 1,
+                "Should update at least our test project: "
+                + updated);
+        var projects = r.getAsJsonArray("projects");
+        var names = StreamSupport.stream(
+                        projects.spliterator(), false)
+                .map(e -> e.getAsString())
+                .collect(Collectors.toSet());
+        assertTrue(names.contains(MAVEN_PROJECT),
+                "Should include test project: " + names);
+    }
+}

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.text,
  org.eclipse.ui,
- org.eclipse.ui.ide
+ org.eclipse.ui.ide,
+ org.eclipse.m2e.core
 Import-Package: com.google.gson,
  org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -104,6 +104,22 @@ Explicitly notify Eclipse that files changed on disk. No build wait, no markers.
 
 Returns `{"refreshed":true, ...}` or `{"refreshed":false, "reason":"not in workspace"}`.
 
+### `GET /maven/update?[project=<name>][&offline][&force][&no-config][&no-clean][&no-refresh][&wait]`
+
+Maven Update Project (Alt+F5 equivalent). Uses m2e core API.
+
+| Parameter | Description |
+|-----------|-------------|
+| `project` | Project name (default: all Maven projects) |
+| `offline` | Offline mode |
+| `force` | Force update of snapshots/releases |
+| `no-config` | Skip update project configuration from pom.xml |
+| `no-clean` | Skip clean projects |
+| `no-refresh` | Skip refresh workspace resources |
+| `wait` | Wait for auto-build, include `errors` count in response |
+
+Returns `{"updated":N, "projects":[...], "ok":true/false, "errors":N}`.
+
 ## Refactoring
 
 ### `GET /organize-imports?file=<path>`

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -28,6 +28,7 @@ public class HttpServer {
     private final SearchHandler search = new SearchHandler();
     private final DiagnosticsHandler diagnostics =
             new DiagnosticsHandler();
+    private final MavenHandler maven = new MavenHandler();
     private final RefactoringHandler refactoring =
             new RefactoringHandler();
     private final EditorHandler editor = new EditorHandler();
@@ -381,6 +382,8 @@ public class HttpServer {
                         diagnostics.handleBuild(params));
                 case "/refresh" -> Response.json(
                         diagnostics.handleRefresh(params));
+                case "/maven/update" -> Response.json(
+                        maven.handleUpdate(params));
                 case "/type-info" -> Response.json(
                         search.handleTypeInfo(params));
                 case "/source" -> search.handleSource(params);

--- a/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
@@ -147,6 +147,32 @@ class JdtUtils {
                 ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
     }
 
+    static final String JDT_PROBLEM_MARKER =
+            "org.eclipse.jdt.core.problem";
+
+    /**
+     * Count JDT compilation errors in the given resource scope.
+     */
+    static int countErrors(
+            org.eclipse.core.resources.IResource scope)
+            throws org.eclipse.core.runtime.CoreException {
+        var markers = scope.findMarkers(
+                JDT_PROBLEM_MARKER, true,
+                org.eclipse.core.resources.IResource
+                        .DEPTH_INFINITE);
+        int count = 0;
+        for (var m : markers) {
+            if (m.getAttribute(
+                    org.eclipse.core.resources.IMarker
+                            .SEVERITY, -1)
+                    == org.eclipse.core.resources.IMarker
+                            .SEVERITY_ERROR) {
+                count++;
+            }
+        }
+        return count;
+    }
+
     static String compactSignature(IMethod m) throws JavaModelException {
         StringBuilder sig = new StringBuilder();
         sig.append(m.getElementName()).append("(");

--- a/plugin/src/io/github/kaluchi/jdtbridge/MavenHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/MavenHandler.java
@@ -1,0 +1,133 @@
+package io.github.kaluchi.jdtbridge;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+/**
+ * Handles Maven-related operations via m2e core API.
+ */
+class MavenHandler {
+
+
+    /**
+     * Maven Update Project — equivalent to Alt+F5 in Eclipse.
+     * Uses m2e core internal API (ProjectConfigurationManager)
+     * directly — same logic as UpdateMavenProjectJob but without
+     * UI bundle dependency.
+     *
+     * Params:
+     *   project=<name>   specific project (default: all maven)
+     *   offline          offline mode
+     *   force            force update of snapshots/releases
+     *   no-config        skip update project config from pom.xml
+     *   no-clean         skip clean projects
+     *   no-refresh       skip refresh workspace resources
+     *   wait             wait for auto-build, count errors
+     */
+    String handleUpdate(Map<String, String> params)
+            throws Exception {
+        String projectName = params.get("project");
+        boolean offline = params.containsKey("offline");
+        boolean force = params.containsKey("force");
+        boolean updateConfig =
+                !params.containsKey("no-config");
+        boolean clean = !params.containsKey("no-clean");
+        boolean refresh = !params.containsKey("no-refresh");
+
+        IWorkspaceRoot root =
+                ResourcesPlugin.getWorkspace().getRoot();
+
+        var projects = new ArrayList<IProject>();
+        if (projectName != null && !projectName.isBlank()) {
+            IProject project = root.getProject(projectName);
+            if (!project.exists()) {
+                return HttpServer.jsonError(
+                        "Project not found: " + projectName);
+            }
+            if (!org.eclipse.m2e.core.MavenPlugin
+                    .isMavenProject(project)) {
+                return HttpServer.jsonError(
+                        "Not a Maven project: "
+                        + projectName);
+            }
+            projects.add(project);
+        } else {
+            for (IProject p : root.getProjects()) {
+                if (p.isOpen()
+                        && org.eclipse.m2e.core.MavenPlugin
+                                .isMavenProject(p)) {
+                    projects.add(p);
+                }
+            }
+        }
+
+        if (projects.isEmpty()) {
+            return HttpServer.jsonError(
+                    "No Maven projects found");
+        }
+
+        boolean wait = params.containsKey("wait");
+
+        var configManager =
+                (org.eclipse.m2e.core.internal.project
+                        .ProjectConfigurationManager)
+                org.eclipse.m2e.core.MavenPlugin
+                        .getProjectConfigurationManager();
+        var request =
+                new org.eclipse.m2e.core.project
+                        .MavenUpdateRequest(
+                                projects, offline, force);
+        var updateErrors = configManager
+                .updateProjectConfiguration(
+                        request, updateConfig, clean,
+                        refresh, null);
+
+        int errorCount = -1;
+        if (wait) {
+            JdtUtils.joinAutoBuild();
+            errorCount = 0;
+            for (IProject p : projects) {
+                errorCount += JdtUtils.countErrors(p);
+            }
+        }
+
+        var result = new JsonObject();
+        result.addProperty("updated", projects.size());
+        var names = new JsonArray();
+        for (IProject p : projects) {
+            names.add(p.getName());
+        }
+        result.add("projects", names);
+        // Filter to actual errors (not OK statuses)
+        boolean ok = true;
+        var sb = new StringBuilder();
+        if (updateErrors != null) {
+            updateErrors.forEach((k, v) -> {
+                if (!v.isOK()) {
+                    sb.append(k).append(": ")
+                            .append(v.getMessage())
+                            .append("\n");
+                }
+            });
+            ok = sb.isEmpty();
+        }
+        result.addProperty("ok", ok);
+        if (errorCount >= 0) {
+            result.addProperty("errors", errorCount);
+        }
+        if (!ok) {
+            result.addProperty("message",
+                    sb.toString().strip());
+        }
+        return result.toString();
+    }
+}


### PR DESCRIPTION
Summary:
- New MavenHandler with /maven/update endpoint using m2e core API
  (ProjectConfigurationManager.updateProjectConfiguration) directly,
  no UI bundle dependency. Same logic as UpdateMavenProjectJob.
- All Alt+F5 dialog options: offline, force, update-config, clean, refresh.
- -f flag: waits for auto-build, counts JDT compilation errors.
- Onboarding guide with -q suppression.
- m2e dependency added to MANIFEST.MF (hard). CI target platform updated.
- JdtUtils.countErrors() shared between MavenHandler and DiagnosticsHandler.

Test plan:
- [x] 611 Tycho tests, 383 CLI tests -- all pass
- [x] 11 MavenIntegrationTest cases with isolated fixture:
  - Broken project: errors > 0, ok still true, cross-check with countErrors
  - Clean project: errors = 0
  - Without wait: no errors field
  - Response: updated count, project names array, ok status
  - Error paths: project not found, non-maven project
  - All maven projects: includes test project
- [x] Live: jdt maven update --project m8-server -f -q
- [x] Docs: README, AGENTS, cli/README, plugin/README