### PR TITLE
Fix exit codes and standardize empty states

### DIFF
--- a/cli/src/commands/agent.mjs
+++ b/cli/src/commands/agent.mjs
@@ -107,7 +107,7 @@ export async function agentList() {
   const sessions = readSessions();
 
   if (sessions.length === 0) {
-    console.log("No agent sessions.");
+    console.log("(no agent sessions)");
     return;
   }
 
@@ -250,7 +250,7 @@ function printSessionError(subcmd, hint, candidates) {
       console.error(`  jdt agent ${subcmd} ${s.name}`);
     }
   } else if (!hint) {
-    console.error("No agent sessions.");
+    console.error("(no agent sessions)");
   } else {
     console.error(`No agent session found: ${hint}`);
   }

--- a/cli/src/commands/build.mjs
+++ b/cli/src/commands/build.mjs
@@ -14,7 +14,7 @@ export async function build(args) {
   const result = await get(url, 180_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   const n = result.errors || 0;
   if (n === 0) {

--- a/cli/src/commands/editor.mjs
+++ b/cli/src/commands/editor.mjs
@@ -6,7 +6,7 @@ export async function editors() {
   const results = await get("/editors");
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no open editors)");
@@ -35,7 +35,7 @@ export async function open(args) {
   const result = await get(url);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   console.log("Opened");
 }

--- a/cli/src/commands/errors.mjs
+++ b/cli/src/commands/errors.mjs
@@ -16,7 +16,7 @@ export async function errors(args) {
   const results = await get(url, 180_000);
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no errors)");

--- a/cli/src/commands/find.mjs
+++ b/cli/src/commands/find.mjs
@@ -14,7 +14,7 @@ export async function find(args) {
   const results = await get(url, 30_000);
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no results)");

--- a/cli/src/commands/hierarchy.mjs
+++ b/cli/src/commands/hierarchy.mjs
@@ -15,7 +15,7 @@ export async function hierarchy(args) {
   );
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
 
   const lines = [];
@@ -26,7 +26,7 @@ export async function hierarchy(args) {
   if (lines.length > 2) {
     console.log(lines.join("\n"));
   } else {
-    console.log("No hierarchy found.");
+    console.log("(no hierarchy)");
   }
 }
 

--- a/cli/src/commands/implementors.mjs
+++ b/cli/src/commands/implementors.mjs
@@ -19,7 +19,7 @@ export async function implementors(args) {
   const results = await get(url, 30_000);
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no implementors)");

--- a/cli/src/commands/launch.mjs
+++ b/cli/src/commands/launch.mjs
@@ -5,7 +5,7 @@ export async function launchList() {
   const results = await get("/launch/list");
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no launches)");
@@ -25,7 +25,7 @@ export async function launchConfigs() {
   const results = await get("/launch/configs");
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no launch configurations)");
@@ -43,7 +43,7 @@ export async function launchClear(args) {
   const result = await get(url);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   console.log(`Removed ${result.removed} terminated launch${result.removed !== 1 ? "es" : ""}`);
 }
@@ -74,7 +74,7 @@ async function launchWithMode(args, mode) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
 
   const follow = args.includes("-f") || args.includes("--follow");
@@ -143,7 +143,7 @@ export async function launchStop(args) {
   const result = await get(url);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   console.log(`Stopped ${result.name}`);
 }
@@ -178,7 +178,7 @@ export async function launchLogs(args) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   if (result.output) {
     const text = result.output.endsWith("\n")

--- a/cli/src/commands/maven.mjs
+++ b/cli/src/commands/maven.mjs
@@ -27,7 +27,7 @@ async function mavenUpdate(args) {
   const result = await get(url, 300_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
 
   if (result.ok) {

--- a/cli/src/commands/project-info.mjs
+++ b/cli/src/commands/project-info.mjs
@@ -18,7 +18,7 @@ export async function projectInfo(args) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   const maxLines = parseInt(flags.lines) || 50;
   console.log(formatProjectInfo(result, maxLines));

--- a/cli/src/commands/projects.mjs
+++ b/cli/src/commands/projects.mjs
@@ -4,7 +4,7 @@ export async function projects() {
   const results = await get("/projects");
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   for (const p of results) console.log(p);
 }

--- a/cli/src/commands/refactoring.mjs
+++ b/cli/src/commands/refactoring.mjs
@@ -16,7 +16,7 @@ export async function organizeImports(args) {
   );
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   console.log(`Imports: +${result.added} -${result.removed}`);
 }
@@ -34,7 +34,7 @@ export async function format(args) {
   );
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   if (result.modified) {
     console.log(green("Formatted"));
@@ -64,7 +64,7 @@ export async function rename(args) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   console.log(green("Renamed"));
   if (result.warnings) {
@@ -83,7 +83,7 @@ export async function move(args) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
   console.log(green("Moved"));
   if (result.warnings) {

--- a/cli/src/commands/references.mjs
+++ b/cli/src/commands/references.mjs
@@ -24,7 +24,7 @@ export async function references(args) {
   const results = await get(url, 30_000);
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no references)");

--- a/cli/src/commands/refresh.mjs
+++ b/cli/src/commands/refresh.mjs
@@ -30,7 +30,7 @@ export async function refresh(args) {
       );
       if (result.error) {
         console.error(result.error);
-        process.exit(1);
+        return;
       }
       console.log(`Refreshed project ${projectName}`);
     } else {
@@ -38,7 +38,7 @@ export async function refresh(args) {
       const result = await get("/refresh", 60_000);
       if (result.error) {
         console.error(result.error);
-        process.exit(1);
+        return;
       }
       console.log("Refreshed workspace");
     }

--- a/cli/src/commands/source.mjs
+++ b/cli/src/commands/source.mjs
@@ -30,7 +30,7 @@ export async function source(args) {
       blocks.push(formatMarkdown(r));
     }
   }
-  if (blocks.length === 0) process.exit(1);
+  if (blocks.length === 0) return;
   console.log(blocks.join("\n\n---\n\n"));
 }
 

--- a/cli/src/commands/subtypes.mjs
+++ b/cli/src/commands/subtypes.mjs
@@ -15,7 +15,7 @@ export async function subtypes(args) {
   );
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no subtypes)");

--- a/cli/src/commands/test-run.mjs
+++ b/cli/src/commands/test-run.mjs
@@ -43,7 +43,7 @@ export async function testRun(args) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
 
   // Wait briefly for session to register total count

--- a/cli/src/commands/test-sessions.mjs
+++ b/cli/src/commands/test-sessions.mjs
@@ -8,7 +8,7 @@ export async function testSessions() {
   const results = await get("/test/sessions");
   if (results.error) {
     console.error(results.error);
-    process.exit(1);
+    return;
   }
   if (results.length === 0) {
     console.log("(no test sessions)");

--- a/cli/src/commands/test-status.mjs
+++ b/cli/src/commands/test-status.mjs
@@ -35,7 +35,7 @@ export async function testStatus(args) {
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
 
   formatTestStatus(result);

--- a/cli/src/commands/type-info.mjs
+++ b/cli/src/commands/type-info.mjs
@@ -16,7 +16,7 @@ export async function typeInfo(args) {
   );
   if (result.error) {
     console.error(result.error);
-    process.exit(1);
+    return;
   }
 
   const filePath = toSandboxPath(stripProject(result.file));

--- a/cli/test/agent.test.mjs
+++ b/cli/test/agent.test.mjs
@@ -88,7 +88,7 @@ describe("agent commands", () => {
   describe("list", () => {
     it("shows empty message when no sessions", async () => {
       await agentList();
-      expect(io.logs.some((l) => l.includes("No agent sessions"))).toBe(true);
+      expect(io.logs.some((l) => l.includes("(no agent sessions)"))).toBe(true);
     });
 
     it("shows sessions from files", async () => {
@@ -122,7 +122,7 @@ describe("agent commands", () => {
   describe("stop", () => {
     it("errors when no sessions exist", async () => {
       await expect(agentStop([])).rejects.toThrow("exit(1)");
-      expect(io.errors.some((l) => l.includes("No agent sessions"))).toBe(
+      expect(io.errors.some((l) => l.includes("(no agent sessions)"))).toBe(
         true,
       );
     });
@@ -211,7 +211,7 @@ describe("agent commands", () => {
   describe("logs", () => {
     it("errors when no sessions exist", async () => {
       await expect(agentLogs([])).rejects.toThrow("exit(1)");
-      expect(io.errors.some((l) => l.includes("No agent sessions"))).toBe(true);
+      expect(io.errors.some((l) => l.includes("(no agent sessions)"))).toBe(true);
     });
 
     it("errors when session not found", async () => {

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -506,91 +506,91 @@ describe("commands (integration)", () => {
   it("projects exits on server error", async () => {
     await setupMock(errorServer());
     const { projects } = await import("../src/commands/projects.mjs");
-    await expect(projects([])).rejects.toThrow("exit(1)");
+    await projects([]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("find exits on server error", async () => {
     await setupMock(errorServer());
     const { find } = await import("../src/commands/find.mjs");
-    await expect(find(["Foo"])).rejects.toThrow("exit(1)");
+    await find(["Foo"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("subtypes exits on server error", async () => {
     await setupMock(errorServer());
     const { subtypes } = await import("../src/commands/subtypes.mjs");
-    await expect(subtypes(["app.Foo"])).rejects.toThrow("exit(1)");
+    await subtypes(["app.Foo"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("hierarchy exits on server error", async () => {
     await setupMock(errorServer());
     const { hierarchy } = await import("../src/commands/hierarchy.mjs");
-    await expect(hierarchy(["app.Foo"])).rejects.toThrow("exit(1)");
+    await hierarchy(["app.Foo"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("implementors exits on server error", async () => {
     await setupMock(errorServer());
     const { implementors } = await import("../src/commands/implementors.mjs");
-    await expect(implementors(["app.Foo", "m"])).rejects.toThrow("exit(1)");
+    await implementors(["app.Foo", "m"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("type-info exits on server error", async () => {
     await setupMock(errorServer());
     const { typeInfo } = await import("../src/commands/type-info.mjs");
-    await expect(typeInfo(["app.Foo"])).rejects.toThrow("exit(1)");
+    await typeInfo(["app.Foo"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("errors exits on server error", async () => {
     await setupMock(errorServer());
     const { errors } = await import("../src/commands/errors.mjs");
-    await expect(errors([])).rejects.toThrow("exit(1)");
+    await errors([]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("build exits on server error", async () => {
     await setupMock(errorServer());
     const { build } = await import("../src/commands/build.mjs");
-    await expect(build(["--project", "my-client"])).rejects.toThrow("exit(1)");
+    await build(["--project", "my-client"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("project-info exits on server error", async () => {
     await setupMock(errorServer());
     const { projectInfo } = await import("../src/commands/project-info.mjs");
-    await expect(projectInfo(["proj"])).rejects.toThrow("exit(1)");
+    await projectInfo(["proj"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("organize-imports exits on server error", async () => {
     await setupMock(errorServer());
     const { organizeImports } = await import("../src/commands/refactoring.mjs");
-    await expect(organizeImports(["f.java"])).rejects.toThrow("exit(1)");
+    await organizeImports(["f.java"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("format exits on server error", async () => {
     await setupMock(errorServer());
     const { format } = await import("../src/commands/refactoring.mjs");
-    await expect(format(["f.java"])).rejects.toThrow("exit(1)");
+    await format(["f.java"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("rename exits on server error", async () => {
     await setupMock(errorServer());
     const { rename } = await import("../src/commands/refactoring.mjs");
-    await expect(rename(["app.Foo", "Bar"])).rejects.toThrow("exit(1)");
+    await rename(["app.Foo", "Bar"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("move exits on server error", async () => {
     await setupMock(errorServer());
     const { move } = await import("../src/commands/refactoring.mjs");
-    await expect(move(["app.Foo", "app.bar"])).rejects.toThrow("exit(1)");
+    await move(["app.Foo", "app.bar"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
@@ -769,16 +769,18 @@ describe("commands (integration)", () => {
     await expect(launchConsole([])).rejects.toThrow("exit(1)");
   });
 
-  it("launch console error exits", async () => {
+  it("launch console error does not exit 1", async () => {
     await setupMock(errorServer());
     const { launchConsole } = await import("../src/commands/launch.mjs");
-    await expect(launchConsole(["my-server"])).rejects.toThrow("exit(1)");
+    await launchConsole(["my-server"]);
+    expect(io.errors[0]).toContain("Something went wrong");
   });
 
-  it("launch list error exits", async () => {
+  it("launch list error does not exit 1", async () => {
     await setupMock(errorServer());
     const { launchList } = await import("../src/commands/launch.mjs");
-    await expect(launchList()).rejects.toThrow("exit(1)");
+    await launchList();
+    expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("launch console --follow streams text/plain", async () => {
@@ -896,21 +898,21 @@ describe("commands (integration)", () => {
   it("editors exits on server error", async () => {
     await setupMock(errorServer());
     const { editors } = await import("../src/commands/editor.mjs");
-    await expect(editors()).rejects.toThrow("exit(1)");
+    await editors();
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("open exits on server error", async () => {
     await setupMock(errorServer());
     const { open } = await import("../src/commands/editor.mjs");
-    await expect(open(["app.Foo"])).rejects.toThrow("exit(1)");
+    await open(["app.Foo"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("references exits on server error", async () => {
     await setupMock(errorServer());
     const { references } = await import("../src/commands/references.mjs");
-    await expect(references(["app.Foo"])).rejects.toThrow("exit(1)");
+    await references(["app.Foo"]);
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
@@ -1073,13 +1075,13 @@ describe("commands (integration)", () => {
     expect(out).toContain("`org.eclipse.core.runtime.CoreException`");
   });
 
-  it("source with error", async () => {
+  it("source with error does not exit 1", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Type not found: Bogus" }));
     });
     const { source } = await import("../src/commands/source.mjs");
-    await expect(source(["Bogus"])).rejects.toThrow("exit(1)");
+    await source(["Bogus"]);
     expect(io.errors[0]).toContain("not found");
   });
 
@@ -1366,5 +1368,83 @@ describe("commands (integration)", () => {
     await projectInfo(["m8-server"]);
     const out = io.logs.join("\n");
     expect(out).toContain("/d/git/m8/m8-server");
+  });
+
+  // ---- Empty states: consistent (no <entity>) format ----
+
+  it("all empty states use (no <entity>) format", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("[]");
+    });
+
+    const cases = [
+      { mod: "../src/commands/find.mjs", fn: "find", args: ["X"], expected: "(no results)" },
+      { mod: "../src/commands/subtypes.mjs", fn: "subtypes", args: ["X"], expected: "(no subtypes)" },
+      { mod: "../src/commands/implementors.mjs", fn: "implementors", args: ["X", "m"], expected: "(no implementors)" },
+      { mod: "../src/commands/references.mjs", fn: "references", args: ["X"], expected: "(no references)" },
+      { mod: "../src/commands/errors.mjs", fn: "errors", args: [], expected: "(no errors)" },
+    ];
+
+    for (const { mod, fn, args, expected } of cases) {
+      io.logs.length = 0;
+      vi.resetModules();
+      vi.doMock("../src/bridge-env.mjs", () => ({ getPinnedBridge: () => null }));
+      vi.doMock("../src/discovery.mjs", () => ({
+        discoverInstances: async () => [],
+        findInstance: async () => ({ port, token: null, pid: process.pid, workspace: "/test", host: "127.0.0.1" }),
+      }));
+      const module = await import(mod);
+      await module[fn](args);
+      expect(io.logs[0]).toBe(expected);
+    }
+  });
+
+  // ---- Domain errors: exit 0, not exit 1 ----
+
+  it("domain errors do not call process.exit", async () => {
+    await setupMock(errorServer());
+
+    const cases = [
+      { mod: "../src/commands/find.mjs", fn: "find", args: ["X"] },
+      { mod: "../src/commands/subtypes.mjs", fn: "subtypes", args: ["X"] },
+      { mod: "../src/commands/references.mjs", fn: "references", args: ["X"] },
+      { mod: "../src/commands/errors.mjs", fn: "errors", args: [] },
+      { mod: "../src/commands/type-info.mjs", fn: "typeInfo", args: ["X"] },
+      { mod: "../src/commands/hierarchy.mjs", fn: "hierarchy", args: ["X"] },
+      { mod: "../src/commands/projects.mjs", fn: "projects", args: [] },
+    ];
+
+    for (const { mod, fn, args } of cases) {
+      io.errors.length = 0;
+      vi.resetModules();
+      vi.doMock("../src/bridge-env.mjs", () => ({ getPinnedBridge: () => null }));
+      vi.doMock("../src/discovery.mjs", () => ({
+        discoverInstances: async () => [],
+        findInstance: async () => ({ port, token: null, pid: process.pid, workspace: "/test", host: "127.0.0.1" }),
+      }));
+      const module = await import(mod);
+      // Should NOT throw — returns normally (exit 0)
+      await module[fn](args);
+      expect(io.errors[0]).toContain("Something went wrong");
+    }
+  });
+
+  // ---- Missing args: still exit 1 ----
+
+  it("missing args still exit 1", async () => {
+    const cases = [
+      { mod: "../src/commands/find.mjs", fn: "find", args: [] },
+      { mod: "../src/commands/subtypes.mjs", fn: "subtypes", args: [] },
+      { mod: "../src/commands/type-info.mjs", fn: "typeInfo", args: [] },
+      { mod: "../src/commands/hierarchy.mjs", fn: "hierarchy", args: [] },
+      { mod: "../src/commands/references.mjs", fn: "references", args: [] },
+    ];
+
+    for (const { mod, fn, args } of cases) {
+      vi.resetModules();
+      const module = await import(mod);
+      await expect(module[fn](args)).rejects.toThrow("exit(1)");
+    }
   });
 });

--- a/cli/test/test-commands.test.mjs
+++ b/cli/test/test-commands.test.mjs
@@ -117,13 +117,14 @@ describe("test commands", () => {
     expect(io.errors[0]).toContain("Usage");
   });
 
-  it("test run exits on server error", async () => {
+  it("test run does not exit 1 on server error", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Something went wrong" }));
     });
     const { testRun } = await import("../src/commands/test-run.mjs");
-    await expect(testRun(["com.example.FooTest", "-q"])).rejects.toThrow("exit(1)");
+    await testRun(["com.example.FooTest", "-q"]);
+    expect(io.errors[0]).toContain("Something went wrong");
   });
 
   it("test run sends method param with FQMN#method", async () => {
@@ -280,13 +281,13 @@ describe("test commands", () => {
     await testStatus(["s", "--all"]);
   });
 
-  it("test status exits on server error", async () => {
+  it("test status does not exit 1 on server error", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Session not found" }));
     });
     const { testStatus } = await import("../src/commands/test-status.mjs");
-    await expect(testStatus(["bad-session"])).rejects.toThrow("exit(1)");
+    await testStatus(["bad-session"]);
     expect(io.errors[0]).toContain("Session not found");
   });
 
@@ -316,12 +317,13 @@ describe("test commands", () => {
     expect(io.logs[0]).toContain("no test sessions");
   });
 
-  it("test sessions exits on error", async () => {
+  it("test sessions does not exit 1 on error", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "fail" }));
     });
     const { testSessions } = await import("../src/commands/test-sessions.mjs");
-    await expect(testSessions()).rejects.toThrow("exit(1)");
+    await testSessions();
+    expect(io.errors[0]).toContain("fail");
   });
 });


### PR DESCRIPTION
## Summary

- Domain responses (Type not found, empty results) now exit 0 instead of exit 1
- exit(1) reserved for: missing args (usage error) and connection failures (tool broken)
- Standardize empty state messages to (no entity) format across all commands
- 28 exit code fixes across 18 command files

## Test plan

- [x] npm test -- 473 tests pass
- [x] Comprehensive test: empty states format for 5 commands
- [x] Comprehensive test: domain errors exit 0 for 7 commands
- [x] Comprehensive test: missing args still exit 1 for 5 commands
- [ ] Manual: jdt refs NonExistent#foo -- should not be red in Claude Code