### PR TITLE
Fix npm link lockfile corruption and JSON path leak

### DIFF
--- a/cli/src/commands/agent-sandbox.mjs
+++ b/cli/src/commands/agent-sandbox.mjs
@@ -71,9 +71,13 @@ export async function run({ agent, name, agentArgs, session }) {
     const isVisible = (visibility.stdout || "").trim() === "visible";
 
     if (isVisible) {
+      // npm link with --no-save --ignore-scripts to avoid rewriting
+      // package-lock.json on the host via virtiofs. Without these flags,
+      // npm resolves deps for Linux and overwrites the Windows lockfile.
+      // This is fragile — npm link is only for jdt CLI developers.
       console.log(`Linking CLI from ${repoRoot} (live sync)...`);
       const linkCmd = ["sandbox", "exec", container,
-        "bash", "-c", `cd "${sandboxCliPath}" && npm link`];
+        "bash", "-c", `cd "${sandboxCliPath}" && npm link --no-save --ignore-scripts`];
       console.log(dim(`  $ docker ${linkCmd.join(" ")}`));
       spawnSync("docker", linkCmd, { stdio: "inherit" });
       cliInstalled = true;

--- a/cli/src/commands/source.mjs
+++ b/cli/src/commands/source.mjs
@@ -14,7 +14,9 @@ export async function source(args) {
   const results = await Promise.all(pos.map((arg) => fetchOne(arg)));
 
   if (jsonFlag) {
-    console.log(JSON.stringify(results.length === 1 ? results[0] : results, null, 2));
+    const data = results.length === 1 ? results[0] : results;
+    remapJsonPaths(data);
+    console.log(JSON.stringify(data, null, 2));
     return;
   }
 
@@ -282,6 +284,21 @@ function formatMarkdown(result) {
   }
 
   return lines.join("\n");
+}
+
+/** Recursively apply toSandboxPath to all "file" values in JSON data. */
+function remapJsonPaths(obj) {
+  if (Array.isArray(obj)) {
+    for (const item of obj) remapJsonPaths(item);
+  } else if (obj && typeof obj === "object") {
+    for (const key of Object.keys(obj)) {
+      if (key === "file" && typeof obj[key] === "string") {
+        obj[key] = toSandboxPath(obj[key]);
+      } else {
+        remapJsonPaths(obj[key]);
+      }
+    }
+  }
 }
 
 export const help = `Print source code of a type or method with resolved references.

--- a/cli/test/source-format.test.mjs
+++ b/cli/test/source-format.test.mjs
@@ -420,6 +420,22 @@ describe("source format", () => {
     expect(out).not.toContain("Outgoing Calls:");
   });
 
+  it("--json converts file paths in sandbox (Linux)", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(METHOD_RESPONSE));
+    });
+    mockSandboxPaths();
+    const { source } = await import("../src/commands/source.mjs");
+    await source(["pkg.Foo#bar", "--json"]);
+    const out = io.logs.join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.file).toBe("/d/src/Foo.java");
+    for (const ref of parsed.refs) {
+      if (ref.file) expect(ref.file).not.toMatch(/^[A-Z]:[/\\]/);
+    }
+  });
+
   it("file path converted in sandbox (Linux)", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });


### PR DESCRIPTION
## Summary

- npm link inside Docker sandbox with --no-save --ignore-scripts to prevent package-lock.json corruption via virtiofs
- source --json now applies toSandboxPath recursively to all file fields in JSON output

## Test plan

- [x] npm test -- 470 tests pass (1 new for JSON path remapping)
- [ ] Sandbox: jdt source --json shows /d/... paths instead of D:\...
- [ ] npm link no longer rewrites package-lock.json on host