### PR TITLE
Improve find format: KIND/FQN/ORIGIN table, fix typeKindStr

### DIFF
--- a/cli/src/commands/find.mjs
+++ b/cli/src/commands/find.mjs
@@ -1,6 +1,9 @@
 import { get } from "../client.mjs";
 import { extractPositional } from "../args.mjs";
 import { stripProject, toSandboxPath } from "../paths.mjs";
+import { formatTable } from "../format/table.mjs";
+
+const BADGE = { class: "[C]", interface: "[I]", enum: "[E]", annotation: "[A]" };
 
 export async function find(args) {
   const pos = extractPositional(args);
@@ -20,9 +23,23 @@ export async function find(args) {
     console.log("(no results)");
     return;
   }
-  for (const r of results) {
-    console.log(`${r.fqn}  ${toSandboxPath(stripProject(r.file))}`);
-  }
+
+  // Deduplicate binary types (appear once per project on classpath)
+  const seen = new Set();
+  const deduped = results.filter((r) => {
+    if (!r.binary) return true;
+    if (seen.has(r.fqn)) return false;
+    seen.add(r.fqn);
+    return true;
+  });
+
+  const headers = ["KIND", "FQN", "ORIGIN"];
+  const rows = deduped.map((r) => [
+    BADGE[r.kind] || "[C]",
+    `\`${r.fqn}\``,
+    r.binary ? (r.origin || "binary") : toSandboxPath(stripProject(r.file)),
+  ]);
+  console.log(formatTable(headers, rows));
 }
 
 export const help = `Find type declarations by name, wildcard, or package.

--- a/cli/src/commands/projects.mjs
+++ b/cli/src/commands/projects.mjs
@@ -1,4 +1,5 @@
 import { get } from "../client.mjs";
+import { dim } from "../color.mjs";
 
 export async function projects() {
   const results = await get("/projects");
@@ -6,7 +7,12 @@ export async function projects() {
     console.error(results.error);
     return;
   }
-  for (const p of results) console.log(p);
+  if (results.length === 0) {
+    console.log("(no projects)");
+    return;
+  }
+  console.log(`${results.length} projects:\n`);
+  for (const p of results) console.log(`- \`${p}\``);
 }
 
 export const help = `List all Java projects in the Eclipse workspace.

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -73,56 +73,85 @@ describe("commands (integration)", () => {
     });
     const { projects } = await import("../src/commands/projects.mjs");
     await projects([]);
-    expect(io.logs).toEqual(["my-server", "my-client"]);
+    const out = io.logs.join("\n");
+    expect(out).toContain("2 projects");
+    expect(out).toContain("`my-server`");
+    expect(out).toContain("`my-client`");
   });
 
-  it("find shows FQN and file", async () => {
+  it("find shows table with headers", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { fqn: "com.example.Foo", file: "/my-server/src/main/java/app/my/Foo.java" },
+        { fqn: "com.example.Foo", file: "/my-server/src/Foo.java", kind: "class" },
       ]));
     });
     const { find } = await import("../src/commands/find.mjs");
     await find(["Foo"]);
-    expect(io.logs[0]).toContain("com.example.Foo");
-    expect(io.logs[0]).toContain("my-server/src/main/java/app/my/Foo.java");
+    const out = io.logs[0];
+    expect(out).toContain("KIND");
+    expect(out).toContain("FQN");
+    expect(out).toContain("ORIGIN");
+    expect(out).toContain("[C]");
+    expect(out).toContain("`com.example.Foo`");
+    expect(out).toContain("my-server/src/Foo.java");
   });
 
-  it("find shows absolute Windows path on host", async () => {
+  it("find deduplicates binary types", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { fqn: "com.example.Foo", file: "D:/git/project/src/Foo.java" },
-      ]));
-    });
-    const { find } = await import("../src/commands/find.mjs");
-    await find(["Foo"]);
-    expect(io.logs[0]).toContain(toSandboxPath("D:/git/project/src/Foo.java"));
-  });
-
-  it("find shows JAR project path on host", async () => {
-    await setupMock((req, res) => {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify([
-        { fqn: "javax.swing.JPanel", file: "D:/git/m8/m8-client" },
+        { fqn: "javax.swing.JPanel", file: "D:/m8/m8-client", binary: true, origin: "rt.jar" },
+        { fqn: "javax.swing.JPanel", file: "D:/m8/m8-server", binary: true, origin: "rt.jar" },
       ]));
     });
     const { find } = await import("../src/commands/find.mjs");
     await find(["JPanel"]);
-    expect(io.logs[0]).toContain(toSandboxPath("D:/git/m8/m8-client"));
+    const out = io.logs[0];
+    expect(out.match(/javax\.swing\.JPanel/g).length).toBe(1);
+    expect(out).toContain("rt.jar");
   });
 
-  it("find shows backslash Windows path", async () => {
+  it("find shows source path and binary origin", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { fqn: "com.example.Bar", file: "D:\\git\\project\\src\\Bar.java" },
+        { fqn: "com.example.Foo", file: "D:/git/project/src/Foo.java", kind: "class" },
+        { fqn: "javax.swing.JPanel", file: "D:/m8/m8-client", kind: "class", binary: true, origin: "rt.jar" },
       ]));
     });
     const { find } = await import("../src/commands/find.mjs");
-    await find(["Bar"]);
-    expect(io.logs[0]).toContain(toSandboxPath("D:\\git\\project\\src\\Bar.java"));
+    await find(["Foo"]);
+    const out = io.logs[0];
+    expect(out).toContain(toSandboxPath("D:/git/project/src/Foo.java"));
+    expect(out).toContain("rt.jar");
+  });
+
+  it("find shows interface badge", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([
+        { fqn: "com.example.Service", file: "/my-server/src/Service.java", kind: "interface" },
+      ]));
+    });
+    const { find } = await import("../src/commands/find.mjs");
+    await find(["Service"]);
+    const out = io.logs[0];
+    expect(out).toContain("[I]");
+  });
+
+  it("find shows annotation badge", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([
+        { fqn: "org.junit.Test", kind: "annotation", binary: true, origin: "junit-4.13.2.jar" },
+      ]));
+    });
+    const { find } = await import("../src/commands/find.mjs");
+    await find(["Test"]);
+    const out = io.logs[0];
+    expect(out).toContain("[A]");
+    expect(out).toContain("junit-4.13.2.jar");
   });
 
   it("find shows no results message", async () => {
@@ -1189,40 +1218,43 @@ describe("commands (integration)", () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { fqn: "com.example.Foo", file: "D:/git/project/src/Foo.java" },
+        { fqn: "com.example.Foo", file: "D:/git/project/src/Foo.java", kind: "class" },
       ]));
     });
     mockSandboxPaths();
     const { find } = await import("../src/commands/find.mjs");
     await find(["Foo"]);
-    expect(io.logs[0]).toContain("/d/git/project/src/Foo.java");
+    const out = io.logs[0];
+    expect(out).toContain("/d/git/project/src/Foo.java");
   });
 
-  it("find converts JAR project path in sandbox", async () => {
+  it("find binary shows origin not path in sandbox", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { fqn: "javax.swing.table.TableModel", file: "D:/git/m8/m8-client" },
+        { fqn: "javax.swing.table.TableModel", file: "D:/m8/m8-client", binary: true, kind: "interface", origin: "rt.jar" },
       ]));
     });
     mockSandboxPaths();
     const { find } = await import("../src/commands/find.mjs");
     await find(["TableModel"]);
-    expect(io.logs[0]).toContain("/d/git/m8/m8-client");
+    const out = io.logs[0];
+    expect(out).toContain("rt.jar");
+    expect(out).not.toContain("/d/m8");
   });
 
   it("find keeps workspace-relative path unchanged in sandbox", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { fqn: "com.example.Foo", file: "/my-server/src/Foo.java" },
+        { fqn: "com.example.Foo", file: "/my-server/src/Foo.java", kind: "class" },
       ]));
     });
     mockSandboxPaths();
     const { find } = await import("../src/commands/find.mjs");
     await find(["Foo"]);
-    expect(io.logs[0]).toContain("my-server/src/Foo.java");
-    expect(io.logs[0]).not.toContain("/d/");
+    const out = io.logs[0];
+    expect(out).toContain("my-server/src/Foo.java");
   });
 
   it("errors converts path in sandbox", async () => {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/SearchIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/SearchIntegrationTest.java
@@ -76,6 +76,139 @@ public class SearchIntegrationTest {
     }
 
     @Test
+    public void findBinaryTypeHasFlag() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "ArrayList"));
+        JsonArray arr = parseArray(json);
+        assertTrue(arr.size() > 0, "Should find ArrayList");
+        boolean anyBinary = false;
+        for (var el : arr) {
+            var obj = el.getAsJsonObject();
+            if (obj.has("binary") && obj.get("binary").getAsBoolean()) {
+                anyBinary = true;
+                break;
+            }
+        }
+        assertTrue(anyBinary,
+                "ArrayList should have binary flag");
+    }
+
+    @Test
+    public void findSourceTypeNoBinaryFlag() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "Animal"));
+        JsonArray arr = parseArray(json);
+        var animal = findByFqn(arr, "test.model.Animal");
+        assertNotNull(animal);
+        assertFalse(animal.has("binary"),
+                "Source type should not have binary flag");
+    }
+
+    @Test
+    public void findSourceTypeHasKind() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "Animal"));
+        JsonArray arr = parseArray(json);
+        var animal = findByFqn(arr, "test.model.Animal");
+        assertNotNull(animal);
+        assertEquals("interface",
+                animal.get("kind").getAsString(),
+                "Animal should be interface");
+    }
+
+    @Test
+    public void findSourceTypeHasOriginProject() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "Dog"));
+        JsonArray arr = parseArray(json);
+        var dog = findByFqn(arr, "test.model.Dog");
+        assertNotNull(dog);
+        assertTrue(dog.has("origin"),
+                "Source type should have origin");
+        assertFalse(dog.get("origin").getAsString().isEmpty(),
+                "Origin should not be empty for source type");
+    }
+
+    @Test
+    public void findBinaryTypeHasOriginJar() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "ArrayList"));
+        JsonArray arr = parseArray(json);
+        boolean anyWithJar = false;
+        for (var el : arr) {
+            var obj = el.getAsJsonObject();
+            if (obj.has("binary") && obj.has("origin")) {
+                String origin = obj.get("origin").getAsString();
+                if (origin.endsWith(".jar")) {
+                    anyWithJar = true;
+                    break;
+                }
+            }
+        }
+        assertTrue(anyWithJar,
+                "Binary ArrayList should have .jar origin");
+    }
+
+    @Test
+    public void findBinaryTypeHasKind() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "ArrayList"));
+        JsonArray arr = parseArray(json);
+        boolean anyWithKind = false;
+        for (var el : arr) {
+            var obj = el.getAsJsonObject();
+            if (obj.has("kind")) {
+                anyWithKind = true;
+                break;
+            }
+        }
+        assertTrue(anyWithKind,
+                "Binary type should have kind field");
+    }
+
+    @Test
+    public void findInterfaceTypeKind() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "Animal"));
+        JsonArray arr = parseArray(json);
+        var animal = findByFqn(arr, "test.model.Animal");
+        assertNotNull(animal);
+        assertEquals("interface",
+                animal.get("kind").getAsString(),
+                "Animal is an interface");
+    }
+
+    @Test
+    public void findAnnotationTypeKind() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "Marker"));
+        JsonArray arr = parseArray(json);
+        var marker = findByFqn(arr, "test.edge.Marker");
+        assertNotNull(marker, "Should find Marker annotation");
+        assertEquals("annotation",
+                marker.get("kind").getAsString(),
+                "Marker should have annotation kind");
+    }
+
+    @Test
+    public void findEnumTypeKind() throws Exception {
+        String json = handler.handleFind(
+                Map.of("name", "ElementType"));
+        JsonArray arr = parseArray(json);
+        boolean anyEnum = false;
+        for (var el : arr) {
+            var obj = el.getAsJsonObject();
+            if ("enum".equals(
+                    obj.has("kind") ? obj.get("kind").getAsString() : "")) {
+                anyEnum = true;
+                break;
+            }
+        }
+        assertTrue(anyEnum,
+                "ElementType should have enum kind");
+    }
+
+    @Test
     public void findByPackage() throws Exception {
         String json = handler.handleFind(
                 Map.of("name", "test.model"));

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/SourceReportTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/SourceReportTest.java
@@ -176,4 +176,39 @@ public class SourceReportTest {
                     "Should have interface typeKind: " + json);
         }
     }
+
+    @Nested
+    class TypeKindStr {
+
+        @BeforeAll
+        static void setUp() throws Exception { TestFixture.create(); }
+
+        @Test
+        void classType() throws Exception {
+            IType type = JdtUtils.findType("test.model.Dog");
+            assertEquals("class", SourceReport.typeKindStr(type));
+        }
+
+        @Test
+        void interfaceType() throws Exception {
+            IType type = JdtUtils.findType("test.model.Animal");
+            assertNotNull(type, "Animal should be found");
+            assertEquals("interface", SourceReport.typeKindStr(type));
+        }
+
+        @Test
+        void annotationType() throws Exception {
+            IType type = JdtUtils.findType("test.edge.Marker");
+            assertNotNull(type, "Marker should be found");
+            assertEquals("annotation", SourceReport.typeKindStr(type),
+                    "Annotation must be detected before interface");
+        }
+
+        @Test
+        void enumType() throws Exception {
+            IType type = JdtUtils.findType("test.edge.Color");
+            assertNotNull(type, "Color should be found");
+            assertEquals("enum", SourceReport.typeKindStr(type));
+        }
+    }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/SearchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/SearchHandler.java
@@ -97,12 +97,7 @@ class SearchHandler {
                     public void acceptSearchMatch(SearchMatch match) {
                         if (match.getElement() instanceof IType type) {
                             if (sourceOnly && type.isBinary()) return;
-                            var e = new JsonObject();
-                            e.addProperty("fqn",
-                                    type.getFullyQualifiedName());
-                            e.addProperty("file",
-                                    resourcePath(match));
-                            arr.add(e);
+                            arr.add(findEntry(type, resourcePath(match)));
                         }
                     }
                 },
@@ -156,23 +151,13 @@ class SearchHandler {
                 for (ICompilationUnit cu
                         : pkg.getCompilationUnits()) {
                     for (IType type : cu.getTypes()) {
-                        var e = new JsonObject();
-                        e.addProperty("fqn",
-                                type.getFullyQualifiedName());
-                        e.addProperty("file",
-                                resourcePath(type));
-                        arr.add(e);
+                        arr.add(findEntry(type, resourcePath(type)));
                     }
                 }
                 if (!sourceOnly) {
                     for (var cf : pkg.getOrdinaryClassFiles()) {
-                        IType type = cf.getType();
-                        var e = new JsonObject();
-                        e.addProperty("fqn",
-                                type.getFullyQualifiedName());
-                        e.addProperty("file",
-                                type.getPath().toOSString());
-                        arr.add(e);
+                        arr.add(findEntry(cf.getType(),
+                                cf.getType().getPath().toOSString()));
                     }
                 }
             }
@@ -651,6 +636,29 @@ class SearchHandler {
     }
 
     // ---- Helpers ----
+
+    /** Build a find result entry with FQN, kind, origin, binary. */
+    private static JsonObject findEntry(IType type, String file) {
+        var obj = new JsonObject();
+        obj.addProperty("fqn", type.getFullyQualifiedName());
+        obj.addProperty("file", file);
+        obj.addProperty("kind", SourceReport.typeKindStr(type));
+        if (type.isBinary()) {
+            obj.addProperty("binary", true);
+            try {
+                var pkg = type.getPackageFragment();
+                var root = (IPackageFragmentRoot) pkg.getParent();
+                var path = root.getPath();
+                obj.addProperty("origin", path.lastSegment());
+            } catch (Exception e) {
+                obj.addProperty("origin", "binary");
+            }
+        } else {
+            obj.addProperty("origin",
+                    type.getJavaProject().getElementName());
+        }
+        return obj;
+    }
 
     private JsonObject typeEntry(IType type) {
         var obj = new JsonObject();

--- a/plugin/src/io/github/kaluchi/jdtbridge/SourceReport.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/SourceReport.java
@@ -406,11 +406,11 @@ class SourceReport {
         }
     }
 
-    private static String typeKindStr(IType type) {
+    static String typeKindStr(IType type) {
         try {
-            if (type.isInterface()) return "interface";
-            if (type.isEnum()) return "enum";
             if (type.isAnnotation()) return "annotation";
+            if (type.isEnum()) return "enum";
+            if (type.isInterface()) return "interface";
         } catch (Exception e) { /* ignore */ }
         return "class";
     }


### PR DESCRIPTION
## Summary

- find outputs aligned table with KIND, FQN, ORIGIN headers
- Binary types deduplicated and show JAR name as origin
- Source types show absolute OS file path as origin
- typeKindStr checks isAnnotation before isInterface (annotation is interface in Java)
- projects shows count + backtick-wrapped names

## Test plan

- [x] Plugin tests: SourceReportTest 19 passed, SearchIntegrationTest 41 passed
- [x] CLI tests: 474 passed
- [x] jdt find Test -- shows annotation/class badges + JAR names
- [x] jdt find DiagnosticsHandler -- shows source file path
- [x] jdt projects -- shows count + backticks