### PR TITLE
Add launch config command, enrich launch configs

### DIFF
--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -50,6 +50,7 @@ import { git, help as gitHelp } from "./commands/git.mjs";
 import {
   launchList,
   launchConfigs,
+  launchConfig,
   launchRun,
   launchDebug,
   launchStop,
@@ -58,6 +59,7 @@ import {
   launchConsole,
   launchListHelp,
   launchConfigsHelp,
+  launchConfigHelp,
   launchRunHelp,
   launchDebugHelp,
   launchStopHelp,
@@ -78,6 +80,7 @@ const { version } = createRequire(import.meta.url)("../package.json");
 const launchSubcommands = {
   list: { fn: launchList, help: launchListHelp },
   configs: { fn: launchConfigs, help: launchConfigsHelp },
+  config: { fn: launchConfig, help: launchConfigHelp },
   run: { fn: launchRun, help: launchRunHelp },
   debug: { fn: launchDebug, help: launchDebugHelp },
   stop: { fn: launchStop, help: launchStopHelp },
@@ -91,6 +94,7 @@ const launchHelp = `Manage launches (running and terminated processes).
 Subcommands:
   jdt launch list                           list all launches
   jdt launch configs                        list saved launch configurations
+  jdt launch config <name> [--xml]          show configuration details
   jdt launch run <config> [-f] [-q]         launch a configuration
   jdt launch debug <config> [-f] [-q]       launch in debug mode
   jdt launch logs <name> [-f] [--tail N]    show console output

--- a/cli/src/commands/launch.mjs
+++ b/cli/src/commands/launch.mjs
@@ -1,6 +1,7 @@
 import { get, getStream } from "../client.mjs";
 import { extractPositional, parseFlags } from "../args.mjs";
 import { output } from "../output.mjs";
+import { printJson } from "../json-output.mjs";
 import { formatTable } from "../format/table.mjs";
 
 export async function launchList(args = []) {
@@ -26,10 +27,28 @@ export async function launchConfigs(args = []) {
   output(args, data, {
     empty: "(no launch configurations)",
     text(data) {
-      const rows = data.map((r) => [r.name, r.type]);
-      console.log(formatTable(["NAME", "TYPE"], rows));
+      const rows = data.map((r) => [
+        r.name,
+        r.type,
+        r.project || "",
+        configTarget(r),
+      ]);
+      console.log(
+        formatTable(["NAME", "TYPE", "PROJECT", "TARGET"], rows),
+      );
     },
   });
+}
+
+function configTarget(r) {
+  if (r.class) {
+    let t = r.class;
+    if (r.method) t += "#" + r.method;
+    return t;
+  }
+  if (r.mainClass) return r.mainClass;
+  if (r.goals) return r.goals;
+  return "";
 }
 
 export async function launchClear(args) {
@@ -42,6 +61,28 @@ export async function launchClear(args) {
     return;
   }
   console.log(`Removed ${result.removed} terminated launch${result.removed !== 1 ? "es" : ""}`);
+}
+
+export async function launchConfig(args) {
+  const pos = extractPositional(args);
+  const name = pos[0];
+  if (!name) {
+    console.error("Usage: launch config <name> [--xml] [--json]");
+    process.exit(1);
+  }
+  const xml = args.includes("--xml");
+  let url = `/launch/config?name=${encodeURIComponent(name)}`;
+  if (xml) url += "&format=xml";
+  const data = await get(url);
+  if (data.error) {
+    console.error(data.error);
+    return;
+  }
+  if (xml) {
+    console.log(data.xml);
+  } else {
+    printJson(data);
+  }
 }
 
 /**
@@ -249,12 +290,29 @@ export const launchConfigsHelp = `List saved launch configurations.
 
 Usage:  jdt launch configs [--json]
 
+Shows NAME, TYPE, PROJECT, and TARGET (class, method, main class, or goals).
+
 Options:
-  --json    output as JSON
+  --json    output as JSON (includes runner for test configs)
 
 Examples:
   jdt launch configs
   jdt launch configs --json`;
+
+export const launchConfigHelp = `Show details of a launch configuration.
+
+Usage:  jdt launch config <name> [--xml]
+
+By default, outputs JSON with all configuration attributes.
+With --xml, outputs the raw .launch XML file content.
+
+Options:
+  --xml     output raw .launch XML instead of JSON
+
+Examples:
+  jdt launch config my-server
+  jdt launch config my-server --xml
+  jdt launch config ObjectMapperTest | jq .attributes`;
 
 export const launchRunHelp = `Launch a saved configuration (non-blocking).
 

--- a/cli/test/commands.json.test.mjs
+++ b/cli/test/commands.json.test.mjs
@@ -415,20 +415,24 @@ describe("--json output", () => {
     expect(data).toEqual([]);
   });
 
-  it("launch configs --json outputs valid JSON", async () => {
+  it("launch configs --json outputs valid JSON with enriched fields", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { name: "my-server", type: "Java Application" },
-        { name: "jdtbridge-verify", type: "Maven Build" },
+        { name: "my-server", type: "Java Application", project: "m8-server", mainClass: "app.m8.Main" },
+        { name: "jdtbridge-verify", type: "Maven Build", goals: "clean verify" },
+        { name: "AllTests", type: "JUnit", project: "m8-server", class: "app.m8.AllTests", runner: "JUnit 5" },
       ]));
     });
     const { launchConfigs } = await import("../src/commands/launch.mjs");
     await launchConfigs(["--json"]);
     const data = parseJsonOutput(io.logs);
     expect(data).toBeInstanceOf(Array);
-    expect(data).toHaveLength(2);
-    expect(data[0].name).toBe("my-server");
+    expect(data).toHaveLength(3);
+    expect(data[0].project).toBe("m8-server");
+    expect(data[0].mainClass).toBe("app.m8.Main");
+    expect(data[1].goals).toBe("clean verify");
+    expect(data[2].runner).toBe("JUnit 5");
   });
 
   it("project-info --json outputs raw server response", async () => {

--- a/cli/test/commands.launch.test.mjs
+++ b/cli/test/commands.launch.test.mjs
@@ -94,12 +94,13 @@ describe("launch commands", () => {
     expect(io.logs[0]).toContain("last line");
   });
 
-  it("launch configs shows configurations as table", async () => {
+  it("launch configs shows configurations as table with project and target", async () => {
     await setupMock((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify([
-        { name: "my-server", type: "Java Application" },
-        { name: "AllTests", type: "JUnit" },
+        { name: "my-server", type: "Java Application", project: "m8-server", mainClass: "app.m8.Main" },
+        { name: "AllTests", type: "JUnit", project: "m8-server", class: "app.m8.AllTests", runner: "JUnit 5" },
+        { name: "jdtbridge-verify", type: "Maven Build", goals: "clean verify" },
       ]));
     });
     const { launchConfigs } = await import("../src/commands/launch.mjs");
@@ -107,8 +108,14 @@ describe("launch commands", () => {
     const out = io.logs[0];
     expect(out).toContain("NAME");
     expect(out).toContain("TYPE");
+    expect(out).toContain("PROJECT");
+    expect(out).toContain("TARGET");
     expect(out).toContain("my-server");
+    expect(out).toContain("m8-server");
+    expect(out).toContain("app.m8.Main");
     expect(out).toContain("AllTests");
+    expect(out).toContain("app.m8.AllTests");
+    expect(out).toContain("clean verify");
   });
 
   it("launch configs empty", async () => {
@@ -321,5 +328,60 @@ describe("launch commands", () => {
     const { launchRun } = await import("../src/commands/launch.mjs");
     await launchRun(["my-server"]);
     expect(io.logs[0]).toContain("Launched");
+  });
+
+  it("launch config shows JSON details", async () => {
+    const detail = {
+      name: "ObjectMapperTest", type: "JUnit", typeId: "org.eclipse.jdt.junit.launchconfig",
+      file: "/ws/.metadata/.plugins/org.eclipse.debug.core/ObjectMapperTest.launch",
+      attributes: { "org.eclipse.jdt.launching.MAIN_TYPE_NAME": "app.m8.ObjectMapperTest" },
+    };
+    await setupMock((req, res) => {
+      expect(req.url).toContain("name=ObjectMapperTest");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(detail));
+    });
+    const { launchConfig } = await import("../src/commands/launch.mjs");
+    await launchConfig(["ObjectMapperTest"]);
+    const out = io.logs.join("\n");
+    expect(out).toContain("ObjectMapperTest");
+    expect(out).toContain("MAIN_TYPE_NAME");
+  });
+
+  it("launch config --xml shows raw XML", async () => {
+    const xml = '<?xml version="1.0"?>\n<launchConfiguration type="org.eclipse.jdt.junit.launchconfig"/>';
+    await setupMock((req, res) => {
+      expect(req.url).toContain("format=xml");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ name: "ObjectMapperTest", file: "/test.launch", xml }));
+    });
+    const { launchConfig } = await import("../src/commands/launch.mjs");
+    await launchConfig(["ObjectMapperTest", "--xml"]);
+    expect(io.logs[0]).toContain("launchConfiguration");
+  });
+
+  it("launch config missing name exits", async () => {
+    const { launchConfig } = await import("../src/commands/launch.mjs");
+    await expect(launchConfig([])).rejects.toThrow("exit(1)");
+  });
+
+  it("launch config error shows message", async () => {
+    await setupMock(errorServer());
+    const { launchConfig } = await import("../src/commands/launch.mjs");
+    await launchConfig(["nonexistent"]);
+    expect(io.errors[0]).toContain("Something went wrong");
+  });
+
+  it("launch configs shows method in target", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([
+        { name: "FooTest.bar", type: "JUnit", project: "proj", class: "com.FooTest", method: "bar" },
+      ]));
+    });
+    const { launchConfigs } = await import("../src/commands/launch.mjs");
+    await launchConfigs();
+    const out = io.logs[0];
+    expect(out).toContain("com.FooTest#bar");
   });
 });

