### PR TITLE
Make graph predicates subject-level, widen @sourceCard, refresh docs

### DIFF
--- a/.claude/agents/Explore.md
+++ b/.claude/agents/Explore.md
@@ -21,8 +21,8 @@ For Java-specific queries, use `jdt q '<qlang-pipeline>'` — semantic results f
 jdt q '"<FQN>" | @callers'                  # call sites (not string matches)
 jdt q '"<FQN>" | @calls'                    # methods this body invokes
 jdt q '"<FQN>" | @source'                   # source text
-jdt q '"<FQN>" | @members | table'           # class overview (fields, methods)
-jdt q '"<FQN>" | @methods | @untested * /fqn'  # members with no test-scope caller
+jdt q '"<FQN>" | @members * /fqn'            # class overview (fields, methods)
+jdt q '"<FQN>" | @methods | filter(@untested) * /fqn'  # members with no test-scope caller
 jdt q '"*Pat*" | @types * /fqn'              # find types by name pattern
 jdt q '"<FQN>" | @implementors'              # type or method implementors
 jdt q '"<FQN>" | @supers | @ancestors'       # transitive supertypes

--- a/.claude/agents/Plan.md
+++ b/.claude/agents/Plan.md
@@ -19,7 +19,7 @@ This is a READ-ONLY planning task. You CANNOT edit, write, or create files.
 
 ```
 jdt q '"<FQN>" | @source'                   # source text of type/method/field
-jdt q '"<FQN>" | @members | table'          # class overview without reading 600 lines
+jdt q '"<FQN>" | @members * /fqn'           # class overview without reading 600 lines
 jdt q '"<FQN>" | @callers'                  # who calls this method
 jdt q '"<FQN>" | @calls'                    # what this method invokes
 jdt q '"<FQN>" | @implementors'             # implementations of an interface method
@@ -34,7 +34,7 @@ jdt q '"<project>" | @problems'             # compilation state of a project
 1. **Understand Requirements**: Read provided context, explore with `jdt q`
 2. **Explore Thoroughly**:
    - `| @source` for source text
-   - `| @members | table` for class overviews
+   - `| @members * /fqn` for class overviews
    - `| @callers` / `| @calls` to trace call graphs both ways
    - `| @supers` / `| @subtypes` / `| @ancestors` / `| @descendants` for type relationships
    - Grep/Glob for non-Java files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ jdt q '"io.github.kaluchi.jdtbridge.SearchHandler" | @members * /name'
 jdt q '"io.github.kaluchi.jdtbridge.JdtUtils#findMethod" | @callers | count'
 jdt q '"my-server" | @problems * /message'
 jdt q '"org.springframework.jdbc.core.JdbcTemplate#query" | @source' | grep -n throw
-jdt q '"io.github.kaluchi.jdtbridge.HttpServer" | @methods | @untested * /fqn'
+jdt q '"io.github.kaluchi.jdtbridge.HttpServer" | @methods | filter(@untested) * /fqn'
 ```
 
 ### Subagents (Explore, Plan)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jdt q '"com.example.core.Repository#save(Order)" | @implementors'
 
 # Understand a 600-line class without reading it. Fields, method signatures,
 # supertypes — structured overview via @members / @supers / @subtypes.
-jdt q '"com.example.web.OrderController" | @members | table'
+jdt q '"com.example.web.OrderController" | @members * /fqn'
 
 # Run tests with real-time progress streaming.
 # Failures shown immediately — no waiting for full suite to finish.

--- a/cli/agents/Explore.md
+++ b/cli/agents/Explore.md
@@ -21,8 +21,8 @@ For Java-specific queries, use `jdt q '<qlang-pipeline>'` — semantic results f
 jdt q '"<FQN>" | @callers'                  # call sites (not string matches)
 jdt q '"<FQN>" | @calls'                    # methods this body invokes
 jdt q '"<FQN>" | @source'                   # source text
-jdt q '"<FQN>" | @members | table'           # class overview (fields, methods)
-jdt q '"<FQN>" | @methods | @untested * /fqn'  # members with no test-scope caller
+jdt q '"<FQN>" | @members * /fqn'            # class overview (fields, methods)
+jdt q '"<FQN>" | @methods | filter(@untested) * /fqn'  # members with no test-scope caller
 jdt q '"*Pat*" | @types * /fqn'              # find types by name pattern
 jdt q '"<FQN>" | @implementors'              # type or method implementors
 jdt q '"<FQN>" | @supers | @ancestors'       # transitive supertypes

