### PR TITLE
Update CLI reference to match current jdt help

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,45 +103,6 @@ An agent's context window is finite. Every irrelevant token displaces useful rea
 
 MCP is the right choice for things like database connections, OAuth flows, or cloud APIs with no CLI equivalent. But for developer tools where output filtering matters and humans benefit too, a CLI wins.
 
-## Commands
-
-Most commands have short aliases for quick typing.
-
-| Command | Alias | Eclipse | What it does |
-|---------|-------|---------|-------------|
-| `status [sections...] [-q]` | | Prt Scr | CLI screenshot of Eclipse — start here |
-| `find <Name\|package>` | | Ctrl+Shift+T | Find types by name, wildcard, or package |
-| `references <FQMN>` | `refs` | Ctrl+Shift+G | All references to a type, method, or field |
-| `subtypes <FQN>` | `subt` | F4 | All subtypes and implementors |
-| `hierarchy <FQN>` | `hier` | F4 | Full type hierarchy (supers + subs) |
-| `implementors <FQMN>` | `impl` | | Implementations of an interface method |
-| `type-info <FQN>` | `ti` | | Class overview (fields, methods, signatures) |
-| `source <FQMN>` | `src` | F3 | Source code + resolved references (hypertext navigation) |
-| `build [--project <name>]` | `b` | Ctrl+B | Build project (incremental or clean) |
-| `test run <FQN> [-f]` | | | Run JUnit tests with progress streaming |
-| `errors [--project <name>]` | `err` | | Compilation errors and diagnostics |
-| `refresh [<file>] [--project <name>]` | `r` | F5 | Manually notify Eclipse of file changes |
-| `maven update [--project <name>]` | | Alt+F5 | Update Maven project |
-| `organize-imports <file>` | `oi` | Ctrl+Shift+O | Organize imports (Eclipse settings) |
-| `format <file>` | `fmt` | Ctrl+Shift+F | Format code (Eclipse settings) |
-| `rename <FQMN> <new>` | | Alt+Shift+R | Rename type, method, or field across workspace |
-| `move <FQN> <package>` | | Alt+Shift+V | Move type to another package |
-| `open <FQMN>` | | F3 | Open in Eclipse editor |
-| `launch list` | | | List launches (running + terminated) |
-| `launch configs` | | | List saved launch configurations (MRU order) |
-| `launch run <config> [-f] [-q]` | | | Launch a configuration (`-f` to stream) |
-| `launch debug <config> [-f] [-q]` | | F11 | Launch in debug mode |
-| `launch logs <name> [-f]` | | | Show console output (`-f` to stream) |
-| `launch stop <name>` | | Ctrl+F2 | Stop a running launch |
-| `launch clear [name]` | | | Remove terminated launches |
-| `projects` | | | List workspace projects (name, location, repo) |
-| `project-info <name>` | `pi` | | Project overview (packages, types, methods) |
-| `editors` | `ed` | Ctrl+E | Open editor tabs (FQN, project, path) |
-| `git [list] [repo...]` | | | Git repos, branches, dirty state |
-| `setup [--check\|--remove]` | | | Install, check, or remove Eclipse plugin |
-
-Run `jdt help <command>` for detailed flags and options.
-
 ## How it works
 
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,13 +19,17 @@ jdt setup --skip-build          # reinstall last build
 jdt setup --clean               # clean build (mvn clean verify)
 jdt setup --remove              # uninstall plugin from Eclipse
 jdt setup --eclipse <path>      # specify Eclipse path (saved to config)
+jdt setup --claude              # configure Claude Code for this project (permissions + hooks)
+jdt setup --remove-claude       # remove JDT Bridge hooks from Claude Code settings
 ```
 
-If Eclipse is running, you will be prompted to stop it. After install, Eclipse restarts automatically with the same workspace.
+Eclipse must be stopped for install/update/remove operations. If running, you will be prompted to stop it. After install, Eclipse restarts automatically with the same workspace.
 
 ## Commands
 
 Run `jdt help <command>` for detailed flags and examples. Most commands have short aliases.
+
+All data-returning commands support `--json` for structured output (JSON snapshot, or JSONL when streaming with `-f`).
 
 ### Dashboard
 
@@ -36,13 +40,13 @@ jdt status [sections...] [-q]                          # workspace overview (sta
 ### Search & navigation
 
 ```bash
