### PR TITLE
feat: support --project override for test run with class FQN

### DIFF
--- a/cli/src/commands/test-run.mjs
+++ b/cli/src/commands/test-run.mjs
@@ -25,6 +25,8 @@ export async function testRun(args) {
     url += `class=${encodeURIComponent(fqn)}`;
     const method = parsed.method;
     if (method) url += `&method=${encodeURIComponent(method)}`;
+    if (flags.project)
+      url += `&project=${encodeURIComponent(flags.project)}`;
   } else if (flags.project) {
     url += `project=${encodeURIComponent(flags.project)}`;
     if (flags.package)
@@ -81,20 +83,25 @@ function sleep(ms) {
 
 export const help = `Launch tests non-blocking with real-time progress.
 
-Usage:  jdt test run <FQN>[#method] [-f] [-q]
+Usage:  jdt test run <FQN>[#method] [--project <name>] [-f] [-q]
         jdt test run --project <name> [--package <pkg>] [-f] [-q]
 
 Without -f, launches and prints a guide with available commands.
 With -f, launches and streams test progress until completion.
 
+When --project is used with <FQN>, the test class is resolved by name
+but launched using the specified project's classpath. This is useful when
+test sources live in one project but need dependencies from another.
+
 Flags:
-  -f, --follow    stream test status (only failures by default)
-  -q, --quiet     suppress onboarding guide
-  --all           include passed tests in output (with -f)
-  --ignored       show only ignored tests (with -f)
+  --project <name>  override the project for classpath resolution
+  -f, --follow      stream test status (only failures by default)
+  -q, --quiet       suppress onboarding guide
+  --all             include passed tests in output (with -f)
+  --ignored         show only ignored tests (with -f)
 
 Examples:
-  jdt test run com.example.MyTest                 run + show guide
-  jdt test run com.example.MyTest -f              run + stream failures
-  jdt test run com.example.MyTest -f --all        run + stream all tests
-  jdt test run --project my-project -f             run project tests + stream`;
+  jdt test run com.example.MyTest                       run + show guide
+  jdt test run com.example.MyTest --project Build -f    run with Build classpath
+  jdt test run com.example.MyTest -f --all              run + stream all tests
+  jdt test run --project my-project -f                  run project tests + stream`;

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -119,9 +119,22 @@ class TestHandler {
         if (fqn != null && !fqn.isBlank()) {
             IType type = JdtUtils.findType(fqn);
             if (type != null) {
-                resolvedProject =
-                        type.getJavaProject().getElementName();
-                testKind = detectTestKind(type);
+                // Prefer explicit project over type's project
+                if (projectName != null
+                        && !projectName.isBlank()) {
+                    resolvedProject = projectName;
+                    var model = JavaCore.create(
+                            ResourcesPlugin.getWorkspace()
+                                    .getRoot());
+                    IJavaProject jp =
+                            model.getJavaProject(projectName);
+                    testKind = detectTestKind(jp);
+                } else {
+                    resolvedProject =
+                            type.getJavaProject()
+                                    .getElementName();
+                    testKind = detectTestKind(type);
+                }
             }
         } else if (projectName != null
                 && !projectName.isBlank()) {
@@ -203,17 +216,31 @@ class TestHandler {
                 return HttpServer.jsonError("Type not found: " + fqn);
             }
 
-            IJavaProject jp = type.getJavaProject();
+            // Use explicit project if provided, otherwise
+            // fall back to the project that owns the type.
+            // This is needed when the test class lives in
+            // project A but must run from project B's classpath
+            // (e.g. test in Grinbel, classpath from Build).
+            String effectiveProject = projectName;
+            if (effectiveProject == null
+                    || effectiveProject.isBlank()) {
+                effectiveProject =
+                        type.getJavaProject().getElementName();
+            }
+
+            IJavaProject jp = JavaCore.create(
+                    ResourcesPlugin.getWorkspace().getRoot())
+                    .getJavaProject(effectiveProject);
             wc.setAttribute(
                     IJavaLaunchConfigurationConstants
                             .ATTR_PROJECT_NAME,
-                    jp.getElementName());
+                    effectiveProject);
             wc.setAttribute(
                     IJavaLaunchConfigurationConstants
                             .ATTR_MAIN_TYPE_NAME,
                     fqn);
             wc.setAttribute(ATTR_TEST_KIND,
-                    detectTestKind(type));
+                    detectTestKind(jp));
 
             if (methodName != null && !methodName.isBlank()) {
                 wc.setAttribute(ATTR_TEST_NAME, methodName);


### PR DESCRIPTION
## Summary
- When running `jdt test run <FQN> --project <name>`, use the specified project's classpath instead of the project that owns the type
- This is needed when test sources live in one project but require dependencies from another (e.g. test class in Grinbel, classpath from Build)

## Changes
- **CLI**: pass `project` parameter alongside `class` in URL query string
- **Plugin**: prefer explicit `projectName` over `type.getJavaProject()` in `configureLaunch()` and `prepareLaunch()` metadata resolution

## Test plan
- [x] `jdt test run com.example.MyTest --project Build -f` uses Build's classpath
- [x] `jdt test run com.example.MyTest -f` (no --project) keeps existing behavior
- [x] `jdt test run --project Build -f` (no class, project-wide) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)