### PR TITLE
Show Object in supertypes, reject hierarchy of Object

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/RefCountContractTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/RefCountContractTest.java
@@ -481,13 +481,16 @@ public class RefCountContractTest {
         void dogSupertypesExact() throws Exception {
             var json = typeJson("test.model.Dog");
             var supers = json.getAsJsonArray("supertypes");
-            assertEquals(1, supers.size());
+            assertEquals(2, supers.size());
             assertEquals("test.model.Animal",
                     supers.get(0).getAsJsonObject()
                             .get("fqn").getAsString());
             assertEquals("interface",
                     supers.get(0).getAsJsonObject()
                             .get("kind").getAsString());
+            assertEquals("java.lang.Object",
+                    supers.get(1).getAsJsonObject()
+                            .get("fqn").getAsString());
         }
 
         @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/SearchIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/SearchIntegrationTest.java
@@ -139,7 +139,27 @@ public class SearchIntegrationTest {
         assertNotNull(obj.get("error"));
     }
 
+    @Test
+    public void subtypesRejectsObject() throws Exception {
+        String json = handler.handleSubtypes(
+                Map.of("class", "java.lang.Object"));
+        JsonObject obj = JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("error").getAsString()
+                .contains("too broad"));
+    }
+
     // ---- /hierarchy ----
+
+    @Test
+    public void hierarchyRejectsObject() throws Exception {
+        String json = handler.handleHierarchy(
+                Map.of("class", "java.lang.Object"));
+        JsonObject obj = JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("error").getAsString()
+                .contains("too broad"));
+    }
 
     @Test
     public void hierarchyOfDog() throws Exception {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TypeLevelHierarchyTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TypeLevelHierarchyTest.java
@@ -103,11 +103,11 @@ public class TypeLevelHierarchyTest {
         }
 
         @Test
-        void objectNotInSupertypes() throws Exception {
+        void objectInSupertypes() throws Exception {
             JsonObject obj = sourceJson("test.model.Dog");
             JsonArray supers = obj.getAsJsonArray("supertypes");
-            assertFalse(hasInArray(supers, "java.lang.Object"),
-                    "Object should be filtered");
+            assertTrue(hasInArray(supers, "java.lang.Object"),
+                    "Object should be in supertypes");
         }
     }
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/SearchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/SearchHandler.java
@@ -266,6 +266,10 @@ class SearchHandler {
         if (fqn == null || fqn.isBlank()) {
             return HttpServer.jsonError("Missing 'class' parameter");
         }
+        if ("java.lang.Object".equals(fqn)) {
+            return HttpServer.jsonError(
+                    "Hierarchy too broad for java.lang.Object");
+        }
 
         IType type = JdtUtils.findType(fqn);
         if (type == null) {
@@ -285,6 +289,10 @@ class SearchHandler {
         String fqn = params.get("class");
         if (fqn == null || fqn.isBlank()) {
             return HttpServer.jsonError("Missing 'class' parameter");
+        }
+        if ("java.lang.Object".equals(fqn)) {
+            return HttpServer.jsonError(
+                    "Hierarchy too broad for java.lang.Object");
         }
 
         IType type = JdtUtils.findType(fqn);

--- a/plugin/src/io/github/kaluchi/jdtbridge/SourceReport.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/SourceReport.java
@@ -382,16 +382,17 @@ class SourceReport {
                 addSupersRecursive(arr, h, iface, depth + 1);
             }
         } catch (Exception e) { /* skip */ }
-        // Superclass chain
+        // Superclass chain (including java.lang.Object)
         IType superclass = h.getSuperclass(type);
         if (superclass == null) return;
-        String fqn;
-        try { fqn = superclass.getFullyQualifiedName(); }
-        catch (Exception e) { return; }
-        if ("java.lang.Object".equals(fqn)) return;
         var s = hierEntry(superclass);
         s.addProperty("depth", depth);
         arr.add(s);
+        // Object has no further supers — stop recursion
+        try {
+            if ("java.lang.Object".equals(superclass.getFullyQualifiedName()))
+                return;
+        } catch (Exception e) { return; }
         addSupersRecursive(arr, h, superclass, depth + 1);
     }
 


### PR DESCRIPTION
## Summary

- Include java.lang.Object in supertypes (was filtered, now shown)
- Reject hierarchy/subtypes for java.lang.Object with domain error (newTypeHierarchy hangs)
- 2 new plugin tests for the rejection

## Test plan

- [x] Plugin tests -- 615 passed
- [x] CLI tests -- 473 passed
- [x] jdt hier test.model.Dog -- shows Object in supertypes
- [x] jdt hier java.lang.Object -- returns error, does not hang
- [x] jdt subtypes java.lang.Object -- returns error