--- a/cli/agents/Plan.md
+++ b/cli/agents/Plan.md
@@ -19,7 +19,7 @@ This is a READ-ONLY planning task. You CANNOT edit, write, or create files.
 
 ```
 jdt q '"<FQN>" | @source'                   # source text of type/method/field
-jdt q '"<FQN>" | @members | table'          # class overview without reading 600 lines
+jdt q '"<FQN>" | @members * /fqn'           # class overview without reading 600 lines
 jdt q '"<FQN>" | @callers'                  # who calls this method
 jdt q '"<FQN>" | @calls'                    # what this method invokes
 jdt q '"<FQN>" | @implementors'             # implementations of an interface method
@@ -34,7 +34,7 @@ jdt q '"<project>" | @problems'             # compilation state of a project
 1. **Understand Requirements**: Read provided context, explore with `jdt q`
 2. **Explore Thoroughly**:
    - `| @source` for source text
-   - `| @members | table` for class overviews
+   - `| @members * /fqn` for class overviews
    - `| @callers` / `| @calls` to trace call graphs both ways
    - `| @supers` / `| @subtypes` / `| @ancestors` / `| @descendants` for type relationships
    - Grep/Glob for non-Java files

--- a/cli/lib/jdt/graph.qlang
+++ b/cli/lib/jdt/graph.qlang
@@ -342,18 +342,18 @@
 |~~ Polymorphic seed lift. Map subjects (skeleton/detail) pass
     through. String subjects dispatch by shape:
       - has '#' and '(' → @method (FQN with explicit signature)
-      - has '#', no '(' → @field (FQN for a field)
-      - no '#'          → @type (FQN for a type)
-    A bare method name without parens (`Type#method`) is
-    syntactically indistinguishable from a field reference — to
-    resolve a method use `Type#method(ArgTypes)` or feed it to
-    @method directly. ~~|
+      - has '#', no '(' → @field, falling back to @method via fail-track
+                          (mirrors GraphHandler.resolveTarget — fields take
+                          priority over nullary / sole-overload methods of
+                          the same name)
+      - no '#'          → @type (FQN for a type) ~~|
 let(:@asNode, as(:subj)
     | reify | /type | as(:subjType)
     | subj
     | when(subjType | eq(:string),
            cond(contains("#"),
-                cond(contains("("), @method, @field),
+                cond(contains("("), @method,
+                     @field !| (subj | @method)),
                 @type)))
 
 |~~ Type that contains a member. Member skeletons carry :containingType
@@ -470,7 +470,9 @@ let(:@problemsVia, [:fetcher, :liftNode, :fileLocation, :packageTypes],
     @problemMarkers / @asNode / @containingFile / @typesInPackage
     operands plug into the conduit. ~~|
 let(:@problems, @problemsVia(@problemMarkers, @asNode,
-                              @containingFile, @typesInPackage))
+                              @containingFile, @typesInPackage)
+                * union({:error   /severity | eq("error")
+                         :warning /severity | eq("warning")}))
 
 |~~ Incoming call sites of a method — distinct :from skeletons
     of every :call reference. Eclipse SearchEngine emits one
@@ -598,11 +600,18 @@ let(:@testCallers, @callers | filter(/isTestScope))
 |~~ Callers outside test scope — production usage audit. ~~|
 let(:@productionCallers, @callers | filter(/isTestScope | not))
 
-|~~ Keep only elements whose @callers include no test-scope code.
-    Applied after @methods / @fields — yields un-exercised
-    declarations. ~~|
+|~~ Subject-level predicate — true iff the method/field has zero
+    test-scope callers. An exercise-gap marker for production code
+    that tests do not reach. Members with only test-scope callers
+    (no production users) are NOT flagged — they already have a
+    test touching them.
+
+    Compose over a Vec of member skeletons via filter / every / any:
+      "pkg.Foo" | @methods | filter(@untested) * /fqn
+      "pkg.Foo" | @methods | any(@untested)
+    Or apply to a single method / field node for a boolean check. ~~|
 let(:@untested,
-    filter(@callers | filter(/isTestScope) | empty))
+    @callers | filter(/isTestScope) | empty)
 
 |~~ For a type node, every test-scope caller across the type
     itself plus its declared methods and fields. Returns the Vec