--- a/docs/jdt-launch-spec.md
+++ b/docs/jdt-launch-spec.md
@@ -1,0 +1,350 @@
+# jdt launch — Design Spec
+
+## Overview
+
+`jdt launch` manages Eclipse launch configurations and running processes.
+It exposes the Eclipse Debug/Launch infrastructure through CLI commands,
+letting agents and terminal users list, inspect, run, monitor, and stop
+any launch configuration in the workspace — JUnit tests, Java applications,
+Maven builds, PDE plugin tests, and custom agent types.
+
+## Eclipse concepts mapped to CLI
+
+| Eclipse concept | CLI surface |
+|---|---|
+| Launch Configuration (saved .launch file) | `jdt launch configs`, `jdt launch config <name>` |
+| ILaunch (running/terminated process) | `jdt launch list`, `jdt launch logs`, `jdt launch stop` |
+| Launch Manager | Internal — mediates all launch operations |
+| Launch History (favorites + recent) | `jdt launch configs` sorts favorites first |
+| Console output (IStreamMonitor) | `jdt launch logs` (snapshot), `jdt launch logs -f` (stream) |
+
+## Commands
+
+### `jdt launch list [--json]`
+
+List active and terminated launches (current Eclipse session).
+
+```
+NAME                TYPE                MODE  STATUS          PID
+my-server           Java Application    run   running         12345
+ObjectMapperTest    JUnit               run   terminated (0)
+```
+
+JSON fields: `name`, `type`, `mode`, `terminated`, `started`, `exitCode`, `pid`.
+
+Launches are ephemeral — they exist only for the current Eclipse session.
+Restarting Eclipse clears the list. Use `jdt launch clear` to remove
+terminated entries without restarting.
+
+### `jdt launch configs [--json]`
+
+List all saved launch configurations in the workspace.
+
+```
+NAME              TYPE                PROJECT      TARGET
+my-server         Java Application    m8-server    app.m8.Main
+ObjectMapperTest  JUnit               m8-server    app.m8.ObjectMapperTest
+jdtbridge-verify  Maven Build                      clean verify
+AllTests          JUnit Plug-in Test  jdtbridge    io.github.kaluchi.jdtbridge.AllTests
+```
+
+Columns:
+- **NAME** — configuration name (unique identifier for `jdt launch run`)
+- **TYPE** — Eclipse launch type (human-readable)
+- **PROJECT** — Java project (from `org.eclipse.jdt.launching.PROJECT_ATTR`)
+- **TARGET** — type-specific summary:
+  - JUnit: `class#method` (FQMN)
+  - Java Application: main class
+  - Maven Build: goals
+
+JSON includes additional fields per type:
+- JUnit / JUnit Plug-in Test: `class`, `method`, `runner` (JUnit 4/5/6)
+- Java Application: `mainClass`
+- Maven Build: `goals`, `profiles`
+
+Sort order: favorites first, then launch history, then alphabetical.
+This matches the Eclipse Run > Run Configurations dialog order.
+
+### `jdt launch config <name> [--xml]`
+
+Show full details of a single launch configuration.
+
+Default output (JSON):
+```json
+{
+  "name": "ObjectMapperTest",
+  "type": "JUnit",
+  "typeId": "org.eclipse.jdt.junit.launchconfig",
+  "file": "/path/to/.metadata/.plugins/org.eclipse.debug.core/.launches/ObjectMapperTest.launch",
+  "attributes": {
+    "org.eclipse.jdt.launching.MAIN_TYPE_NAME": "app.m8.ObjectMapperTest",
+    "org.eclipse.jdt.launching.PROJECT_ATTR": "m8-server",
+    "org.eclipse.jdt.junit.TEST_KIND": "org.eclipse.jdt.junit.loader.junit5",
+    "org.eclipse.jdt.launching.VM_ARGUMENTS": "-Xmx512m"
+  }
+}
+```
+
+With `--xml`, outputs the raw .launch file content (Eclipse XML format).
+Useful for debugging attribute issues or comparing configurations.
+
+Design decisions:
+- Default is JSON (not text table) because config details are inherently
+  nested key-value data, not tabular. JSON is both human-readable and
+  machine-parseable.
+- Attribute keys are raw Eclipse IDs (e.g. `org.eclipse.jdt.launching.MAIN_TYPE_NAME`),
+  not mapped to friendly names. This preserves the full fidelity and avoids
+  lossy mapping. Agents can use known keys; humans use `--xml` for the full picture.
+- `getAttributes()` preserves types: strings, booleans, integers, lists, maps.
+  This is richer than parsing XML where everything is a string.
+
+### `jdt launch run <name> [-f] [-q]`
+
+Launch a saved configuration in run mode (non-blocking).
+
+Without `-f`: prints launch info + onboarding guide.
+With `-f`: launches and streams console output until termination.
+With `-q`: suppresses the guide.
+
+```
+Launched my-server (run) [Java Application]
+  PID:        12345
+  Working dir: /d/git/m8
+  Command:    java -cp ... app.m8.Main
+```
+
+### `jdt launch debug <name> [-f] [-q]`
+
+Same as `run` but attaches the Eclipse debugger.
+
+### `jdt launch logs <name> [-f] [--tail N] [--stdout] [--stderr]`
+
+Show console output of a launch.
+
+Without `-f`: snapshot of current output.
+With `-f`: stream live until process exits (Ctrl+C to detach, process keeps running).
+`--tail N`: last N lines only.
+`--stdout`/`--stderr`: filter to one stream.
+
+### `jdt launch stop <name>`
+
+Terminate a running launch. Returns error if already terminated.
+
+### `jdt launch clear [name]`
+
+Remove terminated launches from the list.
+Without name: removes all terminated.
+With name: removes only that specific terminated launch.
+
+## HTTP API
+
+### `GET /launch/list`
+
+Returns: `[{name, type, mode, terminated, started, exitCode, pid}]`
+
+### `GET /launch/configs`
+
+Returns: `[{name, type, project?, class?, method?, runner?, mainClass?, goals?, profiles?}]`
+
+Fields vary by launch type. Only non-null fields are included.
+
+### `GET /launch/config?name=<name>[&format=xml]`
+
+Default: `{name, type, typeId, file, attributes: {key: value, ...}}`
+
+`format=xml`: `{name, file, xml: "<raw .launch XML content>"}`
+
+Attribute values preserve Eclipse types:
+- `String` -> JSON string
+- `boolean` -> JSON boolean
+- `int` -> JSON number
+- `List<String>` -> JSON array
+- `Set<String>` -> JSON array
+- `Map<String, String>` -> JSON object
+
+### `GET /launch/run?name=<name>[&debug]`
+
+Returns: `{ok, name, mode, type, pid, cmdline, workingDir}`
+
+### `GET /launch/console?name=<name>[&tail=N][&stream=stdout|stderr]`
+
+Returns: `{name, terminated, output}`
+
+### `GET /launch/console/stream?name=<name>[&tail=N][&stream=stdout|stderr]`
+
+SSE stream (text/plain). Streams console output until process terminates.
+
+### `GET /launch/stop?name=<name>`
+
+Returns: `{ok, name}`
+
+### `GET /launch/clear[?name=<name>]`
+
+Returns: `{removed: N}`
+
+## Architecture
+
+### Plugin classes
+
+| Class | Responsibility |
+|---|---|
+| `LaunchHandler` | HTTP handlers for all `/launch/*` endpoints. Reads from LaunchManager and LaunchTracker, serializes JSON responses. |
+| `LaunchTracker` | `ILaunchesListener2` implementation. Tracks all launches, captures console output via `IStreamMonitor`. Survives `ILaunch` removal from LaunchManager. |
+| `ConsoleStreamer` | SSE streamer for `/launch/console/stream`. Sends accumulated output then streams live until termination. |
+
+### CLI modules
+
+| Module | Responsibility |
+|---|---|
+| `commands/launch.mjs` | All launch subcommands: list, configs, config, run, debug, stop, clear, logs |
+| `format/table.mjs` | Shared table formatter (used by list and configs) |
+| `output.mjs` | Format dispatcher (--json routing) |
+| `json-output.mjs` | JSON printer with path remapping |
+
+### Launch types and their identifiers
+
+| Human name | Type ID | Plugin |
+|---|---|---|
+| JUnit | `org.eclipse.jdt.junit.launchconfig` | JDT |
+| JUnit Plug-in Test | `org.eclipse.pde.ui.JunitLaunchConfig` | PDE |
+| Java Application | `org.eclipse.jdt.launching.localJavaApplication` | JDT |
+| Maven Build | `org.eclipse.m2e.Maven2LaunchConfigurationType` | m2e |
+| Launch Group | `org.eclipse.debug.core.groups.GroupLaunchConfigurationType` | Debug |
+| JDT Bridge Agent | `io.github.kaluchi.jdtbridge.ui.agentLaunchType` | jdtbridge.ui |
+
+### Key attribute keys
+
+**Common (all Java types):**
+- `org.eclipse.jdt.launching.PROJECT_ATTR` — project name
+- `org.eclipse.jdt.launching.MAIN_TYPE_NAME` — main class FQN
+- `org.eclipse.jdt.launching.VM_ARGUMENTS` — JVM arguments
+- `org.eclipse.debug.core.ATTR_WORKING_DIRECTORY` — working directory
+
+**JUnit-specific:**
+- `org.eclipse.jdt.junit.TEST_KIND` — runner (junit4/junit5/junit6 loader ID)
+- `org.eclipse.jdt.junit.TESTNAME` — specific test method
+- `org.eclipse.jdt.junit.CONTAINER` — test container (for package/project scope)
+
+**PDE JUnit-specific:**
+- `run_in_ui_thread` — false for headless tests
+- `application` — test application ID
+- `default`, `automaticAdd`, `includeOptional` — bundle resolution
+- `location` — temp workspace path
+- `clearws` — clear workspace before run
+
+**Maven-specific:**
+- `M2_GOALS` — Maven goals
+- `M2_PROFILES` — Maven profiles
+
+**JDT Bridge Agent-specific:**
+- `io.github.kaluchi.jdtbridge.provider` — "local" or "sandbox"
+- `io.github.kaluchi.jdtbridge.agent` — agent name
+- `io.github.kaluchi.jdtbridge.workingDir` — working directory
+- `io.github.kaluchi.jdtbridge.agentArgs` — agent arguments
+
+## Launch configuration storage
+
+`.launch` files are always stored in the workspace metadata directory:
+```
+<workspace>/.metadata/.plugins/org.eclipse.debug.core/.launches/<name>.launch
+```
+
+Format: XML with `launchConfiguration` root element. Attributes are stored
+as typed elements (`stringAttribute`, `booleanAttribute`, `listAttribute`, etc.).
+
+**Eclipse API:**
+- `getFile()` — returns `null` for configs in `.metadata` (all standard configs).
+  Only non-null if the .launch file is stored inside a workspace project.
+- `getLocation()` — deprecated since 3.5 (EFS). Not used.
+- `getAttributes()` — deserialized `Map<String, Object>` with proper types.
+- `DebugPlugin.getStateLocation()` — returns the debug plugin state directory.
+  Appending `.launches/<name>.launch` gives the file path. This is the same
+  approach Eclipse uses internally (`LaunchManager.LOCAL_LAUNCH_CONFIGURATION_CONTAINER_PATH`).
+
+Accessible via:
+- `ILaunchConfiguration.getAttributes()` — returns deserialized `Map<String, Object>`
+  with proper types (String, Boolean, Integer, List, Map). Richer than parsing XML.
+- `jdt launch config <name>` — full attributes as JSON (default)
+- `jdt launch config <name> --xml` — raw .launch XML content
+
+## Launch lifecycle
+
+```
+[saved .launch file] --jdt launch run--> [ILaunch: running] --terminates--> [ILaunch: terminated]
+                                               |                                    |
+                                         jdt launch list                    jdt launch list
+                                         jdt launch logs -f                 jdt launch logs
+                                         jdt launch stop                    jdt launch clear
+```
+
+Key lifecycle facts:
+- **ILaunch is session-scoped.** Restarting Eclipse clears all ILaunch objects.
+- **LaunchTracker survives ILaunch removal.** Even after `jdt launch clear`,
+  tracker retains console output until plugin restarts.
+- **Console output is in-memory.** LaunchTracker accumulates stdout/stderr
+  in StringBuilder buffers. No persistence across Eclipse restarts.
+- **Launch configs are persistent.** Saved as .launch files on disk.
+  Survive Eclipse restarts. Managed via Run > Run Configurations dialog.
+
+## Launch history and ordering
+
+`jdt launch configs` uses Eclipse's internal launch history API
+(`DebugUIPlugin.getLaunchConfigurationManager()`) to sort results:
+
+1. **Favorites** (Run favorites, then Debug favorites)
+2. **Recent history** (Run history, then Debug history)
+3. **Remaining configs** (alphabetical)
+
+This matches the order in Eclipse's Run > Run History menu.
+The API is `@SuppressWarnings("restriction")` — internal Eclipse API,
+but stable across versions.
+
+## Relationship to `jdt test`
+
+Test launches are a special case of the launch system:
+
+- `jdt test run` creates a JUnit/PDE launch configuration and launches it
+- The resulting ILaunch appears in `jdt launch list`
+- Console output is accessible via `jdt launch logs`
+- Test-specific progress is tracked separately by `TestSessionTracker`
+
+Test launch configs created by `jdt test run` use timestamped names
+(e.g. `SearchIntegrationTest-1775075114208`) and are saved to disk.
+This is a known issue — configs accumulate. Future improvement: reuse
+configs with stable names (see Known Issues).
+
+## Known issues
+
+### Launch config accumulation from `jdt test run`
+
+Each `jdt test run` creates a new ILaunchConfigurationWorkingCopy with a
+unique timestamped name. Eclipse's `wc.launch()` persists it as a .launch file.
+Over time, workspace accumulates stale test configs.
+
+Planned fix: use stable names (just the class/package/project name without
+timestamp) and clean up the previous terminated ILaunch before creating a new one.
+
+### Maven prerequisite in `jdt setup --skip-build`
+
+`jdt setup --skip-build` checks for Maven even though it doesn't invoke it.
+This blocks installation in environments without Maven (e.g. Docker sandbox
+where Maven runs via Eclipse launch config). The prerequisites check should
+be aware of `--skip-build` and skip the Maven requirement.
+
+## Design constraints
+
+1. **Eclipse must be running.** All launch operations go through the running
+   Eclipse instance via HTTP. No headless mode.
+
+2. **Single workspace.** Launch configs are workspace-scoped. The bridge
+   serves one workspace per Eclipse instance.
+
+3. **No cross-instance launches.** Cannot launch a config from one Eclipse
+   instance in another.
+
+4. **Console buffer limits.** LaunchTracker uses unbounded StringBuilders.
+   Very long-running processes (hours of output) may consume significant memory.
+
+5. **Path conversion.** In Docker sandbox mode, Windows paths from Eclipse
+   are converted to Linux paths via `toSandboxPath()`. This applies to
+   `file` fields in JSON output.

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -160,6 +160,173 @@ public class LaunchHandlerTest {
                         "Should have type: " + json);
             }
         }