-jdt find <Name|package> [--source-only]                 # find types by name, wildcard, or package
-jdt references <FQMN> [--field <name>]                  # (alias: refs) references to type/method/field
+jdt find <Name|*Pattern*|pkg> [--source-only]          # find types by name, wildcard, or package
+jdt references <FQMN> [--field <name>]                 # (alias: refs) references to type/method/field
 jdt subtypes <FQN>                                     # (alias: subt) all subtypes/implementors
 jdt hierarchy <FQN>                                    # (alias: hier) supers + interfaces + subtypes
 jdt implementors <FQMN>                                # (alias: impl) implementations of interface method
 jdt type-info <FQN>                                    # (alias: ti) class overview (fields, methods)
-jdt source <FQMN>                                      # (alias: src) source code (project + libraries)
+jdt source <FQMN> [<FQMN> ...]                         # (alias: src) source code (project + libraries)
 ```
 
 ### Testing & building
@@ -52,17 +56,20 @@ jdt build [--project <name>] [--incremental]           # (alias: b) build projec
 jdt test run <FQN>[#method] [--project <name>] [-f]    # launch tests (non-blocking)
 jdt test run --project <name> [--package <pkg>] [-f]   # run tests in project
 jdt test status <session> [-f] [--all] [--ignored]     # show test progress/results
-jdt test sessions                                       # list test sessions
+jdt test sessions                                      # list test sessions
 ```
+
+With `-f`, streams test progress until completion. `-q` suppresses the onboarding guide.
+`--all` includes passed tests, `--ignored` shows skipped.
 
 All commands auto-refresh from disk. `build` is the only command that triggers explicit builds.
 
 ### Diagnostics
 
 ```bash
-jdt errors [--project <name>] [--file <path>]          # (alias: err) compilation errors
+jdt errors [--file <path>] [--project <name>]          # (alias: err) compilation errors
 jdt errors --warnings --all                            # include warnings and all marker types
-jdt refresh <file> [<file> ...]                        # (alias: r) notify Eclipse of file changes
+jdt refresh <file> [<file> ...] [-q]                   # (alias: r) notify Eclipse of file changes
 jdt refresh --project <name>                           # refresh entire project
 jdt refresh                                            # refresh entire workspace
 ```
@@ -76,10 +83,12 @@ after every Edit/Write — Eclipse stays in sync without manual intervention.
 ### Maven
 
 ```bash
-jdt maven update                                       # update all Maven projects (Alt+F5)
+jdt maven update                                       # (alias: up) update all Maven projects (Alt+F5)
 jdt maven update --project m8-server                   # update specific project
 jdt maven update -f                                    # wait for auto-build, show error count
 jdt maven update --force --offline                     # force snapshots, offline mode
+jdt maven update --no-config --no-clean --no-refresh   # skip config/clean/refresh steps
+jdt maven up -q                                        # quiet mode, suppress guide
 ```
 
 ### Refactoring
@@ -119,10 +128,22 @@ jdt open <FQMN>                                        # open in Eclipse editor
 
 ```bash
 jdt projects                                           # list workspace projects (name, location, repo)
-jdt project-info <name> [--lines N]                    # (alias: pi) project overview
+jdt project-info <name> [--lines N]                    # (alias: pi) project overview (adaptive detail)
 jdt editors                                            # (alias: ed) open editors (FQN, project, path)
-jdt git [list] [repo...] [--no-files]                  # git repos, branches, dirty state
+jdt git [list] [repo...] [--no-files] [--limit N]      # git repos, branches, dirty state
 ```
+
+### Agents
+
+```bash
+jdt agent run <provider> <agent> [--name <id>]         # launch agent session
+jdt agent list                                         # running agent sessions
+jdt agent stop <name>                                  # stop by session ID
+jdt agent logs <name> [-f]                             # stream agent output
+jdt agent providers                                    # available providers
+```
+
+Providers: `local` (system terminal with bridge env vars), `sandbox` (Docker with bridge connectivity).
 
 ## Instance discovery
 


### PR DESCRIPTION
Remove command table from root README (landing page, not reference).
Update cli/README.md to match actual jdt help output:

- setup --claude / --remove-claude
- --json note at top instead of per-line
- find pattern, source multi-FQMN, test/errors/refresh/maven flags
- New Agents section
- Fix comment alignment to column 56