### PR TITLE
Add jdt status intro, full subcommand help, launch logs cross-refs

### DIFF
--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -107,8 +107,8 @@ async function launchDispatch(args) {
   }
   const cmd = launchSubcommands[sub];
   if (!cmd) {
-    console.error(`Unknown launch subcommand: ${sub}`);
-    console.log(launchHelp);
+    console.error(`Unknown launch subcommand: ${sub}\n`);
+    printFullSubcommandHelp("launch", launchSubcommands);
     process.exit(1);
   }
   await cmd.fn(rest);
@@ -137,8 +137,8 @@ async function testDispatch(args) {
   }
   const cmd = testSubcommands[sub];
   if (!cmd) {
-    console.error(`Unknown test subcommand: ${sub}`);
-    console.log(testHelp);
+    console.error(`Unknown test subcommand: ${sub}\n`);
+    printFullSubcommandHelp("test", testSubcommands);
     process.exit(1);
   }
   await cmd.fn(rest);
@@ -171,8 +171,8 @@ async function agentDispatch(args) {
   }
   const cmd = agentSubcommands[sub];
   if (!cmd) {
-    console.error(`Unknown agent subcommand: ${sub}`);
-    console.log(agentHelp);
+    console.error(`Unknown agent subcommand: ${sub}\n`);
+    printFullSubcommandHelp("agent", agentSubcommands);
     process.exit(1);
   }
   await cmd.fn(rest);