@@ -621,30 +630,31 @@ let(:@tests,
 
 |~ ── Annotation conduits ───────────────────────────────────── ~|
 
-|~~ Keep only elements declaring the given annotation FQN. The
-    argument is a String — the full qualified annotation type,
-    e.g. "org.junit.jupiter.api.Test", "java.lang.Deprecated",
-    "org.springframework.stereotype.Service". ~~|
-let(:@annotated, [:annotationFqn],
-    filter(/annotations | any(eq(annotationFqn))))
+|~~ Subject-level predicate — true iff the element's :annotations
+    Vec contains annotationFqn. Argument is a String — the full
+    qualified annotation type, e.g. "org.junit.jupiter.api.Test",
+    "java.lang.Deprecated", "org.springframework.stereotype.Service".
 
-|~~ Deprecated elements — shorthand for
-    @annotated("java.lang.Deprecated"). ~~|
-let(:@deprecated, @annotated("java.lang.Deprecated"))
+    Compose with filter / every / any over a Vec of skeletons:
+      xs | filter(@annotatedWith("...Service"))
+      xs | any(@annotatedWith("...Test"))
+    Or apply directly to a single node-Map for a boolean check. ~~|
+let(:@annotatedWith, [:annotationFqn],
+    /annotations | any(eq(annotationFqn)))
 
-|~~ JUnit Jupiter `@Test` methods. Portable across JUnit 4 if the
-    caller wants that flavor, they pass the JUnit 4 FQN to
-    @annotated directly: @annotated("org.junit.Test"). ~~|
-let(:@testMethods,
-    @annotated("org.junit.jupiter.api.Test"))
+|~~ Deprecated-element predicate — alias of
+    @annotatedWith("java.lang.Deprecated"). Same predicate
+    contract — compose with filter / every / any, or apply to
+    a single node for true / false. ~~|
+let(:@deprecated, @annotatedWith("java.lang.Deprecated"))
 
 |~ ── Markdown render shortcuts ────────────────────────────── ~|
 
-|~~ Collect a member's detail + source text + outgoing + incoming
-    refs into a single bundle and hand it to the host-bound
-    mdSource renderer. For a method / field: source body + call
-    sites both ways. For a type: source + its type-use refs on
-    each side.
+|~~ @source enriched with the context an IDE shows on Ctrl/Cmd-hover:
+    detail header (signature, modifiers, javadoc), source body,
+    outgoing / incoming refs, and — for types — supers / subtypes.
+    Subject can be a Type, Method, or Field; mdSource omits empty
+    sections, so non-type subjects render without a Hierarchy block.
 
     Pipes the rendered String through as-is — `jdt q '…' >
     Foo.md` writes markdown without quoting.  ~~|
@@ -652,8 +662,10 @@ let(:@sourceCard,
     @asNode | as(:self)
     | {:node     self | @detail
        :text     self | @source
-       :outgoing self | @outgoingRefs     !| []
-       :incoming self | @incomingRefs(:all) !| []}
+       :outgoing self | @outgoingRefs       !| []
+       :incoming self | @incomingRefs(:all) !| []
+       :supers   self | @supers             !| []
+       :subtypes self | @subtypes           !| []}
     | mdSource)
 
 |~~ Type hierarchy card — ↑ supers / ↓ subtypes flat markdown. ~~|

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -214,34 +214,56 @@ wildcard like "*Service") or a nullary axis (@projects, @problems).
 Exit is always 0; errors land on stdout as \`!{:kind … :message …}\`
 values — route with \`!|\`.
 
-───── Cookbook — copy, swap the FQN, run ─────
+───── fqn — fully qualified name ─────
 
-  # 1. Find types by wildcard
+  fqn identifies a workspace element. Format depends on element kind:
+
+  <Type>      pkg.Class                         inner: pkg.Outer.Inner
+  <Method>    pkg.Class#name(ParamType,…)       signature optional — required only to disambiguate overloads
+  <Field>     pkg.Class#name
+  <Package>   pkg.sub
+  <Project>   eclipse project name (NOT a path)
+  <File>      absolute filesystem path
+
+  Interfaces / annotations / enums / records share the <Type> format.
+
+───── Cookbook ─────
+
+  # Find types by wildcard
   jdt q '"*Service" | @types * /fqn'
 
-  # 2. Full card for a method — source + refs + hierarchy, markdown
-  jdt q '"pkg.Foo#bar()" | @sourceCard' > bar.md
+  # Read source — Type, Method, or Field; library sources too when a JAR has source attachment
+  jdt q '"<Method>" | @source'
 
-  # 3. Who calls a method (distinct FQNs)
-  jdt q '"pkg.Foo#bar" | @callers * /fqn | distinct'
+  # Markdown card — header + code fence + outgoing / incoming refs
+  jdt q '"<Method>" | @sourceCard'
 
-  # 4. Full supertype chain of a type
-  jdt q '"pkg.Foo" | @ancestors * /fqn'
+  # Callers of a method
+  jdt q '"<Method>" | @callers * /fqn'
 
-  # 5. Compilation state, flat table
-  jdt q '@problems * {:sev /severity :file /location/file :line /location/startLine :msg /message} | table'
+  # Outgoing calls of a method
+  jdt q '"<Method>" | @calls * /fqn'
 
-  # 6. Deletion candidates — public methods with zero callers
-  jdt q '"pkg.Foo" | @methods | filter(/modifiers | any(eq("public"))) | filter(@callers | empty) * /fqn'
+  # Supertype chain of a type
+  jdt q '"<Type>" | @ancestors * /fqn'
 
-  # 7. Hotspots — biggest methods in a type, ranked
-  jdt q '"pkg.Foo" | @methods | sortWith(desc(/location/lineCount)) | take(5) * {:fqn /fqn :lines /location/lineCount} | table'
+  # Subtypes of a type (all descendants), or implementations of an abstract/interface method
+  jdt q '"<Type>" | @implementors * /fqn'
 
-  # 8. Project-wide dead code — every type's public orphans
-  jdt q '"my.project" | @typesInProject * @publicOrphans | flat * /fqn'
-  -- pattern: Vec-of-nodes | * conduit | flat * /fqn  — distribute,
-  -- flatten the per-type Vecs, project fqn. Reuse for @tests,
-  -- @untested, @typeUses, etc. across a project.
+  # Compile errors in a project (drop filter or use /warning to see warnings instead)
+  jdt q '"<Project>" | @problems | filter(/error) * {:file /location/file :line /location/startLine :msg /message}'
+
+  # Types in a project carrying an annotation (annotation is a <Type>)
+  jdt q '"<Project>" | @typesInProject | filter(@annotatedWith("<Type>")) * /fqn'
+
+  # Tests that exercise a type
+  jdt q '"<Type>" | @tests * /fqn'
+
+  # Existence check — element on success, :type-not-found via fail-track on miss
+  jdt q '"<Type>" | @type !| /kind'
+
+  # Hotspots — biggest methods in a type
+  jdt q '"<Type>" | @methods | sortWith(desc(/location/lineCount)) | take(5) * {:fqn /fqn :lines /location/lineCount}'
 
 ───── Volume estimate — size a result before reading it ─────
 
@@ -279,12 +301,13 @@ Containment:
   package | @typesInPackage
   file    | @typesInFile
   project | @packagesInProject  @typesInProject
-  node    | @classpath  @containingType  @containingPackage
+  project | @classpath
+  node    | @containingType  @containingPackage
             @containingFile  @containingProject
 
 Hierarchy:
   type   | @supers  @subtypes  @ancestors  @descendants  @implementors
-  method | @overrides  @overloads
+  method | @overrides  @overloads  @implementors
 
 References (nullary, subject from pipeValue):
   node   | @incomingRefs          default refKind by subject kind
@@ -295,15 +318,16 @@ References (nullary, subject from pipeValue):
 Sugar conduits:
   method  | @callers  @testCallers  @productionCallers
   field   | @readers  @writers
-  member  | @calls  @typeUses  @dependsOn  @usedBy
+  member  | @calls  @typeUses
+  type    | @dependsOn  @usedBy
   type    | @tests                  test-scope callers across type + members
   node    | @detail                 lift skeleton → detail
-  element | @annotated(fqn)  @deprecated  @testMethods
-            @untested  @publicOrphans  @deadCode
+  element | @annotatedWith(fqn)  @deprecated  @untested   — predicates, use inside filter/every/any
+  type    | @publicOrphans  @deadCode
   Vec     | @sourceOnly  @overview  @inProject(projName)
 
 Markdown cards (return a String — pipe to a file):
-  "pkg.Foo#bar()" | @sourceCard      header + code + refs + hierarchy
+  "pkg.Foo#bar()" | @sourceCard      header + code fence + outgoing / incoming refs
   "pkg.Foo"       | @hierarchyCard   ↑ supers / ↓ subtypes
   "pkg.Foo"       | @outlineCard     fields / methods / inner types
   Vec<:reference> | mdRefs           grouped by refKind
@@ -318,7 +342,7 @@ Host-bound I/O + format (from qlang-cli):
   manifest | count                              all ops
   manifest | filter(/effectful) * /name         every axis name
   reify(:@members)                              descriptor
-  reify(:@members) | runExamples | table        verify docs
+  reify(:@members) | runExamples                verify docs
   reify(:@callers) | /source                    read a conduit's body
 
 ───── Debug — errors are data ─────

--- a/cli/src/commands/setup.mjs
+++ b/cli/src/commands/setup.mjs
@@ -459,6 +459,33 @@ export async function setup(args) {
     return setupRemote(args.slice(1));
   }
 
+  // Validate args: default mode installs the plugin (stops Eclipse, runs mvn
+  // verify) — must not run on typos or unknown flags. Reject anything not in
+  // the allowlist so the user gets help instead of a destructive side effect.
+  // `jdt help setup` is the way to read the help, consistent with other commands.
+  const booleanFlags = new Set([
+    "--check", "--remove", "--claude", "--remove-claude",
+    "--skip-build", "--clean",
+  ]);
+  const valueFlags = new Set(["--eclipse"]);
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (!a.startsWith("--")) {
+      console.error(`Unexpected argument: ${a}\n`);
+      console.log(help);
+      process.exit(1);
+    }
+    if (valueFlags.has(a)) {
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) i++;
+      continue;
+    }
+    if (!booleanFlags.has(a)) {
+      console.error(`Unknown option: ${a}\n`);
+      console.log(help);
+      process.exit(1);
+    }
+  }
+
   const flags = parseFlags(args);
   const config = readConfig();
   if (flags.eclipse) config.eclipse = flags.eclipse;

--- a/cli/test/graph-annotated.test.mjs
+++ b/cli/test/graph-annotated.test.mjs
@@ -1,0 +1,79 @@
+// Behavioural tests for the :jdt/graph annotation predicates.
+//
+//   @annotatedWith(fqn) — true iff subject :annotations contains fqn
+//   @deprecated         — alias of @annotatedWith("java.lang.Deprecated")
+//
+// Both run on inline node-Map subjects, so no HTTP / Eclipse — the
+// default loadGraphSession (which throws on any HTTP) catches any
+// accidental network attempt.
+
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { loadGraphSession, resetGraphSession }
+    from "./helpers/graph-session.mjs";
+
+describe("@annotatedWith — annotation-FQN predicate", () => {
+  let session;
+  beforeAll(async () => { session = await loadGraphSession(); });
+  afterEach(resetGraphSession);
+
+  it("true when :annotations contains the FQN", async () => {
+    const { result } = await session.evalCell(`
+      {:annotations ["org.springframework.stereotype.Service"]}
+      | @annotatedWith("org.springframework.stereotype.Service")
+    `);
+    expect(result).toBe(true);
+  });
+
+  it("false when :annotations does not contain the FQN", async () => {
+    const { result } = await session.evalCell(`
+      {:annotations ["org.springframework.stereotype.Service"]}
+      | @annotatedWith("java.lang.Deprecated")
+    `);
+    expect(result).toBe(false);
+  });
+
+  it("false on empty :annotations", async () => {
+    const { result } = await session.evalCell(`
+      {:annotations []} | @annotatedWith("java.lang.Deprecated")
+    `);
+    expect(result).toBe(false);
+  });
+
+  it("matches exact FQN — substring does not match", async () => {
+    const { result } = await session.evalCell(`
+      {:annotations ["org.springframework.stereotype.Service"]}
+      | @annotatedWith("Service")
+    `);
+    expect(result).toBe(false);
+  });
+
+  it("composes into filter over a Vec of node-Maps", async () => {
+    const { result } = await session.evalCell(`
+      [{:fqn "A" :annotations ["S.Service"]}
+       {:fqn "B" :annotations ["S.Controller"]}
+       {:fqn "C" :annotations ["S.Service" "X"]}]
+      | filter(@annotatedWith("S.Service")) * /fqn
+    `);
+    expect(result).toEqual(["A", "C"]);
+  });
+});
+
+describe("@deprecated — alias predicate", () => {
+  let session;
+  beforeAll(async () => { session = await loadGraphSession(); });
+  afterEach(resetGraphSession);
+
+  it("true on a node with java.lang.Deprecated annotation", async () => {
+    const { result } = await session.evalCell(`
+      {:annotations ["java.lang.Deprecated"]} | @deprecated
+    `);
+    expect(result).toBe(true);
+  });
+
+  it("false on a node without it", async () => {
+    const { result } = await session.evalCell(`
+      {:annotations ["java.lang.Override"]} | @deprecated
+    `);
+    expect(result).toBe(false);
+  });
+});

--- a/cli/test/graph-problems.test.mjs
+++ b/cli/test/graph-problems.test.mjs
@@ -19,53 +19,16 @@
 // no range filter, matching the @source "Top-level types return
 // the full compilation unit" docstring.
 
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { describe, it, expect, afterEach } from "vitest";
 import { keyword } from "@kaluchi/qlang-core";
+import { loadGraphSession, resetGraphSession }
+    from "./helpers/graph-session.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const MODULE_LIB = join(__dirname, "..", "lib");
+// Thin wrapper preserving the (mockedGet) → session signature used
+// across this file's 50+ call sites.
+const loadSession = (mockedGet) => loadGraphSession({ mockedGet });
 
-function createLocator(graphImpls) {
-  return (namespaceName) => {
-    const qlangPath = join(
-        MODULE_LIB, ...namespaceName.split("/")) + ".qlang";
-    const source = readFileSync(qlangPath, "utf8");
-    const impls = namespaceName === "jdt/graph"
-        ? graphImpls : undefined;
-    return { source, impls };
-  };
-}
-
-async function loadSession(mockedGet) {
-  process.env.JDT_GRAPH_CACHE = "0";
-  vi.resetModules();
-  // client.mjs is imported by both graph.impl.mjs (get) and
-  // path-translate.mjs (currentInstance). currentInstance is
-  // stubbed to null so translateHostPathFromLocal is a no-op —
-  // tests run as a local instance, paths pass through unchanged.
-  vi.doMock("../src/client.mjs", () => ({
-    get: mockedGet,
-    currentInstance: () => null,
-    BridgeNotRunningError: class BridgeNotRunningError extends Error {},
-    isConnectionError: () => false,
-  }));
-  const graphImpl = await import(
-      "../lib/jdt/graph.impl.mjs?graphmod=" + Date.now());
-  const { createSession } = await import(
-      "@kaluchi/qlang-core/session");
-  const session = await createSession({
-      locator: createLocator(graphImpl.createImpls()) });
-  return session;
-}
-
-afterEach(() => {
-  delete process.env.JDT_GRAPH_CACHE;
-  vi.resetModules();
-  vi.doUnmock("../src/client.mjs");
-});
+afterEach(resetGraphSession);
 
 // ────────────────────────────────────────────────────────────────
 // HTTP-path mode: verifies primitive @problemMarkers URL shape.

--- a/cli/test/graph-untested.test.mjs
+++ b/cli/test/graph-untested.test.mjs
@@ -1,0 +1,60 @@
+// Behavioural tests for the :jdt/graph @untested predicate via
+// :qlang/impl override on @incomingRefs — the single builtin under
+// @untested → @callers → @incomingRefs. stubOp parses a qlang-literal
+// source string and wires it as the operand's stub impl in one step.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { loadGraphSession, resetGraphSession }
+    from "./helpers/graph-session.mjs";
+import { stubOp } from "./helpers/operand-stub.mjs";
+
+describe("@untested — test-coverage gap predicate", () => {
+  afterEach(resetGraphSession);
+
+  it("true when the member has no callers at all", async () => {
+    const { result } = await (await loadGraphSession({
+      implsOverrides: await stubOp("@incomingRefs", `[]`),
+    })).evalCell(`{:fqn "pkg.Foo#bar()" :kind "method"} | @untested`);
+    expect(result).toBe(true);
+  });
+
+  it("true when every caller is production (no test-scope)", async () => {
+    const { result } = await (await loadGraphSession({
+      implsOverrides: await stubOp("@incomingRefs", `[
+        {:refKind "call" :from {:fqn "pkg.A#x()" :isTestScope false}}
+        {:refKind "call" :from {:fqn "pkg.B#y()" :isTestScope false}}
+      ]`),
+    })).evalCell(`{:fqn "pkg.Foo#bar()" :kind "method"} | @untested`);
+    expect(result).toBe(true);
+  });
+
+  it("false when at least one caller is test-scope", async () => {
+    const { result } = await (await loadGraphSession({
+      implsOverrides: await stubOp("@incomingRefs", `[
+        {:refKind "call" :from {:fqn "pkg.A#x()"        :isTestScope false}}
+        {:refKind "call" :from {:fqn "pkg.FooTest#t1()" :isTestScope true}}
+      ]`),
+    })).evalCell(`{:fqn "pkg.Foo#bar()" :kind "method"} | @untested`);
+    expect(result).toBe(false);
+  });
+
+  it("false when ALL callers are test-scope (covered)", async () => {
+    const { result } = await (await loadGraphSession({
+      implsOverrides: await stubOp("@incomingRefs", `[
+        {:refKind "call" :from {:fqn "pkg.FooTest#t1()" :isTestScope true}}
+        {:refKind "call" :from {:fqn "pkg.FooTest#t2()" :isTestScope true}}
+      ]`),
+    })).evalCell(`{:fqn "pkg.Foo#bar()" :kind "method"} | @untested`);
+    expect(result).toBe(false);
+  });
+
+  it("ignores non-call refKinds — a test-scope read is not a caller",
+        async () => {
+    const { result } = await (await loadGraphSession({
+      implsOverrides: await stubOp("@incomingRefs", `[
+        {:refKind "read" :from {:fqn "pkg.FooTest#peek()" :isTestScope true}}
+      ]`),
+    })).evalCell(`{:fqn "pkg.Foo#bar()" :kind "method"} | @untested`);
+    expect(result).toBe(true);
+  });
+});

--- a/cli/test/helpers/graph-session.mjs
+++ b/cli/test/helpers/graph-session.mjs
@@ -1,0 +1,59 @@
+// Loader for the :jdt/graph qlang module under test. Two ways to
+// keep tests off real HTTP / Eclipse:
+//
+//   mockedGet      — async (path) => responseValue. Stubs the
+//                    client.mjs get() at the HTTP-path layer; tests
+//                    that need to verify URL formation observe
+//                    `path` per call.
+//
+//   implsOverrides — { '@operandName': qlangImpl } merged over
+//                    graph.impl.mjs#createImpls(). resolveNamespaceEnv
+//                    patches each builtin descriptor's :qlang/impl
+//                    with the supplied value, so tests that care
+//                    about conduit semantics (not URL paths) can
+//                    bypass the HTTP layer entirely.
+//
+// When neither is supplied, get() throws loud — no test silently
+// hits the real bridge.
+
+import { vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODULE_LIB = join(__dirname, "..", "..", "lib");
+const GRAPH_QLANG = join(MODULE_LIB, "jdt", "graph.qlang");
+
+export async function loadGraphSession({ implsOverrides = {}, mockedGet } = {}) {
+  process.env.JDT_GRAPH_CACHE = "0";
+  vi.resetModules();
+  vi.doMock("../../src/client.mjs", () => ({
+    get: mockedGet ?? (async () => {
+      throw new Error("HTTP must not be hit; supply mockedGet or implsOverrides");
+    }),
+    currentInstance: () => null,
+    BridgeNotRunningError: class extends Error {},
+    isConnectionError: () => false,
+  }));
+  const graphImpl = await import(
+      "../../lib/jdt/graph.impl.mjs?v=" + Date.now());
+  const { createSession } = await import("@kaluchi/qlang-core/session");
+  const session = await createSession({
+    locator: (ns) => ns !== "jdt/graph" ? null : ({
+      source: readFileSync(GRAPH_QLANG, "utf8"),
+      impls: { ...graphImpl.createImpls(), ...implsOverrides },
+    }),
+  });
+  // Pre-import :jdt/graph so tests can call its conduits directly
+  // via session.evalCell without a `use(:jdt/graph) |` prefix.
+  const { error } = await session.evalCell("use(:jdt/graph)");
+  if (error) throw error;
+  return session;
+}
+
+export function resetGraphSession() {
+  delete process.env.JDT_GRAPH_CACHE;
+  vi.resetModules();
+  vi.doUnmock("../../src/client.mjs");
+}

--- a/cli/test/helpers/operand-stub.mjs
+++ b/cli/test/helpers/operand-stub.mjs
@@ -1,0 +1,25 @@
+// Generic stub factory for qlang builtin operands.
+//
+// stubOp(name, qlangSource) → { [name]: <stub-impl> }
+//
+// Parses qlangSource via evalQuery, wraps the resulting value in an
+// overloadedOp that ignores captured args (covers 0- and 1-captured
+// shapes — enough for axis-style operands like @incomingRefs that
+// take an optional modifier). The single-entry object is shaped to
+// spread directly into a loader's implsOverrides Map, so the operand
+// name appears only once at the call site:
+//
+//   implsOverrides: await stubOp("@incomingRefs", `[...]`)
+
+import { evalQuery } from "@kaluchi/qlang-core";
+import { overloadedOp } from "@kaluchi/qlang-core/dispatch";
+
+export async function stubOp(name, qlangSource) {
+  const value = await evalQuery(qlangSource);
+  return {
+    [name]: overloadedOp(name, 2, {
+      0: () => value,
+      1: async () => value,
+    }),
+  };
+}

--- a/cli/test/setup.test.mjs
+++ b/cli/test/setup.test.mjs
@@ -391,4 +391,52 @@ describe("setup command", () => {
       expect(help).toContain("--eclipse");
     });
   });
+
+  // ---- argument validation ----
+  //
+  // Regression: `jdt setup --help` used to fall through into the default
+  // install branch, which stops Eclipse and runs `mvn verify`. Any
+  // unrecognized input must print the problem + help and exit, not install.
+
+  describe("argument validation", () => {
+    it("exits on --help and does not run install (regression)", async () => {
+      const p2InstallFn = vi.fn();
+      const stopEclipseFn = vi.fn(() => true);
+      const execSyncFn = vi.fn(() => "BUILD SUCCESS");
+      mockDeps({
+        eclipse: {
+          isEclipseRunning: () => true,
+          stopEclipse: stopEclipseFn,
+          p2Install: p2InstallFn,
+        },
+        execSync: execSyncFn,
+      });
+      const { setup } = await importSetup();
+      await expect(setup(["--help"])).rejects.toThrow("exit(1)");
+      expect(p2InstallFn).not.toHaveBeenCalled();
+      expect(stopEclipseFn).not.toHaveBeenCalled();
+      const mvnCalls = execSyncFn.mock.calls.filter(
+        ([cmd]) => typeof cmd === "string" && cmd.startsWith("mvn ") && !cmd.includes("--version")
+      );
+      expect(mvnCalls).toEqual([]);
+      expect(io.errors.some((l) => l.includes("Unknown option: --help"))).toBe(true);
+      expect(io.logs.some((l) => l.includes("jdt setup"))).toBe(true);
+    });
+
+    it("exits with error on unknown --flag", async () => {
+      mockDeps();
+      const { setup } = await importSetup();
+      await expect(setup(["--bogus"])).rejects.toThrow("exit(1)");
+      expect(io.errors.some((l) => l.includes("Unknown option: --bogus"))).toBe(true);
+      expect(io.logs.some((l) => l.includes("jdt setup"))).toBe(true);
+    });
+
+    it("exits with error on unexpected positional argument", async () => {
+      mockDeps();
+      const { setup } = await importSetup();
+      await expect(setup(["garbage"])).rejects.toThrow("exit(1)");
+      expect(io.errors.some((l) => l.includes("Unexpected argument: garbage"))).toBe(true);
+      expect(io.logs.some((l) => l.includes("jdt setup"))).toBe(true);
+    });
+  });
 });

--- a/docs/jdt-query-spec.md
+++ b/docs/jdt-query-spec.md
@@ -298,7 +298,7 @@ renderer — one-shot from an fqn or node subject:
 
 | Conduit | Expands to |
 |---|---|
-| `@sourceCard` | `{:node @detail :text @source :outgoing @outgoingRefs :incoming @incomingRefs(:all)} \| mdSource` |
+| `@sourceCard` | `{:node @detail :text @source :outgoing @outgoingRefs :incoming @incomingRefs(:all) :supers @supers :subtypes @subtypes} \| mdSource` |
 | `@hierarchyCard` | `{:node @detail :supers @supers :subtypes @subtypes} \| mdHierarchy` |
 | `@outlineCard` | `{:node @detail :members @members} \| mdOutline` |
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DualSocketTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DualSocketTest.java
@@ -120,13 +120,17 @@ public class DualSocketTest {
                 assertTrue(clientSocket.isConnected());
             }
 
-            // Remote refuses
+            // Remote refuses (retry — OS may not have released
+            // the port immediately after close)
             boolean remoteRefused = false;
-            try (Socket clientSocket = new Socket(
-                    "127.0.0.1", remotePort)) {
-                // might connect to something reusing port
-            } catch (Exception connectionException) {
-                remoteRefused = true;
+            for (int attempt = 0; attempt < 10; attempt++) {
+                try (Socket clientSocket = new Socket(
+                        "127.0.0.1", remotePort)) {
+                    Thread.sleep(50);
+                } catch (Exception connectionException) {
+                    remoteRefused = true;
+                    break;
+                }
             }
             assertTrue(remoteRefused,
                     "Remote port should refuse after stop");


### PR DESCRIPTION
## Summary

- @untested, @annotatedWith, @deprecated become subject-level predicates — compose via filter / any / every, or apply to a single node for a boolean
- Rename @annotated to @annotatedWith; @testMethods dropped (inline via @annotatedWith FQN)
- @asNode dispatches "Type#name" to @field with fail-track to @method, mirroring GraphHandler.resolveTarget priority
- @problems attaches :error / :warning shortcut flags via union
- @sourceCard bundle includes :supers and :subtypes so mdSource renders the Hierarchy section for type subjects
- Cookbook in jdt help q rewritten around generic placeholders and an fqn-format matrix
- Shared loadGraphSession / stubOp helpers extracted; graph-annotated and graph-untested behavioural tests added
- README and agent prompts: jdt q '"<FQN>" | @members | table' replaced with jdt q '"<FQN>" | @members * /fqn' (table keeps its place in .qlang :examples)

## Test plan

- [x] 724/724 CLI tests pass (npm test)
- [x] New graph-annotated + graph-untested suites green
- [x] Live sanity run on m8 workspace — @members * /fqn, @problems with :error/:warning, @types wildcard