+
+        @Test
+        void junitConfigHasClassAndRunner() {
+            String json = handler.handleConfigs(Map.of());
+            var arr = JsonParser.parseString(json)
+                    .getAsJsonArray();
+            for (var el : arr) {
+                var obj = el.getAsJsonObject();
+                String type = obj.get("type").getAsString();
+                if ("JUnit".equals(type)
+                        || "JUnit Plug-in Test".equals(type)) {
+                    assertTrue(obj.has("class")
+                            || obj.has("project"),
+                            "JUnit config should have class "
+                            + "or project: " + obj);
+                    return;
+                }
+            }
+            // No JUnit configs — skip
+        }
+
+        @Test
+        void mavenConfigHasGoals() {
+            String json = handler.handleConfigs(Map.of());
+            var arr = JsonParser.parseString(json)
+                    .getAsJsonArray();
+            for (var el : arr) {
+                var obj = el.getAsJsonObject();
+                String type = obj.get("type").getAsString();
+                if ("Maven Build".equals(type)) {
+                    assertTrue(obj.has("goals"),
+                            "Maven config should have goals: "
+                            + obj);
+                    return;
+                }
+            }
+            // No Maven configs — skip
+        }
+    }
+
+    @Nested
+    class Config {
+
+        @Test
+        void missingNameReturnsError() {
+            String json = handler.handleConfig(Map.of());
+            assertTrue(json.contains("error"),
+                    "Should return error: " + json);
+            assertTrue(json.contains("Missing"),
+                    "Should say missing: " + json);
+        }
+
+        @Test
+        void unknownConfigReturnsError() {
+            String json = handler.handleConfig(
+                    Map.of("name", "no-such-config-xyz-999"));
+            assertTrue(json.contains("error"),
+                    "Should return error: " + json);
+            assertTrue(json.contains("not found"),
+                    "Should say not found: " + json);
+        }
+
+        @Test
+        void knownConfigReturnsAttributes() {
+            // Find any existing config name
+            String listJson = handler.handleConfigs(Map.of());
+            var arr = JsonParser.parseString(listJson)
+                    .getAsJsonArray();
+            if (arr.isEmpty()) return; // no configs to test
+            String name = arr.get(0).getAsJsonObject()
+                    .get("name").getAsString();
+
+            String json = handler.handleConfig(
+                    Map.of("name", name));
+            assertFalse(json.contains("\"error\""),
+                    "Should not error: " + json);
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            assertEquals(name, obj.get("name").getAsString());
+            assertTrue(obj.has("type"),
+                    "Should have type: " + json);
+            assertTrue(obj.has("typeId"),
+                    "Should have typeId: " + json);
+            assertTrue(obj.has("attributes"),
+                    "Should have attributes: " + json);
+            assertTrue(obj.get("attributes").isJsonObject(),
+                    "Attributes should be object: " + json);
+        }
+
+        @Test
+        void xmlFormatReturnsXmlContent() {
+            String listJson = handler.handleConfigs(Map.of());
+            var arr = JsonParser.parseString(listJson)
+                    .getAsJsonArray();
+            if (arr.isEmpty()) return;
+            String name = arr.get(0).getAsJsonObject()
+                    .get("name").getAsString();
+
+            String json = handler.handleConfig(
+                    Map.of("name", name, "format", "xml"));
+            assertFalse(json.contains("\"error\""),
+                    "Should not error: " + json);
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            assertEquals(name, obj.get("name").getAsString());
+            assertTrue(obj.has("xml"),
+                    "Should have xml field: " + json);
+            String xml = obj.get("xml").getAsString();
+            assertTrue(xml.contains("<?xml")
+                    || xml.contains("<launchConfiguration"),
+                    "XML should contain launch config: "
+                    + xml.substring(0,
+                            Math.min(200, xml.length())));
+        }
+
+        @Test
+        void attributesContainExpectedKeys() {
+            // Find a JUnit config specifically
+            String listJson = handler.handleConfigs(Map.of());
+            var arr = JsonParser.parseString(listJson)
+                    .getAsJsonArray();
+            String junitName = null;
+            for (var el : arr) {
+                var obj = el.getAsJsonObject();
+                String type = obj.get("type").getAsString();
+                if ("JUnit".equals(type)
+                        || "JUnit Plug-in Test".equals(type)) {
+                    junitName = obj.get("name").getAsString();
+                    break;
+                }
+            }
+            if (junitName == null) return;
+
+            String json = handler.handleConfig(
+                    Map.of("name", junitName));
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            var attrs = obj.getAsJsonObject("attributes");
+            assertTrue(
+                    attrs.has(
+                        "org.eclipse.jdt.launching.MAIN_TYPE_NAME")
+                    || attrs.has(
+                        "org.eclipse.jdt.junit.CONTAINER"),
+                    "JUnit config should have test class or "
+                    + "container in attributes: " + attrs);
+        }
+
+        @Test
+        void attributeTypesPreserved() {
+            // Get any config and verify attribute value types
+            String listJson = handler.handleConfigs(Map.of());
+            var arr = JsonParser.parseString(listJson)
+                    .getAsJsonArray();
+            if (arr.isEmpty()) return;
+            String name = arr.get(0).getAsJsonObject()
+                    .get("name").getAsString();
+
+            String json = handler.handleConfig(
+                    Map.of("name", name));
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            var attrs = obj.getAsJsonObject("attributes");
+            // Attributes should be valid JSON — no crashes
+            assertNotNull(attrs);
+            assertTrue(attrs.size() > 0,
+                    "Config should have some attributes");
+        }
     }
 
     @Nested

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -440,6 +440,8 @@ public class HttpServer {
                         launch.handleList(params));
                 case "/launch/configs" -> Response.json(
                         launch.handleConfigs(params));
