### PR TITLE
Add startedAt to test sessions for relative time

### DIFF
--- a/cli/src/commands/test-sessions.mjs
+++ b/cli/src/commands/test-sessions.mjs
@@ -21,8 +21,7 @@ export async function testSessions() {
     const time = Number.isFinite(s.time) && s.time > 0
       ? `${s.time.toFixed(1)}s` : "";
     const label = s.label && s.label !== s.session ? s.label : "";
-    const tsMatch = s.session.match(/-(\d{13})$/);
-    const startMs = tsMatch ? Number(tsMatch[1]) : 0;
+    const startMs = s.startedAt || 0;
     let status;
     if (s.state === "running") {
       status = startMs ? `running, started ${ago(now - startMs)}` : "running";

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestSessionHandler.java
@@ -124,6 +124,7 @@ class TestSessionHandler {
             obj.addProperty("time",
                     Double.isNaN(ts.time)
                             ? 0.0 : ts.time);
+            obj.addProperty("startedAt", ts.startedAt);
             arr.add(obj);
         }
         return arr.toString();

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestSessionTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestSessionTracker.java
@@ -29,6 +29,7 @@ class TestSessionTracker extends TestRunListener {
 
     static class TrackedTestSession {
         final String name;
+        final long startedAt = System.currentTimeMillis();
         volatile String label;
         volatile String project;
         volatile String runner;


### PR DESCRIPTION
## Summary

- Server: startedAt field in TrackedTestSession + JSON response
- CLI: STATUS column shows relative time from startedAt

## Test plan

- [x] CLI tests: 474 passed
- [x] Plugin builds without errors
- [x] jdt test sessions -- shows finished Xm ago