@@ -238,6 +238,18 @@ function resolve(name) {
 function fmtAliases(name) {
   const list = aliasesOf[name];
   return list ? " " + dim("(" + list.join(", ") + ")") : "";
+}
+
+function printFullSubcommandHelp(parentName, subcommands) {
+  const names = Object.keys(subcommands);
+  console.log(`jdt ${parentName} has ${names.length} subcommands: ${names.join(", ")}\n`);
+  for (const [name, { help }] of Object.entries(subcommands)) {
+    if (help) {
+      console.log(`--- jdt ${parentName} ${name} ---\n`);
+      console.log(help);
+      console.log();
+    }
+  }
 }
 
 function printOverview() {

--- a/cli/src/commands/git.mjs
+++ b/cli/src/commands/git.mjs
@@ -16,7 +16,8 @@ export async function git(args = []) {
   if (!sub || sub === "list" || sub.startsWith("-")) {
     return gitList(sub === "list" ? args.slice(1) : args);
   }
-  console.error(`Unknown git subcommand: ${sub}`);
+  console.error(`Unknown git subcommand: ${sub}\n`);
+  console.log(help);
   process.exit(1);
 }
 

--- a/cli/src/commands/status.mjs
+++ b/cli/src/commands/status.mjs
@@ -13,7 +13,7 @@ import { basename } from "node:path";
 
 // ---- Public API ----
 
-const SECTION_NAMES = ["git", "editors", "errors", "launches", "tests", "projects", "guide"];
+const SECTION_NAMES = ["intro", "git", "editors", "errors", "launches", "tests", "projects", "guide"];
 
 export async function status(args) {
   const quiet = args.includes("-q") || args.includes("--quiet");
@@ -23,15 +23,20 @@ export async function status(args) {
     : SECTION_NAMES.filter((s) => s !== "guide");
 
   const results = [];
+
+  const showExtras = !quiet && requested.length === 0;
+  // Intro first — context for agents seeing this for the first time
+  if (showExtras || sections.includes("intro")) results.push(introSection());
+
   for (const name of sections) {
+    if (name === "intro" || name === "guide") continue;
     const renderer = RENDERERS[name];
     if (renderer) results.push(await renderer());
   }
 
-  const showGuide = !quiet && requested.length === 0;
-  if (showGuide) results.push(guideSection());
-  // Explicit "guide" in args always shows it
-  if (sections.includes("guide") && !showGuide) results.push(guideSection());
+  // Guide last
+  if (showExtras) results.push(guideSection());
+  if (sections.includes("guide") && !showExtras) results.push(guideSection());
 
   const single = results.length === 1;
   console.log(results.map((s) => formatSection(s, single)).join("\n\n"));
@@ -82,6 +87,33 @@ async function renderTests() {
 
 async function renderProjects() {
   return { title: "Projects", cmd: "jdt projects", body: cliCmd("jdt projects") };
+}
+
+function introSection() {
+  return {
+    title: "Intro",
+    cmd: "jdt status intro",
+    body: `Eclipse IDE is running and connected to this terminal via jdt CLI.
+jdt is a bridge that exposes the IDE's functions as terminal commands.
+Commands cover Java search, compilation, testing, and refactoring.
+Everything the developer sees and does in Eclipse GUI
+the AI assistant can access through jdt CLI against the same
+running instance. Same IDE, different interface.
+
+The sections below are live output from that instance.
+Each section is produced by a command shown in its header:
+  ## Intro      -> jdt status intro
+  ## Git        -> jdt status git
+  ## Editors    -> jdt status editors
+  ...
+  ## Guide      -> jdt status guide
+That command can be run standalone for a fresh snapshot: jdt status errors
+Several commands can be combined in one call: jdt status git editors projects
+Beyond this dashboard, jdt has 30+ more commands.
+Run jdt help for the full reference.
+
+-q suppresses this intro and the guide at the end.`,
+  };
 }
 
 function guideSection() {

--- a/cli/src/commands/test-run.mjs
+++ b/cli/src/commands/test-run.mjs
@@ -104,4 +104,10 @@ Examples:
   jdt test run com.example.MyTest                       run + show guide
   jdt test run com.example.MyTest --project Build -f    run with Build classpath
   jdt test run com.example.MyTest -f --all              run + stream all tests
-  jdt test run --project my-project -f                  run project tests + stream`;
+  jdt test run --project my-project -f                  run project tests + stream
+
+The session ID printed after launch is also the launch name.
+Use it with other commands:
+  jdt test status <session> -f        test pass/fail details
+  jdt launch logs <session>           console output (stdout, stderr, stack traces)
+  jdt launch logs <session> --tail 50 last 50 lines of console`;

--- a/cli/src/commands/test-sessions.mjs
+++ b/cli/src/commands/test-sessions.mjs
@@ -56,4 +56,9 @@ export const help = `List active and completed test sessions.
 
 Usage:  jdt test sessions
 
-Output: session ID, label, test counts, state — one session per line.`;
+Output: session ID, label, test counts, status — one session per line.
+
+The session ID is also the launch name. To see console output
+(stdout, stderr, stack traces) of a test run:
+  jdt launch logs <session-name>
+  jdt launch logs <session-name> --tail 50`;

--- a/cli/src/commands/test-status.mjs
+++ b/cli/src/commands/test-status.mjs
@@ -56,4 +56,8 @@ Flags:
 Examples:
   jdt test status jdtbridge-test-1234567890
   jdt test status jdtbridge-test-1234567890 -f
-  jdt test status jdtbridge-test-1234567890 --ignored`;
+  jdt test status jdtbridge-test-1234567890 --ignored
+
+Console output (stdout, stderr, stack traces):
+  jdt launch logs <session-name>
+  jdt launch logs <session-name> --tail 50`;

--- a/cli/test/status.test.mjs
+++ b/cli/test/status.test.mjs
@@ -110,8 +110,12 @@ describe("SECTION_NAMES", () => {
     expect(SECTION_NAMES).toContain("guide");
   });
 
-  it("has 7 sections", () => {
-    expect(SECTION_NAMES.length).toBe(7);
+  it("has 8 sections", () => {
+    expect(SECTION_NAMES.length).toBe(8);
+  });
+
+  it("contains intro", () => {
+    expect(SECTION_NAMES).toContain("intro");
   });
 });
 

--- a/ui/src/io/github/kaluchi/jdtbridge/ui/ProcessUtil.java
+++ b/ui/src/io/github/kaluchi/jdtbridge/ui/ProcessUtil.java
@@ -1,5 +1,9 @@
 package io.github.kaluchi.jdtbridge.ui;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +53,46 @@ public class ProcessUtil {
 			cmd.add(joinArgs(args));
 		}
 		return new ProcessBuilder(cmd);
+	}
+
+	/**
+	 * Open an interactive terminal window with a command.
+	 * Writes a temp script so the command runs and the terminal
+	 * stays open for the user to see output.
+	 * Same approach as cli/src/terminal.mjs.
+	 */
+	public static Process openTerminal(String command)
+			throws IOException {
+		List<String> cmd = new ArrayList<>();
+		if (IS_WINDOWS) {
+			Path script = Files.createTempFile("jdt-", ".cmd");
+			Files.writeString(script,
+					"@echo.\r\n@" + command
+							+ "\r\n@echo.\r\n@pause\r\n");
+			cmd.add("cmd.exe");
+			cmd.add("/c");
+			cmd.add("start");
+			cmd.add("JDT Bridge");
+			cmd.add("cmd.exe");
+			cmd.add("/K");
+			cmd.add("call " + script);
+		} else {
+			Path script = Files.createTempFile("jdt-", ".sh");
+			Files.writeString(script,
+					"#!/bin/bash\n" + command + "\nexec bash\n");
+			script.toFile().setExecutable(true);
+			if (IS_MAC) {
+				cmd.add("open");
+				cmd.add("-a");
+				cmd.add("Terminal");
+				cmd.add(script.toString());
+			} else {
+				cmd.add("x-terminal-emulator");
+				cmd.add("-e");
+				cmd.add(script.toString());
+			}
+		}
+		return new ProcessBuilder(cmd).start();
 	}
 
 	private static String joinArgs(String... args) {

--- a/ui/src/io/github/kaluchi/jdtbridge/ui/WelcomeStartupHandler.java
+++ b/ui/src/io/github/kaluchi/jdtbridge/ui/WelcomeStartupHandler.java
@@ -13,8 +13,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IStartup;
 
-import io.github.kaluchi.jdtbridge.ui.commands.OpenTerminalHandler;
-import io.github.kaluchi.jdtbridge.ui.preferences.PreferenceConstants;
+import io.github.kaluchi.jdtbridge.ui.ProcessUtil;
 
 /**
  * Replaces the core plugin's browser-based welcome with a native dialog.
@@ -69,13 +68,8 @@ public class WelcomeStartupHandler implements IStartup {
 						+ "Open a terminal to install now?");
 		if (openTerminal) {
 			try {
-				new ProcessBuilder(
-						OpenTerminalHandler.buildCommand(
-								PreferenceConstants.defaultTerminalCommand(),
-								org.eclipse.core.resources.ResourcesPlugin
-										.getWorkspace().getRoot()
-										.getLocation().toFile()))
-						.start();
+				ProcessUtil.openTerminal(
+						"npm install -g @kaluchi/jdtbridge");
 			} catch (Exception e) {
 				LOG.error("Failed to open terminal for setup", e);
 			}


### PR DESCRIPTION
## Summary

- jdt status intro section: explains what jdt is, how dashboard works, 30+ commands reference
- Unknown subcommand now prints full help for all subcommands (not just summary)
- Cross-references to jdt launch logs in test run, test status, test sessions help
- ProcessUtil.openTerminal(command) for WelcomeStartupHandler npm install

## Test plan

- [x] CLI tests: 516 passed
- [x] jdt test history shows full help with all subcommands
- [x] jdt status intro shows self-contained tool description
- [x] jdt status -q hides intro and guide
- [x] Welcome dialog opens terminal with npm install command