+                case "/launch/config" -> Response.json(
+                        launch.handleConfig(params));
                 case "/launch/clear" -> Response.json(
                         launch.handleClear(params));
                 case "/launch/console" -> Response.json(

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -2,9 +2,15 @@ package io.github.kaluchi.jdtbridge;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -13,10 +19,45 @@ import org.eclipse.debug.core.model.IProcess;
 
 class LaunchHandler {
 
+    // Attribute keys for launch configuration types
+    private static final String ATTR_PROJECT_NAME =
+            "org.eclipse.jdt.launching.PROJECT_ATTR";
+    private static final String ATTR_MAIN_TYPE_NAME =
+            "org.eclipse.jdt.launching.MAIN_TYPE_NAME";
+    private static final String ATTR_TEST_KIND =
+            "org.eclipse.jdt.junit.TEST_KIND";
+    private static final String ATTR_TEST_NAME =
+            "org.eclipse.jdt.junit.TESTNAME";
+    private static final String JUNIT_LAUNCH_TYPE =
+            "org.eclipse.jdt.junit.launchconfig";
+    private static final String PDE_JUNIT_LAUNCH_TYPE =
+            "org.eclipse.pde.ui.JunitLaunchConfig";
+    private static final String JAVA_APP_LAUNCH_TYPE =
+            "org.eclipse.jdt.launching.localJavaApplication";
+    private static final String MAVEN_LAUNCH_TYPE =
+            "org.eclipse.m2e.Maven2LaunchConfigurationType";
+    private static final String MAVEN_GOALS =
+            "M2_GOALS";
+    private static final String MAVEN_PROFILES =
+            "M2_PROFILES";
+
     private final LaunchTracker tracker;
 
     LaunchHandler(LaunchTracker tracker) {
         this.tracker = tracker;
+    }
+
+    private static String formatRunner(String testKind) {
+        if (testKind == null) return null;
+        return switch (testKind) {
+        case "org.eclipse.jdt.junit.loader.junit6" ->
+                "JUnit 6";
+        case "org.eclipse.jdt.junit.loader.junit5" ->
+                "JUnit 5";
+        case "org.eclipse.jdt.junit.loader.junit4" ->
+                "JUnit 4";
+        default -> testKind;
+        };
     }
 
     private ILaunchManager launchManager() {
@@ -96,29 +137,196 @@ class LaunchHandler {
 
             if (recent != null) {
                 for (var config : recent) {
-                    var obj = new JsonObject();
-                    obj.addProperty("name",
-                            config.getName());
-                    obj.addProperty("type",
-                            config.getType().getName());
-                    arr.add(obj);
+                    arr.add(configSummary(config));
                     seen.add(config.getName());
                 }
             }
 
             for (var config : allConfigs) {
                 if (seen.contains(config.getName())) continue;
-                var obj = new JsonObject();
-                obj.addProperty("name", config.getName());
-                obj.addProperty("type",
-                        config.getType().getName());
-                arr.add(obj);
+                arr.add(configSummary(config));
             }
 
             return arr.toString();
         } catch (Exception e) {
             return HttpServer.jsonError(e.getMessage());
         }
+    }
+
+    String handleConfig(Map<String, String> params) {
+        String name = params.get("name");
+        if (name == null || name.isBlank()) {
+            return HttpServer.jsonError(
+                    "Missing 'name' parameter");
+        }
+        try {
+            ILaunchConfiguration config = findConfig(name);
+            if (config == null) {
+                return HttpServer.jsonError(
+                        "Launch configuration not found: "
+                        + name);
+            }
+            if ("xml".equals(params.get("format"))) {
+                return configXml(config);
+            }
+            return configDetail(config);
+        } catch (Exception e) {
+            return HttpServer.jsonError(e.getMessage());
+        }
+    }
+
+    // -- config summary (for /launch/configs list) --
+
+    private JsonObject configSummary(
+            ILaunchConfiguration config) throws CoreException {
+        var obj = new JsonObject();
+        obj.addProperty("name", config.getName());
+        String typeName = config.getType().getName();
+        obj.addProperty("type", typeName);
+
+        String project = config.getAttribute(
+                ATTR_PROJECT_NAME, (String) null);
+        if (project != null)
+            obj.addProperty("project", project);
+
+        String typeId = config.getType().getIdentifier();
+        addTypeSummary(obj, config, typeId);
+        return obj;
+    }
+
+    private static void addTypeSummary(JsonObject obj,
+            ILaunchConfiguration config, String typeId)
+            throws CoreException {
+        switch (typeId) {
+        case JUNIT_LAUNCH_TYPE, PDE_JUNIT_LAUNCH_TYPE -> {
+            String mainType = config.getAttribute(
+                    ATTR_MAIN_TYPE_NAME, (String) null);
+            if (mainType != null)
+                obj.addProperty("class", mainType);
+            String method = config.getAttribute(
+                    ATTR_TEST_NAME, (String) null);
+            if (method != null)
+                obj.addProperty("method", method);
+            String runner = formatRunner(
+                    config.getAttribute(
+                            ATTR_TEST_KIND, (String) null));
+            if (runner != null)
+                obj.addProperty("runner", runner);
+        }
+        case JAVA_APP_LAUNCH_TYPE -> {
+            String mainType = config.getAttribute(
+                    ATTR_MAIN_TYPE_NAME, (String) null);
+            if (mainType != null)
+                obj.addProperty("mainClass", mainType);
+        }
+        case MAVEN_LAUNCH_TYPE -> {
+            String goals = config.getAttribute(
+                    MAVEN_GOALS, (String) null);
+            if (goals != null)
+                obj.addProperty("goals", goals);
+            String profiles = config.getAttribute(
+                    MAVEN_PROFILES, (String) null);
+            if (profiles != null
+                    && !profiles.isBlank())
+                obj.addProperty("profiles", profiles);
+        }
+        default -> { /* no extra fields */ }
+        }
+    }
+
+    // -- config detail (for /launch/config?name=X) --
+
+    private String configDetail(ILaunchConfiguration config)
+            throws CoreException {
+        var obj = new JsonObject();
+        obj.addProperty("name", config.getName());
+        obj.addProperty("type", config.getType().getName());
+        obj.addProperty("typeId",
+                config.getType().getIdentifier());
+
+        java.io.File launchFile = resolveLaunchFile(config);
+        if (launchFile != null) {
+            obj.addProperty("file",
+                    launchFile.getAbsolutePath());
+        }
+
+        // All attributes as a nested object
+        Map<String, Object> attrs = config.getAttributes();
+        var attrsObj = new JsonObject();
+        for (var entry : attrs.entrySet()) {
+            attrsObj.add(entry.getKey(),
+                    toJsonElement(entry.getValue()));
+        }
+        obj.add("attributes", attrsObj);
+        return obj.toString();
+    }
+
+    private String configXml(ILaunchConfiguration config)
+            throws CoreException {
+        java.io.File launchFile = resolveLaunchFile(config);
+        if (launchFile == null || !launchFile.exists()) {
+            return HttpServer.jsonError(
+                    "No .launch file for: "
+                    + config.getName());
+        }
+        try {
+            String xml = Files.readString(
+                    launchFile.toPath());
+            var obj = new JsonObject();
+            obj.addProperty("name", config.getName());
+            obj.addProperty("file",
+                    launchFile.getAbsolutePath());
+            obj.addProperty("xml", xml);
+            return obj.toString();
+        } catch (IOException e) {
+            return HttpServer.jsonError(
+                    "Cannot read .launch file: "
+                    + e.getMessage());
+        }
+    }
+
+    private static java.io.File resolveLaunchFile(
+            ILaunchConfiguration config) {
+        java.io.File file = DebugPlugin.getDefault()
+                .getStateLocation()
+                .append(".launches")
+                .append(config.getName() + ".launch")
+                .toFile();
+        return file.exists() ? file : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static com.google.gson.JsonElement toJsonElement(
+            Object value) {
+        if (value == null)
+            return com.google.gson.JsonNull.INSTANCE;
+        if (value instanceof String s)
+            return new JsonPrimitive(s);
+        if (value instanceof Boolean b)
+            return new JsonPrimitive(b);
+        if (value instanceof Number n)
+            return new JsonPrimitive(n);
+        if (value instanceof List<?> list) {
+            var arr = new JsonArray();
+            for (Object item : list)
+                arr.add(toJsonElement(item));
+            return arr;
+        }
+        if (value instanceof Set<?> set) {
+            var arr = new JsonArray();
+            for (Object item : set)
+                arr.add(toJsonElement(item));
+            return arr;
+        }
+        if (value instanceof Map<?, ?> map) {
+            var obj = new JsonObject();
+            for (var entry
+                    : ((Map<String, Object>) map).entrySet())
+                obj.add(entry.getKey(),
+                        toJsonElement(entry.getValue()));
+            return obj;
+        }
+        return new JsonPrimitive(value.toString());
     }
 
     @SuppressWarnings("restriction")


### PR DESCRIPTION
## Summary

- launch configs table now shows PROJECT and TARGET columns (class, mainClass, goals) with type-specific enriched fields in JSON
- New launch config <name> subcommand: full configuration details as JSON (all attributes with preserved types) or raw .launch XML via --xml
- Design spec in docs/jdt-launch-spec.md

## Test plan

- [x] CLI tests pass (568 tests)
- [x] Plugin installed and bridge verified
- [x] launch configs shows enriched table
- [x] launch config returns JSON with attributes
- [x] launch config --xml returns raw .launch content