### PR TITLE
Implement EclEmma coverage support end-to-end (#101)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 coverage/
 !plugin/src/**/coverage/
 !plugin.tests/src/**/coverage/
+!ui/src/**/coverage/
 
 # Eclipse IDE
 .settings/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ bin/
 !cli/bin/
 node_modules/
 coverage/
+!plugin/src/**/coverage/
+!plugin.tests/src/**/coverage/
 
 # Eclipse IDE
 .settings/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ jdt q '"com.example.web.OrderController" | @members * /fqn'
 # Run tests with real-time progress streaming.
 # Failures shown immediately — no waiting for full suite to finish.
 jdt test run com.example.service.OrderServiceTest -f
+
+# Code coverage via the EclEmma plugin (when installed):
+# launch in coverage mode, list active sessions, dump on demand.
+jdt coverage run my-server
+jdt coverage runs
+jdt coverage status MyTest:1700000000000 -f
+jdt coverage dump MyTest:1700000000000 --reset
+jdt coverage refresh
+jdt coverage relaunch
+jdt coverage active
+jdt coverage activate MyTest:1700000000000
+jdt coverage merge MyTest:1700000000000 OtherTest:1700000000050
+jdt coverage remove --all
+jdt coverage stop MyTest:1700000000000
 ```
 
 ## Getting started

--- a/cli/README.md
+++ b/cli/README.md
@@ -75,6 +75,7 @@ See `jdt status intro` for the canonical sell-through pipelines.
 jdt build [--project <name>] [--incremental]           # (alias: b) build project (default: clean)
 jdt test run <FQN>[#method] [--project <name>] [-f]    # launch tests (non-blocking)
 jdt test run --project <name> [--package <pkg>] [-f]   # run tests in project
+jdt test run <FQN> --coverage                          # launch under EclEmma in coverage mode
 jdt test status <testRunId> [-f] [--all] [--ignored]   # show test progress/results
 jdt test runs                                          # list test runs
 ```
@@ -118,6 +119,27 @@ jdt rename <FQN> <newName>                             # rename type or method (
 jdt rename <FQN> <newName> --field <old>               # rename field
 jdt move <FQN> <target.package>                        # move type to another package
 ```
+
+### Coverage (EclEmma)
+
+```bash
+jdt coverage run <configId> [-f] [-q] [--json]         # start coverage launch
+jdt coverage runs                                      # list all sessions (table)
+jdt coverage status <coverageId> [-f] [--json]         # snapshot or stream status
+jdt coverage dump <coverageId> [--reset]               # request a JaCoCo dump
+jdt coverage refresh                                   # re-analyze active session
+jdt coverage relaunch                                  # relaunch active config in coverage mode
+jdt coverage active                                    # show active coverageId
+jdt coverage activate <coverageId>                     # switch active session
+jdt coverage merge <id> <id> [...] [--name <text>]     # merge two or more sessions
+jdt coverage remove [--all]                            # remove active or every session
+jdt coverage stop <coverageId>                         # terminate a live coverage launch
+```
+
+Requires the EclEmma plugin installed alongside jdtbridge. Without it,
+every subcommand returns `coverage-not-installed` JSON. `coverageId`
+for live launches mirrors `testRunId` byte-for-byte; for merged /
+imported sessions it carries the `merged:` / `imported:` prefix.
 
 ### Launches
 

--- a/cli/src/cli.mjs
+++ b/cli/src/cli.mjs
@@ -60,6 +60,30 @@ import {
 import { setup, help as setupHelp } from "./commands/setup.mjs";
 import { use, help as useHelp } from "./commands/use.mjs";
 import { query, help as queryHelp } from "./commands/query.mjs";
+import {
+  coverageRun,
+  coverageRuns,
+  coverageStatus,
+  coverageDump,
+  coverageRefresh,
+  coverageRelaunch,
+  coverageActive,
+  coverageActivate,
+  coverageMerge,
+  coverageRemove,
+  coverageStop,
+  coverageRunHelp,
+  coverageRunsHelp,
+  coverageStatusHelp,
+  coverageDumpHelp,
+  coverageRefreshHelp,
+  coverageRelaunchHelp,
+  coverageActiveHelp,
+  coverageActivateHelp,
+  coverageMergeHelp,
+  coverageRemoveHelp,
+  coverageStopHelp,
+} from "./commands/coverage.mjs";
 import { isConnectionError, BridgeNotRunningError } from "./client.mjs";
 import { bold, red, dim } from "./color.mjs";
 import { installTelemetry } from "./telemetry.mjs";
@@ -144,6 +168,55 @@ async function testDispatch(args) {
   await cmd.fn(rest);
 }
 
+const coverageSubcommands = {
+  run: { fn: coverageRun, help: coverageRunHelp },
+  runs: { fn: coverageRuns, help: coverageRunsHelp },
+  status: { fn: coverageStatus, help: coverageStatusHelp },
+  dump: { fn: coverageDump, help: coverageDumpHelp },
+  refresh: { fn: coverageRefresh, help: coverageRefreshHelp },
+  relaunch: { fn: coverageRelaunch, help: coverageRelaunchHelp },
+  active: { fn: coverageActive, help: coverageActiveHelp },
+  activate: { fn: coverageActivate, help: coverageActivateHelp },
+  merge: { fn: coverageMerge, help: coverageMergeHelp },
+  remove: { fn: coverageRemove, help: coverageRemoveHelp },
+  stop: { fn: coverageStop, help: coverageStopHelp },
+};
+
+const coverageHelp = `Manage EclEmma code coverage sessions and launches.
+
+Subcommands:
+  jdt coverage run <configId> [-f] [-q]              start coverage launch
+  jdt coverage runs                                  list all sessions
+  jdt coverage status <coverageId> [-f]              snapshot or stream
+  jdt coverage dump <coverageId> [--reset]           request a dump
+  jdt coverage refresh                               re-analyze active
+  jdt coverage relaunch                              relaunch active config
+  jdt coverage activate <coverageId>                 switch active session
+  jdt coverage active                                show active session
+  jdt coverage merge <id> <id> [...] [--name <txt>]  merge two or more
+  jdt coverage remove [--all]                        remove active or all
+  jdt coverage stop <coverageId>                     terminate live launch
+
+Requires EclEmma installed in Eclipse. Without it, every subcommand
+returns coverage-not-installed.
+
+Use "jdt help coverage <subcommand>" for details.`;
+
+async function coverageDispatch(args) {
+  const [sub, ...rest] = args;
+  if (!sub || sub === "--help") {
+    console.log(coverageHelp);
+    return;
+  }
+  const cmd = coverageSubcommands[sub];
+  if (!cmd) {
+    console.error(`Unknown coverage subcommand: ${sub}\n`);
+    printFullSubcommandHelp("coverage", coverageSubcommands);
+    process.exit(1);
+  }
+  await cmd.fn(rest);
+}
+
 const agentSubcommands = {
   run: { fn: agentRun, help: agentRunHelp },
   list: { fn: agentList, help: agentListHelp },
@@ -192,6 +265,7 @@ const commands = {
   status: { fn: status, help: statusHelp },
   git: { fn: git, help: gitHelp },
   launch: { fn: launchDispatch, help: launchHelp },
+  coverage: { fn: coverageDispatch, help: coverageHelp },
   agent: { fn: agentDispatch, help: agentHelp },
   setup: { fn: setup, help: setupHelp },
   use: { fn: use, help: useHelp },

--- a/cli/src/commands/coverage.mjs
+++ b/cli/src/commands/coverage.mjs
@@ -206,13 +206,13 @@ Mirrors Coverage View toolbar → Relaunch Session.`;
 
 export async function coverageActive(args) {
   const data = await get("/coverage/active");
+  // Read-only command — must exit 0 even on error
+  // (feedback_jdt_read_only_exit_zero.md). output() routes errors
+  // to stderr/stdout for us; no process.exit on the text path.
   output(args, data, {
     text(d) {
-      if (d.error) {
-        console.error(JSON.stringify(d));
-        process.exit(1);
-      }
-      console.log(d.activeCoverageId == null ? "none" : d.activeCoverageId);
+      console.log(d.activeCoverageId == null
+          ? "none" : d.activeCoverageId);
     },
   });
 }

--- a/cli/src/commands/coverage.mjs
+++ b/cli/src/commands/coverage.mjs
@@ -1,0 +1,371 @@
+// `jdt coverage *` subcommand dispatcher and implementations.
+// Server contract: bridge-coverage-spec.md.
+
+import { get, post } from "../client.mjs";
+import { extractPositional, parseFlags } from "../args.mjs";
+import { output } from "../output.mjs";
+import { renderRunsTable } from "../format/coverage-runs.mjs";
+import {
+  formatRunHeader,
+  formatStatusSnapshot,
+  followCoverageStream,
+  runGuide,
+} from "../format/coverage-status.mjs";
+
+// -- run --------------------------------------------------------------
+
+export async function coverageRun(args) {
+  const filtered = args.filter((a) => a !== "-f" && a !== "-q");
+  const pos = extractPositional(filtered);
+  const flags = parseFlags(args);
+
+  const configId = pos[0];
+  if (!configId) {
+    console.error("Usage: jdt coverage run <configId> [-f] [-q] [--json]");
+    process.exit(1);
+  }
+
+  let url = `/coverage/run?configId=${encodeURIComponent(configId)}`;
+  if (flags.args) url += `&args=${encodeURIComponent(flags.args)}`;
+
+  const result = await get(url, 30_000);
+  if (result.error) {
+    console.error(JSON.stringify(result));
+    process.exit(1);
+  }
+
+  const jsonFlag = args.includes("--json");
+  if (jsonFlag) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatRunHeader(result));
+  }
+
+  const follow = args.includes("-f") || args.includes("--follow");
+  if (follow) {
+    if (!jsonFlag) console.log();
+    const exit = await followCoverageStream(result.coverageId, args);
+    process.exit(exit);
+  }
+
+  const quiet = args.includes("-q") || args.includes("--quiet");
+  if (!quiet && !jsonFlag) {
+    console.log(runGuide(result.coverageId, result.launchId || result.configId));
+  }
+}
+
+export const coverageRunHelp = `Launch a coverage run (non-blocking).
+
+Usage:  jdt coverage run <configId> [-f] [-q] [--json]
+
+Flags:
+  -f, --follow    stream state events until analysis terminates
+  -q, --quiet     suppress onboarding guide
+  --args <text>   extra arguments appended to launch config
+  --json          JSON snapshot output
+
+Examples:
+  jdt coverage run MyTest
+  jdt coverage run MyTest -f
+  jdt coverage run my-server --args "--port 8080"`;
+
+// -- runs -------------------------------------------------------------
+
+export async function coverageRuns(args) {
+  const data = await get("/coverage/runs");
+  output(args, data, {
+    empty: "(no coverage sessions)",
+    text: renderRunsTable,
+  });
+}
+
+export const coverageRunsHelp = `List all coverage sessions.
+
+Usage:  jdt coverage runs [--json]
+
+Mirrors Eclipse's session-selection dropdown in the Coverage View.
+Active session marked with *.`;
+
+// -- status -----------------------------------------------------------
+
+export async function coverageStatus(args) {
+  const pos = extractPositional(args.filter((a) => a !== "-f"));
+  const coverageId = pos[0];
+  if (!coverageId) {
+    console.error("Usage: jdt coverage status <coverageId> [-f] [--json]");
+    process.exit(1);
+  }
+  const follow = args.includes("-f") || args.includes("--follow");
+  if (follow) {
+    const exit = await followCoverageStream(coverageId, args);
+    process.exit(exit);
+  }
+  const url = `/coverage/session?coverageId=${encodeURIComponent(coverageId)}`;
+  const data = await get(url, 30_000);
+  output(args, data, {
+    text(d) { console.log(formatStatusSnapshot(d)); },
+  });
+}
+
+export const coverageStatusHelp = `Show snapshot or stream of one coverage session.
+
+Usage:  jdt coverage status <coverageId> [-f] [--json]
+
+Without -f: snapshot of current state including counters.
+With -f: streams transition events until terminal state.
+
+Counters shown only when analysisReady == true. coverageId may carry
+:N dump suffix to address a specific dump within a live run.`;
+
+// -- dump -------------------------------------------------------------
+
+export async function coverageDump(args) {
+  const pos = extractPositional(args);
+  const coverageId = pos[0];
+  if (!coverageId) {
+    console.error("Usage: jdt coverage dump <coverageId> [--reset] [--json]");
+    process.exit(1);
+  }
+  const reset = args.includes("--reset");
+  const data = await post(
+    "/coverage/dump",
+    JSON.stringify({ coverageId, reset }),
+    "application/json",
+  );
+  output(args, data, {
+    text(d) {
+      if (d.error) {
+        console.error(JSON.stringify(d));
+        process.exit(1);
+      }
+      console.log(`Dumped ${coverageId}${reset ? " (reset)" : ""}`);
+    },
+  });
+}
+
+export const coverageDumpHelp = `Request a dump from the running JaCoCo agent.
+
+Usage:  jdt coverage dump <coverageId> [--reset] [--json]
+
+Mirrors Coverage View toolbar → Dump Execution Data button.
+
+Flags:
+  --reset    clear agent probes after this dump (next dump cumulates
+             only what runs after the reset)`;
+
+// -- refresh ----------------------------------------------------------
+
+export async function coverageRefresh(args) {
+  const data = await post("/coverage/refresh", "{}", "application/json");
+  output(args, data, {
+    text(d) {
+      if (d.error) {
+        console.error(JSON.stringify(d));
+        process.exit(1);
+      }
+      console.log(`Refreshed ${d.activeCoverageId}`);
+    },
+  });
+}
+
+export const coverageRefreshHelp = `Re-analyze the active coverage session.
+
+Usage:  jdt coverage refresh [--json]
+
+Mirrors Coverage View popup → Refresh (F5).`;
+
+// -- relaunch ---------------------------------------------------------
+
+export async function coverageRelaunch(args) {
+  const data = await post("/coverage/relaunch", "{}", "application/json");
+  if (data.error) {
+    console.error(JSON.stringify(data));
+    process.exit(1);
+  }
+  const jsonFlag = args.includes("--json");
+  if (jsonFlag) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+  console.log(formatRunHeader(data));
+  const follow = args.includes("-f") || args.includes("--follow");
+  if (follow) {
+    console.log();
+    const exit = await followCoverageStream(data.coverageId, args);
+    process.exit(exit);
+  }
+}
+
+export const coverageRelaunchHelp = `Re-launch the active session's source config.
+
+Usage:  jdt coverage relaunch [-f] [-q] [--json]
+
+Mirrors Coverage View toolbar → Relaunch Session.`;
+
+// -- active / activate ------------------------------------------------
+
+export async function coverageActive(args) {
+  const data = await get("/coverage/active");
+  output(args, data, {
+    text(d) {
+      if (d.error) {
+        console.error(JSON.stringify(d));
+        process.exit(1);
+      }
+      console.log(d.activeCoverageId == null ? "none" : d.activeCoverageId);
+    },
+  });
+}
+
+export const coverageActiveHelp = `Show the active coverage session ID.
+
+Usage:  jdt coverage active [--json]
+
+Returns "none" when no session is active.`;
+
+export async function coverageActivate(args) {
+  const pos = extractPositional(args);
+  const coverageId = pos[0];
+  if (!coverageId) {
+    console.error("Usage: jdt coverage activate <coverageId> [--json]");
+    process.exit(1);
+  }
+  const data = await post(
+    "/coverage/activate",
+    JSON.stringify({ coverageId }),
+    "application/json",
+  );
+  output(args, data, {
+    text(d) {
+      if (d.error) {
+        console.error(JSON.stringify(d));
+        process.exit(1);
+      }
+      console.log(`Activated ${d.activeCoverageId}`);
+      if (d.previousActiveCoverageId) {
+        console.log(`Previous: ${d.previousActiveCoverageId}`);
+      }
+    },
+  });
+}
+
+export const coverageActivateHelp = `Make a session the active one.
+
+Usage:  jdt coverage activate <coverageId> [--json]`;
+
+// -- merge ------------------------------------------------------------
+
+export async function coverageMerge(args) {
+  const flags = parseFlags(args);
+  const pos = extractPositional(args);
+  if (pos.length < 2) {
+    console.error("Usage: jdt coverage merge <coverageId> <coverageId> [...]"
+      + " [--name <description>] [--json]");
+    process.exit(1);
+  }
+  const body = { coverageIds: pos };
+  if (flags.name) body.description = flags.name;
+  const data = await post(
+    "/coverage/merge",
+    JSON.stringify(body),
+    "application/json",
+  );
+  output(args, data, {
+    text(d) {
+      if (d.error) {
+        console.error(JSON.stringify(d));
+        process.exit(1);
+      }
+      const consumed = d.consumedCoverageIds || [];
+      console.log(`#### Merged ${consumed.length} sessions → ${d.mergedCoverageId}`);
+      if (consumed.length) {
+        console.log("\nConsumed:");
+        for (const id of consumed) console.log(`  ${id}  removed`);
+      }
+      if (d.active) {
+        console.log(`\nActive session: ${d.mergedCoverageId}`);
+        console.log(`  jdt coverage status ${d.mergedCoverageId} -f`);
+      }
+    },
+  });
+}
+
+export const coverageMergeHelp = `Merge two or more coverage sessions.
+
+Usage:  jdt coverage merge <coverageId> <coverageId> [...] [--name <text>] [--json]
+
+Mirrors Coverage View toolbar → Merge Sessions… When --name is omitted
+the bridge supplies Eclipse's default ('Merged ({date} {time})').
+Inputs become unresolvable after merge.`;
+
+// -- remove -----------------------------------------------------------
+
+export async function coverageRemove(args) {
+  const all = args.includes("--all");
+  const data = await post(
+    "/coverage/remove",
+    JSON.stringify(all ? { all: true } : {}),
+    "application/json",
+  );
+  output(args, data, {
+    text(d) {
+      if (d.error) {
+        console.error(JSON.stringify(d));
+        process.exit(1);
+      }
+      const removed = d.removedCoverageIds || [];
+      console.log(`Removed ${removed.length} coverage session${removed.length === 1 ? "" : "s"}`);
+    },
+  });
+}
+
+export const coverageRemoveHelp = `Remove coverage sessions.
+
+Usage:  jdt coverage remove [--all] [--json]
+
+Without --all: removes the active session.
+With --all: removes every tracked session.`;
+
+// -- stop -------------------------------------------------------------
+
+export async function coverageStop(args) {
+  const pos = extractPositional(args);
+  const coverageId = pos[0];
+  if (!coverageId) {
+    console.error("Usage: jdt coverage stop <coverageId>");
+    process.exit(1);
+  }
+  // Resolve coverageId → launchId via /coverage/runs, then delegate.
+  const runs = await get("/coverage/runs");
+  if (runs.error) {
+    console.error(JSON.stringify(runs));
+    process.exit(1);
+  }
+  const run = runs.find((r) => r.coverageId === coverageId);
+  if (!run) {
+    console.error(`coverage-not-found: ${coverageId}`);
+    process.exit(1);
+  }
+  if (run.coverageSessionKind !== "live") {
+    console.error(`coverage-launch-not-live: ${coverageId}`);
+    process.exit(1);
+  }
+  if (!run.launchId) {
+    console.error(`coverage-launch-not-live: no launchId for ${coverageId}`);
+    process.exit(1);
+  }
+  const data = await get(`/launch/stop?launchId=${encodeURIComponent(run.launchId)}`);
+  if (data.error) {
+    console.error(data.error);
+    process.exit(1);
+  }
+  console.log(`Stopped ${coverageId}`);
+}
+
+export const coverageStopHelp = `Terminate a running coverage launch.
+
+Usage:  jdt coverage stop <coverageId>
+
+Resolves coverageId to launchId (via /coverage/runs) and delegates to
+jdt launch stop. Errors with coverage-launch-not-live for merged or
+imported sessions.`;

--- a/cli/src/commands/test-run.mjs
+++ b/cli/src/commands/test-run.mjs
@@ -39,6 +39,8 @@ export async function testRun(args) {
   }
 
   if (args.includes("--no-refresh")) url += "&no-refresh";
+  const coverage = args.includes("--coverage");
+  if (coverage) url += "&coverage=true";
 
   const result = await get(url, 30_000);
   if (result.error) {
@@ -71,6 +73,15 @@ export async function testRun(args) {
   const jsonFlag = args.includes("--json");
   if (!jsonFlag) console.log(formatTestRunHeader(result));
 
+  if (coverage && !jsonFlag) {
+    if (result.coverageId) {
+      console.log(`CoverageId: \`${result.coverageId}\``);
+    }
+    if (result.launchMode) {
+      console.log(`LaunchMode: ${result.launchMode}`);
+    }
+  }
+
   const follow = args.includes("-f") || args.includes("--follow");
   if (follow) {
     if (!jsonFlag) console.log();
@@ -81,6 +92,12 @@ export async function testRun(args) {
   const quiet = args.includes("-q") || args.includes("--quiet");
   if (!quiet) {
     console.log(testRunGuide(testRunId, launchId));
+    if (coverage && result.coverageId && !jsonFlag) {
+      console.log("");
+      console.log("**Coverage status:**");
+      console.log(`  \`jdt coverage status ${result.coverageId}\`             snapshot`);
+      console.log(`  \`jdt coverage status ${result.coverageId} -f\`          follow`);
+    }
   }
 }
 

--- a/cli/src/commands/test-sessions.mjs
+++ b/cli/src/commands/test-sessions.mjs
@@ -2,6 +2,7 @@ import { get } from "../client.mjs";
 import { output } from "../output.mjs";
 import { green, red, yellow } from "../color.mjs";
 import { formatTable } from "../format/table.mjs";
+import { ago } from "../format/relative-time.mjs";
 
 /**
  * List test runs (active and completed).
@@ -41,15 +42,6 @@ function formatCounts(s) {
   if (s.errors > 0) parts.push(red(`${s.errors} errors`));
   if (s.ignored > 0) parts.push(yellow(`${s.ignored} ign`));
   return parts.join(", ");
-}
-
-function ago(ms) {
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  return `${h}h ago`;
 }
 
 export const help = `List test runs (active and completed).

--- a/cli/src/format/coverage-runs.mjs
+++ b/cli/src/format/coverage-runs.mjs
@@ -1,0 +1,21 @@
+// Renderer for `jdt coverage runs` — table output.
+
+import { formatTable } from "./table.mjs";
+import { composeStatus } from "./coverage-state.mjs";
+
+/**
+ * Render the array returned by GET /coverage/runs as a table.
+ * @param {object[]} runs
+ */
+export function renderRunsTable(runs) {
+  const headers = ["COVERAGEID", "CONFIGID", "ACTIVE", "DUMPS", "STATUS"];
+  const now = Date.now();
+  const rows = runs.map((run) => [
+    run.coverageId,
+    run.configId || "—",
+    run.active ? "*" : "",
+    String(run.dumpCount ?? ""),
+    composeStatus(run, now),
+  ]);
+  console.log(formatTable(headers, rows));
+}

--- a/cli/src/format/coverage-state.mjs
+++ b/cli/src/format/coverage-state.mjs
@@ -5,6 +5,7 @@
 //   A — exactly one launch/origin token
 //   B — zero or more data/analysis tokens, in order
 //   C — at most one relative-time token (live runs only)
+import { ago } from "./relative-time.mjs";
 
 /**
  * @param {object} run — entry from /coverage/runs (one element)
@@ -64,14 +65,3 @@ export function composeStatus(run, now = Date.now()) {
   return tokens.join(", ");
 }
 
-function ago(ms) {
-  if (ms < 0) ms = 0;
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
-}

--- a/cli/src/format/coverage-state.mjs
+++ b/cli/src/format/coverage-state.mjs
@@ -1,0 +1,77 @@
+// Compose the STATUS string for jdt coverage runs / status.
+// Source: jdt-coverage-spec § STATUS composition.
+//
+// Three token groups, joined by ", ":
+//   A — exactly one launch/origin token
+//   B — zero or more data/analysis tokens, in order
+//   C — at most one relative-time token (live runs only)
+
+/**
+ * @param {object} run — entry from /coverage/runs (one element)
+ *   coverageSessionKind, terminated, dataReceived,
+ *   analysisLoading, analysisReady, dumpCount,
+ *   consumedCoverageIds (merged), launchTimestamp (live),
+ *   terminatedAt
+ * @param {number} now — Date.now() at render time
+ * @returns {string}
+ */
+export function composeStatus(run, now = Date.now()) {
+  const tokens = [];
+
+  // Group A — origin / launch state
+  const kind = run.coverageSessionKind;
+  if (kind === "merged") {
+    const n = (run.consumedCoverageIds || []).length;
+    tokens.push(`merged ${n} sessions`);
+  } else if (kind === "imported") {
+    tokens.push("imported");
+  } else if (kind === "live") {
+    if (run.terminated) {
+      const endMs = run.terminatedAt || 0;
+      tokens.push(endMs ? `finished ${ago(now - endMs)}` : "finished");
+    } else {
+      tokens.push("running");
+    }
+  }
+
+  // Group B — data / analysis
+  if (run.dataReceived === false && run.terminated === true) {
+    tokens.push("no data received");
+  }
+  if (run.dumpCount > 1) {
+    tokens.push(`${run.dumpCount} dumps`);
+  }
+  if (run.analysisLoading === true) {
+    tokens.push("analysis loading");
+  }
+  if (run.analysisReady === true) {
+    tokens.push("analysis ready");
+  }
+  if (
+    run.analysisLoading === false &&
+    run.analysisReady === false &&
+    run.terminated === true &&
+    run.dataReceived === true
+  ) {
+    tokens.push("analysis pending");
+  }
+
+  // Group C — relative time (live, not terminated)
+  if (kind === "live" && run.terminated === false && run.launchTimestamp) {
+    tokens.push(`started ${ago(now - run.launchTimestamp)}`);
+  }
+
+  return tokens.join(", ");
+}
+
+function ago(ms) {
+  if (ms < 0) ms = 0;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}

--- a/cli/src/format/coverage-status.mjs
+++ b/cli/src/format/coverage-status.mjs
@@ -202,31 +202,11 @@ function formatTime(millis) {
  * Returns 0 on clean exit, 1 on error.
  */
 export async function followCoverageStream(coverageId, args) {
-  const { getStreamLines } = await import("../client.mjs");
+  const { followJsonlStream } = await import("./stream.mjs");
   const jsonFlag = args.includes("--json");
   const url = `/coverage/session/stream?coverageId=${encodeURIComponent(coverageId)}`;
-
-  let detached = false;
-  const onSigint = () => {
-    detached = true;
-    process.stdout.write("\n");
-    process.exit(0);
-  };
-  process.on("SIGINT", onSigint);
-
-  try {
-    await getStreamLines(url, (line) => {
-      if (jsonFlag) console.log(line);
-      else formatStreamEvent(line);
-    });
-  } catch (e) {
-    if (!detached) {
-      console.error(e.message);
-      return 1;
-    }
-    return 0;
-  } finally {
-    process.removeListener("SIGINT", onSigint);
-  }
-  return 0;
+  return followJsonlStream(url, (line) => {
+    if (jsonFlag) console.log(line);
+    else formatStreamEvent(line);
+  });
 }

--- a/cli/src/format/coverage-status.mjs
+++ b/cli/src/format/coverage-status.mjs
@@ -1,0 +1,232 @@
+// Renderers for jdt coverage run / status / -f stream.
+
+import { bold, dim, green, red, yellow } from "../color.mjs";
+import { composeStatus } from "./coverage-state.mjs";
+
+/** Header printed by `jdt coverage run`. */
+export function formatRunHeader(result) {
+  const parts = [];
+  parts.push(`#### Coverage: ${result.configId}`);
+  parts.push(`CoverageId:    \`${result.coverageId}\``);
+  if (result.coverageScope?.length) {
+    parts.push("CoverageScope:");
+    for (const handle of result.coverageScope) {
+      parts.push(`  ${handle}`);
+    }
+  }
+  if (result.launchId) parts.push(`LaunchId:      \`${result.launchId}\``);
+  parts.push(`ConfigId:      \`${result.configId}\``);
+  if (result.configType) parts.push(`ConfigType:    ${result.configType}`);
+  parts.push("LaunchMode:    coverage");
+  return parts.join("\n");
+}
+
+/** Onboarding guide printed by `jdt coverage run` (unless -q). */
+export function runGuide(coverageId, launchId) {
+  return `
+**Coverage status** (coverageId = ${coverageId}):
+  \`jdt coverage status ${coverageId}\`             snapshot
+  \`jdt coverage status ${coverageId} -f\`          follow until ready
+  \`jdt coverage active\`                            show active session
+
+**Console output** (launchId = ${launchId}):
+  \`jdt launch logs ${launchId}\`
+  \`jdt launch logs ${launchId} --tail 50\`
+
+**Manage running launch:**
+  \`jdt coverage dump ${coverageId}\`               request a dump
+  \`jdt coverage dump ${coverageId} --reset\`       dump + reset agent probes
+  \`jdt coverage stop ${coverageId}\`               terminate
+
+**Sessions:**
+  \`jdt coverage runs\`                              list all sessions
+  \`jdt coverage activate ${coverageId}\`           switch IDE display
+  \`jdt coverage refresh\`                           re-analyze active
+  \`jdt coverage relaunch\`                          re-launch active in coverage mode
+  \`jdt coverage merge <coverageId> <coverageId>\`  merge two or more
+  \`jdt coverage remove\`                            remove active
+  \`jdt coverage remove --all\`                      remove all
+
+Add \`-q\` to suppress this guide.`;
+}
+
+/** Format a /coverage/session response as a snapshot block. */
+export function formatStatusSnapshot(entry) {
+  const status = composeStatus(entry);
+  const active = entry.active ? ", active" : "";
+  const lines = [];
+  lines.push(`#### ${entry.coverageId} (${entry.configId || entry.coverageSessionKind}) — ${status}${active}`);
+  lines.push("");
+  if (entry.coverageScope?.length) {
+    lines.push("CoverageScope:");
+    for (const handle of entry.coverageScope) {
+      lines.push(`  ${handle}`);
+    }
+  }
+  if (entry.description) {
+    lines.push(`Description:   ${entry.description}`);
+  }
+  if (entry.configType) {
+    lines.push(`ConfigType:    ${entry.configType}`);
+  }
+  if (entry.launchId) {
+    lines.push(`LaunchId:      ${entry.launchId}`);
+  }
+  if (typeof entry.dumpCount === "number") {
+    lines.push(`DumpCount:     ${entry.dumpCount}`);
+  }
+  if (entry.launchTimestamp) {
+    lines.push(`LaunchedAt:    ${formatDate(entry.launchTimestamp)}`);
+  }
+  if (entry.terminatedAt) {
+    lines.push(`TerminatedAt:  ${formatDate(entry.terminatedAt)}`);
+  } else if (entry.coverageSessionKind === "live" && entry.terminated === false) {
+    lines.push("TerminatedAt:  —");
+  }
+
+  if (entry.analysisReady === true && entry.counters) {
+    lines.push("");
+    for (const [label, key] of [
+      ["Instructions", "instruction"],
+      ["Branches", "branch"],
+      ["Lines", "line"],
+      ["Complexity", "complexity"],
+      ["Methods", "method"],
+      ["Classes", "class"],
+    ]) {
+      const c = entry.counters[key];
+      if (c) lines.push(formatCounterRow(label, c));
+    }
+  } else if (entry.analysisLoading === true) {
+    lines.push("");
+    lines.push(dim("(analysis loading)"));
+  } else if (entry.dataReceived === false && entry.terminated === true) {
+    lines.push("");
+    lines.push(dim("(no data received)"));
+  }
+  return lines.join("\n");
+}
+
+function formatCounterRow(label, c) {
+  const total = c.totalCount ?? 0;
+  if (total === 0) {
+    return `${label.padEnd(13)}—  ${colorStatus("EMPTY")}`;
+  }
+  const ratio = formatRatio(c.coveredRatio);
+  return [
+    label.padEnd(13),
+    `coveredCount=${c.coveredCount}`.padEnd(20),
+    `missedCount=${c.missedCount}`.padEnd(19),
+    `totalCount=${c.totalCount}`.padEnd(18),
+    `coveredRatio=${ratio}`.padEnd(20),
+    colorStatus(c.coverageStatus),
+  ].join("  ");
+}
+
+function formatRatio(r) {
+  if (r == null) return "—";
+  const pct = (r * 100).toFixed(1);
+  return `${pct}%`;
+}
+
+function colorStatus(status) {
+  switch (status) {
+    case "FULLY_COVERED": return green(status);
+    case "PARTLY_COVERED": return yellow(status);
+    case "NOT_COVERED": return red(status);
+    case "EMPTY": return dim(status);
+    default: return status;
+  }
+}
+
+function formatDate(millis) {
+  const d = new Date(millis);
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} `
+    + `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/**
+ * Format one JSONL event from /coverage/session/stream as a single
+ * human-readable line. Returns true if anything was written.
+ */
+export function formatStreamEvent(jsonLine) {
+  let ev;
+  try { ev = JSON.parse(jsonLine); } catch { return false; }
+  const ts = formatTime(Date.now());
+
+  switch (ev.event) {
+    case "snapshot": {
+      const status = composeStatus({
+        coverageSessionKind: ev.coverageSessionKind || "live",
+        terminated: ev.terminated,
+        dataReceived: ev.dataReceived,
+        analysisLoading: ev.analysisLoading,
+        analysisReady: ev.analysisReady,
+        dumpCount: ev.dumpCount || 0,
+      });
+      console.log(`[${ts}] snapshot: ${status || "—"}, ${ev.dumpCount || 0} dumps`);
+      return true;
+    }
+    case "dumped":
+      console.log(`[${ts}] dumped #${ev.dumpIndex} at ${formatTime(ev.dumpTimestamp)}`);
+      return true;
+    case "analysisLoading":
+      console.log(`[${ts}] analyzing #${ev.dumpIndex}`);
+      return true;
+    case "analysisReady":
+      console.log(`[${ts}] ready #${ev.dumpIndex}`);
+      return true;
+    case "terminated": {
+      const at = ev.terminatedAt ? formatTime(ev.terminatedAt) : ts;
+      const tail = ev.dataReceived === false ? " (no data)" : "";
+      console.log(`[${ts}] terminated at ${at}${tail}`);
+      return true;
+    }
+    case "failed":
+      console.log(`[${ts}] failed: ${ev.reason || "unknown"}`);
+      return true;
+    default:
+      return false;
+  }
+}
+
+function formatTime(millis) {
+  const d = new Date(millis);
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/**
+ * Stream /coverage/session/stream events.
+ * Returns 0 on clean exit, 1 on error.
+ */
+export async function followCoverageStream(coverageId, args) {
+  const { getStreamLines } = await import("../client.mjs");
+  const jsonFlag = args.includes("--json");
+  const url = `/coverage/session/stream?coverageId=${encodeURIComponent(coverageId)}`;
+
+  let detached = false;
+  const onSigint = () => {
+    detached = true;
+    process.stdout.write("\n");
+    process.exit(0);
+  };
+  process.on("SIGINT", onSigint);
+
+  try {
+    await getStreamLines(url, (line) => {
+      if (jsonFlag) console.log(line);
+      else formatStreamEvent(line);
+    });
+  } catch (e) {
+    if (!detached) {
+      console.error(e.message);
+      return 1;
+    }
+    return 0;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+  }
+  return 0;
+}

--- a/cli/src/format/relative-time.mjs
+++ b/cli/src/format/relative-time.mjs
@@ -1,0 +1,13 @@
+/** Render a millisecond duration as a coarse-grained "Xs/Xm/Xh/Xd ago"
+ *  string. Used by table renderers that surface relative timing. */
+export function ago(ms) {
+  if (ms < 0) ms = 0;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}

--- a/cli/src/format/stream.mjs
+++ b/cli/src/format/stream.mjs
@@ -1,0 +1,37 @@
+// Shared helpers for following a JSONL stream from the bridge.
+// Used by `jdt test status -f`, `jdt test run -f`, and the
+// `jdt coverage *` -f variants.
+
+/**
+ * Follow a JSONL endpoint with SIGINT handling. Each line is
+ * delivered raw to `onLine`; the caller decides whether to print
+ * it as-is (--json mode) or pass it through a formatter, and may
+ * accumulate per-line state.
+ *
+ * Returns 0 on clean exit, 1 when the stream errored before
+ * SIGINT.
+ */
+export async function followJsonlStream(url, onLine) {
+  const { getStreamLines } = await import("../client.mjs");
+
+  let detached = false;
+  const onSigint = () => {
+    detached = true;
+    process.stdout.write("\n");
+    process.exit(0);
+  };
+  process.on("SIGINT", onSigint);
+
+  try {
+    await getStreamLines(url, onLine);
+    return 0;
+  } catch (e) {
+    if (!detached) {
+      console.error(e.message);
+      return 1;
+    }
+    return 0;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+  }
+}

--- a/cli/src/format/test-status.mjs
+++ b/cli/src/format/test-status.mjs
@@ -184,7 +184,7 @@ Add \`-q\` to suppress this guide.`;
  * Returns exit code: 0 if all pass, 1 if any failures.
  */
 export async function followTestStream(testRunId, args) {
-  const { getStreamLines } = await import("../client.mjs");
+  const { followJsonlStream } = await import("./stream.mjs");
   const jsonFlag = args.includes("--json");
 
   let filter = "failures";
@@ -193,38 +193,18 @@ export async function followTestStream(testRunId, args) {
 
   const url = `/test/status/stream?testRunId=${encodeURIComponent(testRunId)}&filter=${filter}`;
 
-  let detached = false;
-  const onSigint = () => {
-    detached = true;
-    process.stdout.write("\n");
-    process.exit(0);
-  };
-  process.on("SIGINT", onSigint);
-
   let hasFailed = false;
-  try {
-    await getStreamLines(url, (line) => {
-      if (jsonFlag) {
-        console.log(line);
-      } else {
-        formatTestEvent(line);
+  const exit = await followJsonlStream(url, (line) => {
+    if (jsonFlag) console.log(line);
+    else formatTestEvent(line);
+    try {
+      const ev = JSON.parse(line);
+      if (ev.event === "finished"
+          && (ev.failed > 0 || ev.errors > 0)) {
+        hasFailed = true;
       }
-      try {
-        const ev = JSON.parse(line);
-        if (ev.event === "finished"
-            && (ev.failed > 0 || ev.errors > 0)) {
-          hasFailed = true;
-        }
-      } catch { /* ignore parse errors */ }
-    });
-  } catch (e) {
-    if (!detached) {
-      console.error(e.message);
-      return 1;
-    }
-    return 0;
-  } finally {
-    process.removeListener("SIGINT", onSigint);
-  }
+    } catch { /* ignore parse errors */ }
+  });
+  if (exit !== 0) return exit;
   return hasFailed ? 1 : 0;
 }

--- a/cli/test/commands.coverage.test.mjs
+++ b/cli/test/commands.coverage.test.mjs
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createServer } from "node:http";
+import { setColorEnabled } from "../src/color.mjs";
+
+// HTTP-mocked tests for the `jdt coverage *` subcommands.
+// Verifies CLI → bridge URL/method/body wiring and the rendered
+// human output. The bridge contract itself is covered by Java
+// tests in plugin.tests/src/.../coverage/.
+
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+function captureConsole() {
+  const logs = [];
+  const errors = [];
+  const origLog = console.log;
+  const origError = console.error;
+  const origExit = process.exit;
+  console.log = (...args) => logs.push(args.join(" "));
+  console.error = (...args) => errors.push(args.join(" "));
+  process.exit = (code) => { throw new Error(`exit(${code})`); };
+  return {
+    logs, errors,
+    restore() {
+      console.log = origLog;
+      console.error = origError;
+      process.exit = origExit;
+    },
+  };
+}
+
+describe("commands.coverage", () => {
+  let server, port, io;
+
+  beforeEach(() => {
+    setColorEnabled(false);
+    io = captureConsole();
+  });
+
+  afterEach(async () => {
+    io.restore();
+    if (server) await stopServer(server);
+    vi.resetModules();
+  });
+
+  async function setupMock(handler) {
+    ({ server, port } = await startServer(handler));
+    vi.doMock("../src/resolve.mjs", () => ({
+      resolveInstance: async () => ({
+        port, token: null, pid: process.pid,
+        workspace: "/test", host: "127.0.0.1", file: "",
+      }),
+    }));
+  }
+
+  function readBody(req) {
+    return new Promise((resolve) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    });
+  }
+
+  // ---- run --------------------------------------------------------
+
+  it("run sends configId and prints header", async () => {
+    let seen;
+    await setupMock((req, res) => {
+      seen = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true,
+        configId: "MyTest",
+        coverageId: "MyTest:1700000000000",
+        launchId: "MyTest:6408",
+        configType: "JUnit",
+        configTypeId: "org.eclipse.jdt.junit.launchconfig",
+        coverageScope: ["=MyProject/src"],
+        launchTimestamp: 1700000000000,
+        processPid: "6408",
+      }));
+    });
+    const { coverageRun } = await import("../src/commands/coverage.mjs");
+    await coverageRun(["MyTest", "-q"]);
+    expect(seen).toBe("/coverage/run?configId=MyTest");
+    expect(io.logs.join("\n")).toContain("#### Coverage: MyTest");
+    expect(io.logs.join("\n")).toContain("CoverageId:    `MyTest:1700000000000`");
+  });
+
+  it("run prints guide when -q absent", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true, configId: "X", coverageId: "X:1", launchId: "X:42",
+      }));
+    });
+    const { coverageRun } = await import("../src/commands/coverage.mjs");
+    await coverageRun(["X"]);
+    expect(io.logs.join("\n")).toContain("Coverage status");
+    expect(io.logs.join("\n")).toContain("jdt coverage status X:1");
+  });
+
+  it("run with --json emits raw response", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true, configId: "X", coverageId: "X:1", launchId: "X:42",
+      }));
+    });
+    const { coverageRun } = await import("../src/commands/coverage.mjs");
+    await coverageRun(["X", "--json", "-q"]);
+    const body = io.logs.join("\n");
+    expect(body).toContain('"ok": true');
+    expect(body).toContain('"coverageId": "X:1"');
+  });
+
+  it("run shows error and exits 1 on bridge error", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        error: "coverage-config-not-found",
+        message: "Launch configuration not found: Bogus",
+      }));
+    });
+    const { coverageRun } = await import("../src/commands/coverage.mjs");
+    await expect(coverageRun(["Bogus", "-q"])).rejects.toThrow("exit(1)");
+    expect(io.errors.join("\n")).toContain("coverage-config-not-found");
+  });
+
+  it("run prints usage on missing configId", async () => {
+    const { coverageRun } = await import("../src/commands/coverage.mjs");
+    await expect(coverageRun([])).rejects.toThrow("exit(1)");
+    expect(io.errors.join("\n")).toContain("Usage:");
+  });
+
+  // ---- runs -------------------------------------------------------
+
+  it("runs renders table from array response", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([{
+        coverageId: "MyTest:1700000000000",
+        coverageSessionKind: "live",
+        configId: "MyTest",
+        active: true,
+        terminated: false,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        launchTimestamp: Date.now() - 30_000,
+      }]));
+    });
+    const { coverageRuns } = await import("../src/commands/coverage.mjs");
+    await coverageRuns([]);
+    const out = io.logs.join("\n");
+    expect(out).toContain("COVERAGEID");
+    expect(out).toContain("MyTest:1700000000000");
+    expect(out).toContain("running");
+    expect(out).toContain("*"); // active marker
+  });
+
+  it("runs prints '(no coverage sessions)' on empty array", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("[]");
+    });
+    const { coverageRuns } = await import("../src/commands/coverage.mjs");
+    await coverageRuns([]);
+    expect(io.logs.join("\n")).toContain("(no coverage sessions)");
+  });
+
+  it("runs --json passes through raw array", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('[{"coverageId":"X:1"}]');
+    });
+    const { coverageRuns } = await import("../src/commands/coverage.mjs");
+    await coverageRuns(["--json"]);
+    expect(io.logs.join("\n")).toContain('"coverageId": "X:1"');
+  });
+
+  // ---- status -----------------------------------------------------
+
+  it("status renders snapshot with counters", async () => {
+    await setupMock((req, res) => {
+      expect(req.url).toContain("/coverage/session?coverageId=X");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        coverageId: "X:1", configId: "X",
+        coverageSessionKind: "live",
+        terminated: true, dataReceived: true,
+        analysisLoading: false, analysisReady: true,
+        dumpCount: 1, terminatedAt: Date.now(),
+        counters: {
+          instruction: { coveredCount: 5, missedCount: 2, totalCount: 7,
+            coveredRatio: 0.71, missedRatio: 0.29,
+            coverageStatus: "PARTLY_COVERED" },
+        },
+      }));
+    });
+    const { coverageStatus } = await import("../src/commands/coverage.mjs");
+    await coverageStatus(["X:1"]);
+    const out = io.logs.join("\n");
+    expect(out).toContain("X:1");
+    expect(out).toContain("Instructions");
+    expect(out).toContain("PARTLY_COVERED");
+  });
+
+  it("status missing id exits 1", async () => {
+    const { coverageStatus } = await import("../src/commands/coverage.mjs");
+    await expect(coverageStatus([])).rejects.toThrow("exit(1)");
+    expect(io.errors.join("\n")).toContain("Usage:");
+  });
+
+  // ---- dump -------------------------------------------------------
+
+  it("dump POSTs JSON body with coverageId+reset", async () => {
+    let body, ct;
+    await setupMock(async (req, res) => {
+      body = await readBody(req);
+      ct = req.headers["content-type"];
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true}');
+    });
+    const { coverageDump } = await import("../src/commands/coverage.mjs");
+    await coverageDump(["X:1", "--reset"]);
+    expect(JSON.parse(body)).toEqual({ coverageId: "X:1", reset: true });
+    expect(ct).toContain("application/json");
+    expect(io.logs.join("\n")).toContain("Dumped X:1 (reset)");
+  });
+
+  it("dump without --reset sends reset:false", async () => {
+    let body;
+    await setupMock(async (req, res) => {
+      body = await readBody(req);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true}');
+    });
+    const { coverageDump } = await import("../src/commands/coverage.mjs");
+    await coverageDump(["X:1"]);
+    expect(JSON.parse(body)).toEqual({ coverageId: "X:1", reset: false });
+  });
+
+  // ---- refresh ----------------------------------------------------
+
+  it("refresh prints active session id", async () => {
+    await setupMock((req, res) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/coverage/refresh");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true,"activeCoverageId":"MyTest:1"}');
+    });
+    const { coverageRefresh } = await import("../src/commands/coverage.mjs");
+    await coverageRefresh([]);
+    expect(io.logs.join("\n")).toContain("Refreshed MyTest:1");
+  });
+
+  // ---- active / activate -----------------------------------------
+
+  it("active prints id when present", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"activeCoverageId":"MyTest:1"}');
+    });
+    const { coverageActive } = await import("../src/commands/coverage.mjs");
+    await coverageActive([]);
+    expect(io.logs.join("\n")).toContain("MyTest:1");
+  });
+
+  it("active prints 'none' when null", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"activeCoverageId":null}');
+    });
+    const { coverageActive } = await import("../src/commands/coverage.mjs");
+    await coverageActive([]);
+    expect(io.logs.join("\n")).toContain("none");
+  });
+
+  it("activate sends body and prints previous", async () => {
+    let body;
+    await setupMock(async (req, res) => {
+      body = await readBody(req);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true,"activeCoverageId":"X:1","previousActiveCoverageId":"Y:2"}');
+    });
+    const { coverageActivate } = await import("../src/commands/coverage.mjs");
+    await coverageActivate(["X:1"]);
+    expect(JSON.parse(body)).toEqual({ coverageId: "X:1" });
+    expect(io.logs.join("\n")).toContain("Activated X:1");
+    expect(io.logs.join("\n")).toContain("Previous: Y:2");
+  });
+
+  // ---- merge ------------------------------------------------------
+
+  it("merge sends array, prints summary", async () => {
+    let body;
+    await setupMock(async (req, res) => {
+      body = await readBody(req);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        ok: true,
+        mergedCoverageId: "merged:1700000000000",
+        consumedCoverageIds: ["A:1", "B:2"],
+        active: true,
+      }));
+    });
+    const { coverageMerge } = await import("../src/commands/coverage.mjs");
+    await coverageMerge(["A:1", "B:2", "--name", "Combined run"]);
+    const sent = JSON.parse(body);
+    expect(sent.coverageIds).toEqual(["A:1", "B:2"]);
+    expect(sent.description).toBe("Combined run");
+    const out = io.logs.join("\n");
+    expect(out).toContain("Merged 2 sessions");
+    expect(out).toContain("merged:1700000000000");
+    expect(out).toContain("A:1  removed");
+  });
+
+  it("merge with <2 ids exits 1", async () => {
+    const { coverageMerge } = await import("../src/commands/coverage.mjs");
+    await expect(coverageMerge(["A:1"])).rejects.toThrow("exit(1)");
+  });
+
+  // ---- remove -----------------------------------------------------
+
+  it("remove (default) sends empty body, prints count", async () => {
+    let body;
+    await setupMock(async (req, res) => {
+      body = await readBody(req);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true,"removedCoverageIds":["X:1"]}');
+    });
+    const { coverageRemove } = await import("../src/commands/coverage.mjs");
+    await coverageRemove([]);
+    expect(JSON.parse(body)).toEqual({});
+    expect(io.logs.join("\n")).toContain("Removed 1 coverage session");
+  });
+
+  it("remove --all sends {all:true}, plural", async () => {
+    let body;
+    await setupMock(async (req, res) => {
+      body = await readBody(req);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true,"removedCoverageIds":["X:1","Y:2"]}');
+    });
+    const { coverageRemove } = await import("../src/commands/coverage.mjs");
+    await coverageRemove(["--all"]);
+    expect(JSON.parse(body)).toEqual({ all: true });
+    expect(io.logs.join("\n")).toContain("Removed 2 coverage sessions");
+  });
+
+  // ---- stop -------------------------------------------------------
+
+  it("stop resolves coverageId via /coverage/runs then GETs /launch/stop", async () => {
+    const seen = [];
+    await setupMock((req, res) => {
+      seen.push(req.url);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (req.url === "/coverage/runs") {
+        res.end(JSON.stringify([{
+          coverageId: "MyTest:1", coverageSessionKind: "live",
+          launchId: "MyTest:6408",
+        }]));
+      } else if (req.url.startsWith("/launch/stop")) {
+        res.end('{"ok":true,"configId":"MyTest"}');
+      }
+    });
+    const { coverageStop } = await import("../src/commands/coverage.mjs");
+    await coverageStop(["MyTest:1"]);
+    expect(seen[0]).toBe("/coverage/runs");
+    expect(seen[1]).toBe("/launch/stop?launchId=MyTest%3A6408");
+    expect(io.logs.join("\n")).toContain("Stopped MyTest:1");
+  });
+
+  it("stop on merged exits with launch-not-live", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([{
+        coverageId: "merged:1", coverageSessionKind: "merged",
+      }]));
+    });
+    const { coverageStop } = await import("../src/commands/coverage.mjs");
+    await expect(coverageStop(["merged:1"])).rejects.toThrow("exit(1)");
+    expect(io.errors.join("\n")).toContain("coverage-launch-not-live");
+  });
+
+  it("stop unknown coverageId exits 1", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("[]");
+    });
+    const { coverageStop } = await import("../src/commands/coverage.mjs");
+    await expect(coverageStop(["Bogus:1"])).rejects.toThrow("exit(1)");
+    expect(io.errors.join("\n")).toContain("coverage-not-found");
+  });
+});

--- a/cli/test/format-coverage-state.test.mjs
+++ b/cli/test/format-coverage-state.test.mjs
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import { composeStatus } from "../src/format/coverage-state.mjs";
+
+describe("composeStatus — STATUS line composition", () => {
+  describe("Group A — origin / launch state", () => {
+    it("merged kind emits 'merged N sessions'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "merged",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: false,
+        dumpCount: 1,
+        consumedCoverageIds: ["a", "b", "c"],
+      });
+      expect(status).toContain("merged 3 sessions");
+    });
+
+    it("merged with no consumed list defaults to 0", () => {
+      const status = composeStatus({
+        coverageSessionKind: "merged",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: false,
+        dumpCount: 1,
+      });
+      expect(status).toContain("merged 0 sessions");
+    });
+
+    it("imported kind emits 'imported'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "imported",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: false,
+        dumpCount: 1,
+      });
+      expect(status).toContain("imported");
+    });
+
+    it("live + not terminated emits 'running'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: false,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        launchTimestamp: Date.now() - 30_000,
+      });
+      expect(status).toMatch(/^running/);
+    });
+
+    it("live + terminated emits 'finished Xm ago'", () => {
+      const now = Date.now();
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        terminatedAt: now - 5 * 60_000,
+      }, now);
+      expect(status).toContain("finished 5m ago");
+    });
+  });
+
+  describe("Group B — data / analysis", () => {
+    it("dataReceived=false + terminated → 'no data received'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: true,
+        dataReceived: false,
+        analysisLoading: false,
+        analysisReady: false,
+        dumpCount: 0,
+        terminatedAt: Date.now(),
+      });
+      expect(status).toContain("no data received");
+    });
+
+    it("dumpCount > 1 → '<N> dumps'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: false,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 3,
+        launchTimestamp: Date.now(),
+      });
+      expect(status).toContain("3 dumps");
+    });
+
+    it("analysisLoading → 'analysis loading'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: false,
+        dataReceived: true,
+        analysisLoading: true,
+        analysisReady: false,
+        dumpCount: 1,
+        launchTimestamp: Date.now(),
+      });
+      expect(status).toContain("analysis loading");
+    });
+
+    it("analysisReady → 'analysis ready'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        terminatedAt: Date.now() - 1000,
+      });
+      expect(status).toContain("analysis ready");
+    });
+
+    it("terminated + data + neither analysis flag → 'analysis pending'", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: false,
+        dumpCount: 1,
+        terminatedAt: Date.now(),
+      });
+      expect(status).toContain("analysis pending");
+    });
+  });
+
+  describe("Group C — relative time (live, not terminated)", () => {
+    it("appends 'started Xs ago' for running live", () => {
+      const now = Date.now();
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: false,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        launchTimestamp: now - 30_000,
+      }, now);
+      expect(status).toContain("started 30s ago");
+    });
+
+    it("does NOT append relative time for terminated live", () => {
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        launchTimestamp: Date.now() - 60_000,
+        terminatedAt: Date.now() - 30_000,
+      });
+      expect(status).not.toContain("started");
+    });
+
+    it("does NOT append relative time for merged", () => {
+      const status = composeStatus({
+        coverageSessionKind: "merged",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        consumedCoverageIds: ["a", "b"],
+      });
+      expect(status).not.toContain("started");
+    });
+  });
+
+  describe("Token order and joining", () => {
+    it("joins tokens with ', ' in A → B → C order", () => {
+      const now = Date.now();
+      const status = composeStatus({
+        coverageSessionKind: "live",
+        terminated: false,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        launchTimestamp: now - 30_000,
+      }, now);
+      expect(status).toBe("running, analysis ready, started 30s ago");
+    });
+
+    it("merged with analysis ready emits both tokens", () => {
+      const status = composeStatus({
+        coverageSessionKind: "merged",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: true,
+        dumpCount: 1,
+        consumedCoverageIds: ["a", "b"],
+      });
+      expect(status).toBe("merged 2 sessions, analysis ready");
+    });
+
+    it("imported with pending analysis", () => {
+      const status = composeStatus({
+        coverageSessionKind: "imported",
+        terminated: true,
+        dataReceived: true,
+        analysisLoading: false,
+        analysisReady: false,
+        dumpCount: 1,
+      });
+      expect(status).toBe("imported, analysis pending");
+    });
+  });
+});

--- a/cli/test/format-coverage-status.test.mjs
+++ b/cli/test/format-coverage-status.test.mjs
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { setColorEnabled } from "../src/color.mjs";
+import {
+  formatRunHeader,
+  formatStatusSnapshot,
+  formatStreamEvent,
+  runGuide,
+} from "../src/format/coverage-status.mjs";
+
+describe("formatRunHeader", () => {
+  let logs;
+  const origLog = console.log;
+  beforeEach(() => {
+    setColorEnabled(false);
+    logs = [];
+    console.log = (...a) => logs.push(a.join(" "));
+  });
+  afterEach(() => { console.log = origLog; });
+
+  it("renders header with all wire fields", () => {
+    const out = formatRunHeader({
+      configId: "MyTest",
+      coverageId: "MyTest:1700000000000",
+      launchId: "MyTest:6408",
+      configType: "JUnit Plug-in Test",
+      coverageScope: ["=MyProject/src/main/java", "=MyProject/src/test/java"],
+    });
+    expect(out).toContain("#### Coverage: MyTest");
+    expect(out).toContain("CoverageId:    `MyTest:1700000000000`");
+    expect(out).toContain("LaunchId:      `MyTest:6408`");
+    expect(out).toContain("ConfigId:      `MyTest`");
+    expect(out).toContain("ConfigType:    JUnit Plug-in Test");
+    expect(out).toContain("LaunchMode:    coverage");
+    expect(out).toContain("=MyProject/src/main/java");
+  });
+
+  it("omits scope block when coverageScope empty", () => {
+    const out = formatRunHeader({
+      configId: "X", coverageId: "X:1", launchId: "X:1",
+    });
+    expect(out).not.toContain("CoverageScope:");
+  });
+});
+
+describe("formatStatusSnapshot", () => {
+  let logs;
+  const origLog = console.log;
+  beforeEach(() => {
+    setColorEnabled(false);
+    logs = [];
+    console.log = (...a) => logs.push(a.join(" "));
+  });
+  afterEach(() => { console.log = origLog; });
+
+  it("renders header line with id and status", () => {
+    const out = formatStatusSnapshot({
+      coverageId: "MyTest:1700000000000",
+      configId: "MyTest",
+      coverageSessionKind: "live",
+      terminated: true,
+      dataReceived: true,
+      analysisLoading: false,
+      analysisReady: true,
+      dumpCount: 1,
+      terminatedAt: Date.now() - 5 * 60_000,
+      counters: {},
+    });
+    expect(out).toContain("MyTest:1700000000000");
+    expect(out).toContain("MyTest");
+    expect(out).toContain("finished");
+    expect(out).toContain("analysis ready");
+  });
+
+  it("includes counter rows when analysisReady AND counters present", () => {
+    const out = formatStatusSnapshot({
+      coverageId: "X:1",
+      coverageSessionKind: "live",
+      terminated: true,
+      dataReceived: true,
+      analysisLoading: false,
+      analysisReady: true,
+      dumpCount: 1,
+      counters: {
+        instruction: { coveredCount: 12, missedCount: 3, totalCount: 15,
+          coveredRatio: 0.8, missedRatio: 0.2, coverageStatus: "PARTLY_COVERED" },
+        branch: { coveredCount: 0, missedCount: 0, totalCount: 0,
+          coveredRatio: null, missedRatio: null, coverageStatus: "EMPTY" },
+        line: { coveredCount: 5, missedCount: 0, totalCount: 5,
+          coveredRatio: 1.0, missedRatio: 0.0, coverageStatus: "FULLY_COVERED" },
+      },
+    });
+    expect(out).toContain("Instructions");
+    expect(out).toContain("coveredCount=12");
+    expect(out).toContain("missedCount=3");
+    expect(out).toContain("PARTLY_COVERED");
+    expect(out).toContain("Branches");
+    expect(out).toContain("EMPTY"); // 0 totalCount → EMPTY row
+    expect(out).toContain("FULLY_COVERED");
+  });
+
+  it("shows 'analysis loading' marker when analysisLoading", () => {
+    const out = formatStatusSnapshot({
+      coverageId: "X:1",
+      coverageSessionKind: "live",
+      terminated: false,
+      dataReceived: true,
+      analysisLoading: true,
+      analysisReady: false,
+      dumpCount: 1,
+    });
+    expect(out).toContain("analysis loading");
+  });
+
+  it("shows 'no data received' when terminated without data", () => {
+    const out = formatStatusSnapshot({
+      coverageId: "X:1",
+      coverageSessionKind: "live",
+      terminated: true,
+      dataReceived: false,
+      analysisLoading: false,
+      analysisReady: false,
+      dumpCount: 0,
+      terminatedAt: Date.now(),
+    });
+    expect(out).toContain("no data received");
+  });
+});
+
+describe("formatStreamEvent", () => {
+  let logs;
+  const origLog = console.log;
+  beforeEach(() => {
+    setColorEnabled(false);
+    logs = [];
+    console.log = (...a) => logs.push(a.join(" "));
+  });
+  afterEach(() => { console.log = origLog; });
+
+  it("snapshot event prints status line", () => {
+    const ok = formatStreamEvent(JSON.stringify({
+      event: "snapshot", coverageId: "X:1",
+      coverageSessionKind: "live", terminated: false,
+      dataReceived: false, analysisLoading: false,
+      analysisReady: false, dumpCount: 0,
+    }));
+    expect(ok).toBe(true);
+    expect(logs[0]).toContain("snapshot");
+  });
+
+  it("dumped event prints dump index and timestamp", () => {
+    formatStreamEvent(JSON.stringify({
+      event: "dumped", coverageId: "X:1",
+      dumpIndex: 2, dumpTimestamp: Date.now(),
+    }));
+    expect(logs[0]).toContain("dumped #2");
+  });
+
+  it("analysisLoading event prints analyzing line", () => {
+    formatStreamEvent(JSON.stringify({
+      event: "analysisLoading", coverageId: "X:1", dumpIndex: 1,
+    }));
+    expect(logs[0]).toContain("analyzing #1");
+  });
+
+  it("analysisReady event prints ready line", () => {
+    formatStreamEvent(JSON.stringify({
+      event: "analysisReady", coverageId: "X:1", dumpIndex: 1,
+    }));
+    expect(logs[0]).toContain("ready #1");
+  });
+
+  it("terminated event prints terminated line", () => {
+    formatStreamEvent(JSON.stringify({
+      event: "terminated", coverageId: "X:1",
+      terminatedAt: Date.now(), dataReceived: true,
+    }));
+    expect(logs[0]).toContain("terminated");
+  });
+
+  it("terminated with no data tags '(no data)'", () => {
+    formatStreamEvent(JSON.stringify({
+      event: "terminated", coverageId: "X:1",
+      terminatedAt: Date.now(), dataReceived: false,
+    }));
+    expect(logs[0]).toContain("no data");
+  });
+
+  it("failed event prints reason", () => {
+    formatStreamEvent(JSON.stringify({
+      event: "failed", reason: "analysis-cancelled",
+    }));
+    expect(logs[0]).toContain("failed");
+    expect(logs[0]).toContain("analysis-cancelled");
+  });
+
+  it("invalid JSON returns false", () => {
+    const ok = formatStreamEvent("not-json{");
+    expect(ok).toBe(false);
+  });
+
+  it("unknown event returns false", () => {
+    const ok = formatStreamEvent(JSON.stringify({ event: "weird" }));
+    expect(ok).toBe(false);
+  });
+});
+
+describe("runGuide", () => {
+  it("includes coverageId and launchId in commands", () => {
+    const guide = runGuide("MyTest:1", "MyTest:1234");
+    expect(guide).toContain("jdt coverage status MyTest:1");
+    expect(guide).toContain("jdt launch logs MyTest:1234");
+    expect(guide).toContain("jdt coverage dump MyTest:1");
+    expect(guide).toContain("jdt coverage stop MyTest:1");
+    expect(guide).toContain("jdt coverage activate MyTest:1");
+  });
+});

--- a/cli/test/readme-commands.test.mjs
+++ b/cli/test/readme-commands.test.mjs
@@ -28,11 +28,12 @@ function parseCommands(src) {
     }
   }
 
-  // Subcommand maps: launch, test, agent
+  // Subcommand maps: launch, test, agent, coverage
   const subMaps = [
     { pattern: /^const launchSubcommands = \{([\s\S]*?)^\};/m, prefix: "jdt launch" },
     { pattern: /^const testSubcommands = \{([\s\S]*?)^\};/m, prefix: "jdt test" },
     { pattern: /^const agentSubcommands = \{([\s\S]*?)^\};/m, prefix: "jdt agent" },
+    { pattern: /^const coverageSubcommands = \{([\s\S]*?)^\};/m, prefix: "jdt coverage" },
   ];
   for (const { pattern, prefix } of subMaps) {
     const match = src.match(pattern);
@@ -58,7 +59,7 @@ function parseReadmeCommands(content) {
   let inBlock = false;
 
   // Subcommand parents — next word after these is part of the command name
-  const parents = new Set(["launch", "test", "agent", "maven"]);
+  const parents = new Set(["launch", "test", "agent", "maven", "coverage"]);
 
   for (const line of lines) {
     if (line.startsWith("```bash")) { inBlock = true; continue; }
@@ -103,7 +104,7 @@ describe("CLI README completeness", () => {
     for (const cmd of srcCommands) {
       if (hidden.has(cmd)) continue;
       // For parent commands (launch, test, agent, maven) — subcommands cover them
-      if (["jdt launch", "jdt test", "jdt agent", "jdt maven"].includes(cmd)) continue;
+      if (["jdt launch", "jdt test", "jdt agent", "jdt maven", "jdt coverage"].includes(cmd)) continue;
       if (!readmeCommands.has(cmd)) {
         missing.push(cmd);
       }

--- a/docs/bridge-coverage-spec.md
+++ b/docs/bridge-coverage-spec.md
@@ -1,0 +1,904 @@
+# Bridge Coverage Protocol — Design Spec
+
+HTTP surface over `org.eclipse.eclemma.core.CoverageTools` API.
+CLI counterpart: [jdt-coverage-spec](jdt-coverage-spec.md).
+
+## Eclipse → HTTP map
+
+| Eclipse action | Eclipse command id | HTTP endpoint |
+|---|---|---|
+| Right-click → Coverage As (on a config or class) | EclEmma launch shortcut | `GET /coverage/run` |
+| Coverage View — tree of active session (data display) | `org.eclipse.eclemma.ui.CoverageView` (out of scope) | — |
+| Coverage View title bar | `setContentDescription` of active `description` | `GET /coverage/active` |
+| Toolbar dropdown — list of all sessions for selecting active | `selectActiveSession` + `SelectActiveSessionsItems` | `GET /coverage/runs` + `POST /coverage/activate` |
+| Popup → Refresh (F5) | `org.eclipse.ui.file.refresh` → `RefreshSessionHandler` | `POST /coverage/refresh` |
+| Toolbar — Relaunch Session | `relaunchSession` | `POST /coverage/relaunch` |
+| Toolbar — Remove Active Session | `removeActiveSession` | `POST /coverage/remove` (no body) |
+| Toolbar — Remove All Sessions | `removeAllSessions` | `POST /coverage/remove` with `all:true` |
+| Toolbar — Merge Sessions… | `mergeSessions` | `POST /coverage/merge` |
+| Toolbar dropdown — Dump Execution Data per running launch | `dumpExecutionData` + `DumpExecutionDataItems` (reads `PREF_RESET_ON_DUMP` toggle in submenu) | `POST /coverage/dump` (`reset` body field — passed per-call to `RuntimeData.collect(..., reset)`) |
+| Console / Debug View — Stop on running coverage launch | standard launch terminate | `GET /launch/stop` (resolved from `coverageId`) |
+
+Eclipse Import Session (`importSession`), Export Session
+(`exportSession`), and Open Session Execution Data
+(`openSessionExecutionData`) commands have no HTTP endpoint
+counterpart. Sessions added through Eclipse-side `ImportSessionHandler`
+still appear in `GET /coverage/runs` with
+`coverageSessionKind: "imported"`.
+
+## Identity
+
+```
+coverageId(live)             = "<configId>:<launchTimestamp>"            # latest dump
+coverageId(live, dump N)     = "<configId>:<launchTimestamp>:<dumpIndex>"
+coverageId(merged)           = "merged:<addedAtMillis>"                   # "<…>#<seq>" on intra-millisecond collision
+coverageId(imported)         = "imported:<addedAtMillis>"                 # "<…>#<seq>" on intra-millisecond collision
+```
+
+`launchTimestamp` is `ILaunch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP)`,
+set on the `ILaunch` instance synchronously inside
+`LaunchConfiguration.launch(mode, monitor, build)` after
+`getDelegate2().getLaunch(...)` returns and before
+`delegate.launch(...)` runs (so the attribute is visible before any
+JVM spawn). Stored as `Long.toString(System.currentTimeMillis())` in
+the source — `ILaunch.getAttribute` returns `String`; the bridge
+parses with `Long.parseLong(...)` to emit a JSON number. Mirrors
+`testRunId` in
+[bridge-test-spec](bridge-test-spec.md): for one launch in coverage
+mode the `coverageId` and `testRunId` are byte-identical strings —
+they identify the same `ILaunch` from coverage and test perspectives
+respectively.
+
+`dumpIndex` (1-based) addresses a specific `ICoverageSession` within
+a single launch. EclEmma's `AgentServer.run()` loop creates a new
+`ICoverageSession` on every dump (process termination, manual
+`requestDump`). The `coverageId` without suffix always resolves to
+the latest dump in the run; `coverageId:N` selects dump N.
+
+`addedAtMillis` is `System.currentTimeMillis()` captured at the
+`ISessionListener.sessionAdded(session)` callback. No `configId`
+prefix on merged or imported — both are detached from any single
+launch. EclEmma adopts the merged session's `launchConfiguration`
+only when every input with a non-null `getLaunchConfiguration()`
+shares the same value (`SessionManager.java:175-187`); inputs with
+`null` config are skipped during set construction. The bridge does
+not surface that adoption in `coverageId`.
+
+## Data sources (SSOT)
+
+All output fields trace back to one of these source structures.
+Bridge-side fields are derived state in `CoverageTracker`, not stored
+upstream.
+
+### Source structures
+
+| SSOT type | Package | Role | Where bridge reads from |
+|---|---|---|---|
+| `ILaunch` | `org.eclipse.debug.core` | Eclipse debug API for any process launch | `LaunchManager.getLaunches()`; `ILaunchesListener2` callbacks |
+| `ILaunchConfiguration` | `org.eclipse.debug.core` | persistent saved launch config | `ILaunch.getLaunchConfiguration()` |
+| `ILaunchConfigurationType` | `org.eclipse.debug.core` | type metadata of a config | `ILaunchConfiguration.getType()` |
+| `IProcess` | `org.eclipse.debug.core.model` | OS process under an `ILaunch` | `ILaunch.getProcesses()[i]` |
+| `ICoverageLaunch extends ILaunch` | `org.eclipse.eclemma.core.launching` | EclEmma's public `Launch` subclass — exposes `getScope()` + `requestDump(boolean)` only | `LaunchManager.getLaunches()` cast-checked; `CoverageTools.getRunningCoverageLaunches()` |
+| `CoverageLaunch implements ICoverageLaunch` | `org.eclipse.eclemma.internal.core.launching` | concrete subclass; adds public `getAgentServer()` not declared on the interface | bridge casts `(CoverageLaunch) launch` to reach `getAgentServer()` |
+| `AgentServer` | `org.eclipse.eclemma.internal.core.launching` | TCP listener for JaCoCo agent connections; `hasDataReceived()` exposes the per-run flag | `((CoverageLaunch) launch).getAgentServer()` — requires bridge `MANIFEST.MF` to access `org.eclipse.eclemma.internal.core.launching` (e.g. via `Eclipse-BuddyPolicy` or matching `x-friends` allowance) |
+| `ICoverageSession` | `org.eclipse.eclemma.core` | one coverage measurement (immutable) | `SessionManager.getSessions()` |
+| `ISessionManager` | `org.eclipse.eclemma.core` | session registry | `CoverageTools.getSessionManager()` |
+| `JavaCoverageLoader` | `org.eclipse.eclemma.internal.core` | active session analysis cache | `EclEmmaCorePlugin.getInstance().getJavaCoverageLoader()` |
+| `IJavaModelCoverage` | `org.eclipse.eclemma.core.analysis` | per-active-session analyzed coverage tree | `CoverageTools.getJavaModelCoverage()` (also `IJavaModelCoverage.LOADING` sentinel constant) |
+| `SessionAnalyzer` | `org.eclipse.eclemma.internal.core.analysis` | runs JaCoCo `Analyzer` over scope (`SessionAnalyzer.java:60-87`); `processSession(...)` returns `IJavaModelCoverage`. The same call also accumulates `ExecutionDataStore` + `SessionInfoStore` as instance state, exposed afterwards via `getSessionInfos(): List<SessionInfo>` (`SessionAnalyzer.java:89-91`) and `getExecutionData(): Collection<ExecutionData>` (`:93-95`). Bridge keeps the analyzer instance alive long enough to read both getters. | `SessionAnalyzer a = new SessionAnalyzer(); IJavaModelCoverage cov = a.processSession(session, monitor); a.getSessionInfos(); a.getExecutionData();` |
+| `IPackageFragmentRoot` | `org.eclipse.jdt.core` | JDT source/binary root | `ICoverageSession.getScope()` member; `IPackageFragmentRoot.getHandleIdentifier()` for wire serialization |
+| `SessionInfo` | `org.jacoco.core.data` | JaCoCo per-dump metadata (id/start/dump timestamps) | `SessionAnalyzer.getSessionInfos()` after `processSession` |
+| `ExecutionData` | `org.jacoco.core.data` | per-class probe array for one JVM session | `SessionAnalyzer.getExecutionData()` |
+| `ICounter` | `org.jacoco.core.analysis` | counts for one entity (covered/missed/total/ratios/status) | `ICoverageNode.getInstructionCounter()` etc. |
+| `ICoverageNode` | `org.jacoco.core.analysis` | analyzed node with 6 counters | `IJavaModelCoverage` (root); `getCoverageFor(IJavaElement)` |
+| `IPreferenceStore` | `org.eclipse.jface.preference` | preference store of `EclEmmaUIPlugin` | `EclEmmaUIPlugin.getInstance().getPreferenceStore()` |
+| `CoverageTracker.CoverageRun` | bridge-internal | ID-keyed view over `ICoverageSession` lifecycle | bridge `Map<coverageId, CoverageRun>` |
+
+### Sessions in `SessionManager.getSessions()` — three origins
+
+| Kind | `addSession(...)` call site | Distinguishing observable at `sessionAdded(session)` |
+|---|---|---|
+| `live` | `AgentServer.java:123-124` — `sessionManager.addSession(session, preferences.getActivateNewSessions(), launch)` | `session.getLaunchConfiguration()` equals `getLaunchConfiguration()` of a live `ICoverageLaunch` in `LaunchManager.getLaunches()` |
+| `merged` | `SessionManager.java:193` — `addSession(merged, true, null)` (inside the `synchronized (lock)` publication block at `SessionManager.java:192-197`) | followed synchronously by ≥2 `sessionRemoved` calls in the same publication block (`SessionManager.java:194-196`) |
+| `imported` | `SessionImporter.java:71` — `addSession(session, true, null)` | no synchronous `sessionRemoved` follows |
+
+### Per-field SSOT mapping
+
+| Field | `live` SSOT | `merged` SSOT | `imported` SSOT |
+|---|---|---|---|
+| `coverageId` | bridge: `ILaunch.getLaunchConfiguration().getName() + ":" + ILaunch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP)` | bridge: `"merged:" + System.currentTimeMillis()` at `sessionAdded(merged)`, `+ "#<seq>"` if that string was already issued (intra-millisecond collision) | bridge: `"imported:" + System.currentTimeMillis()` at `sessionAdded(imported)`, with the same `#<seq>` collision rule |
+| `coverageSessionKind` | bridge `CoverageRun.coverageSessionKind`; classification at `sessionAdded` | same | same |
+| `configId` | `ILaunch.getLaunchConfiguration().getName()` | `ICoverageSession.getLaunchConfiguration().getName()` if non-null. `mergeSessions` builds `Set<ILaunchConfiguration>` from inputs whose `getLaunchConfiguration() != null` (`SessionManager.java:175-177`), then adopts the unique element only when `launches.size() == 1` (`SessionManager.java:184-187`); inputs with `null` config are skipped during set construction. Three inputs with config A + one with `null` → adopts A; two inputs with A + one with B → `null`. | `null` (constant — `CoverageSession` constructor receives `null` literal at `SessionImporter.java:70`) |
+| `launchId` | bridge: `configId + ":" + ILaunch.getProcesses()[0].getAttribute(IProcess.ATTR_PROCESS_ID)` | `null` (no `ILaunch` — `addSession(merged, true, null)`) | `null` (no `ILaunch` — `addSession(session, true, null)`) |
+| `configType` | `ILaunch.getLaunchConfiguration().getType().getName()` | same on `ICoverageSession.getLaunchConfiguration()` if non-null; else `null` | `null` |
+| `configTypeId` | `ILaunch.getLaunchConfiguration().getType().getIdentifier()` | same on `ICoverageSession.getLaunchConfiguration()` if non-null; else `null` | `null` |
+| `description` | `ICoverageSession.getDescription()` of latest dump (set by `AgentServer.createDescription()` = `MessageFormat(CoreMessages.LaunchSessionDescription_value, configName, new Date())`) | `ICoverageSession.getDescription()` (set from `description` arg to `SessionManager.mergeSessions(sessions, description, monitor)`) | `ICoverageSession.getDescription()` (set via `SessionImporter.setDescription(...)` before `importSession`) |
+| `coverageScope` | `ICoverageSession.getScope()` → `IPackageFragmentRoot.getHandleIdentifier()` per element. For live: scope was set in `CoverageLauncher.getLaunch():106` to `ScopeUtils.getConfiguredScope(config)` | same shape; scope set in `SessionManager.mergeSessions:170,174` as union of inputs' `getScope()` | same shape; scope set via `SessionImporter.setScope(...)` |
+| `terminated` | `ILaunch.isTerminated()` | constant `true` (no `ILaunch`) | constant `true` (no `ILaunch`) |
+| `dataReceived` | `((CoverageLaunch) launch).getAgentServer().hasDataReceived()` (`AgentServer.java:98-100`) | constant `true` — merge precondition is `getSessions().size() > 1` (`MergeSessionsHandler.isEnabled():48-50`), every input had data | constant `true` — the `IExecutionDataSource` set via `SessionImporter.setExecutionDataSource` is the imported data |
+| `analysisLoading` | `sessionManager.getActiveSession() ∈ run.sessions` AND `JavaCoverageLoader.getJavaModelCoverage() == IJavaModelCoverage.LOADING` | same | same |
+| `analysisReady` | `sessionManager.getActiveSession() ∈ run.sessions` AND `coverage != null && coverage != IJavaModelCoverage.LOADING` | same | same |
+| `dumpCount` | `CoverageRun.sessions.size()` — bridge increments per `sessionAdded` matching this run's `ILaunch.getLaunchConfiguration()` | constant `1` — `mergeSessions` produces exactly one `CoverageSession` | constant `1` — `importSession` produces exactly one `CoverageSession` |
+| `launchTimestamp` | `Long.parseLong(ILaunch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP))` — Eclipse stores it as `Long.toString(System.currentTimeMillis())` (`LaunchConfiguration.java:725`); bridge parses to JSON number | `null` | `null` |
+| `terminatedAt` | bridge: `System.currentTimeMillis()` at `ILaunchesListener2.launchesTerminated` callback for this `ILaunch` | bridge: `System.currentTimeMillis()` at `sessionAdded(merged)` (no live launch ever existed) | bridge: `System.currentTimeMillis()` at `sessionAdded(imported)` |
+| `consumedCoverageIds` | absent | bridge-collected `List<String>` of tracker `coverageId`s from the burst of `sessionRemoved` immediately after `sessionAdded(merged)` | absent |
+
+`analysisLoading` / `analysisReady` apply only to the **active**
+session: EclEmma's `JavaCoverageLoader` holds a single
+`IJavaModelCoverage coverage` field (`JavaCoverageLoader.java:42`),
+populated by `LoadSessionJob` for whichever session was last
+activated. For non-active sessions both are `false` on
+`/coverage/runs`; counters reach the wire via
+`CoverageAnalyzer.ensureAnalyzed(session)` invoked by
+`/coverage/session`.
+
+### Lifetime
+
+| What | When created | When destroyed |
+|---|---|---|
+| `CoverageRun` (live) | `ILaunchesListener2.launchesAdded` for an `ICoverageLaunch` | `ISessionListener.sessionRemoved` of last session in run + bridge-side cleanup; also gone after plugin restart (in-memory) |
+| `CoverageRun` (merged) | `ISessionListener.sessionAdded(merged)` | `ISessionListener.sessionRemoved(merged)` (merged runs hold exactly one session); also gone after plugin restart |
+| `ICoverageSession` object | `new CoverageSession(...)` — in `AgentServer.run()` (live) or `mergeSessions(...)` (merged) | explicit `removeSession`/`removeAllSessions`; or plugin restart (in-memory `SessionManager.sessions` list) |
+| `.exec` file | `ExecutionDataFiles.newFile(source)` (`ExecutionDataFiles.java:62-76`) writes to `<plugin-state>/.execdata/session<digits>.exec` — name produced by `File.createTempFile("session", ".exec", folder)` at `:65`, no dash separator | `EclEmmaCorePlugin.start()` and `EclEmmaCorePlugin.stop()` both call `executionDataFiles.deleteTemporaryFiles()` (`EclEmmaCorePlugin.java:99,111`) — files are wiped on every plugin start AND stop |
+| `JavaCoverageLoader.coverage` | `LoadSessionJob.run()` finishing for the active session | `sessionActivated(other)` triggers `cancel(LOADJOB)` and replaces with the new active's analysis; or `sessionActivated(null)` clears it |
+| Bridge `CoverageAnalyzer` cache entry | first call to `ensureAnalyzed(session)` for a non-active session | `ISessionListener.sessionRemoved(session)` |
+
+No persistence across Eclipse restart. Restarting Eclipse clears
+`SessionManager.sessions` (in-memory `ArrayList`) and wipes
+`<plugin-state>/.execdata/` (twice — at stop of old instance and
+start of new). The bridge's `CoverageTracker` rebuilds empty.
+
+## ICoverageSession ↔ coverageId tracker
+
+`ICoverageSession` has identity-only equality (`CoverageSession extends
+PlatformObject`, `equals` not overridden). The bridge maintains an
+explicit indexed model in `CoverageTracker`:
+
+```
+Map<coverageId, CoverageRun>
+
+CoverageRun {
+  coverageId          : String                  // primary key, no suffix
+  coverageSessionKind : "live" | "merged" | "imported"
+  configId            : String?                 // live: launch.config.name
+                                                // merged: mergedSession.launchConfig.name iff non-null
+                                                // imported: null
+  launch              : ILaunch?                // live: ILaunch instance
+                                                // merged/imported: null
+  launchTimestamp     : long?                   // live: ATTR_LAUNCH_TIMESTAMP
+                                                // merged/imported: null
+  description         : String                  // live: AgentServer.createDescription()
+                                                // merged: arg to mergeSessions
+                                                // imported: SessionImporter.setDescription value
+  coverageScope       : Set<IPackageFragmentRoot>
+  sessions            : List<ICoverageSession>  // live: one per AgentServer dump
+                                                // merged/imported: exactly 1
+  dumpedAt            : List<long>              // millis per session added
+  consumedCoverageIds : List<String>?           // merged only
+}
+```
+
+`CoverageTracker` listens to:
+
+- `ILaunchesListener2.launchesAdded` — for each `CoverageLaunch`
+  (cast-checked), pre-create a `CoverageRun` with
+  `coverageSessionKind="live"` indexed by
+  `configId + ":" + Long.parseLong(ATTR_LAUNCH_TIMESTAMP)`.
+  `terminated=false`, `dumpCount=0`, `dataReceived=false`,
+  `launchId=null` — the `IProcess` for the spawned JVM registers
+  later via `DebugEvent.CREATE`, after which the bridge populates
+  `launchId = configId + ":" + ILaunch.getProcesses()[0].getAttribute(IProcess.ATTR_PROCESS_ID)`.
+  `coverageId` is stable from `launchesAdded` onward; `launchId`
+  becomes available when the process attaches.
+- `ISessionListener.sessionAdded(session)` — classify in two phases:
+  - **Phase 1, at callback time** — record the new session in a
+    pending slot keyed by `System.identityHashCode(session)`,
+    capturing `addedAtMillis = System.currentTimeMillis()`. If
+    `session.getLaunchConfiguration() != null` and a live
+    `ICoverageLaunch` in `LaunchManager.getLaunches()` has the same
+    `getLaunchConfiguration()`, immediately classify as **live**
+    dump for that run; append to its `sessions`/`dumpedAt`.
+    `dumpIndex = run.sessions.size()` after append. No phase 2.
+  - **Phase 2, deferred** — sessions that did not classify as live
+    in phase 1 are resolved when control returns from the
+    listener-firing thread (specifically, the bridge captures all
+    `sessionRemoved(input)` events that arrive on the same thread
+    before any further `sessionAdded` does, then runs the
+    classifier):
+    - If ≥2 `sessionRemoved` events for tracked sessions arrived
+      synchronously after this `sessionAdded` (the merge
+      publication block emits exactly N removals, N ≥ 2, after one
+      addition) → **merged**;
+      `coverageId = "merged:" + addedAtMillis`,
+      `consumedCoverageIds = ` tracker `coverageId`s of the removed
+      inputs.
+    - Otherwise → **imported**;
+      `coverageId = "imported:" + addedAtMillis`.
+
+  Two merges within the same millisecond would collide on
+  `addedAtMillis`. The bridge resolves collisions by appending
+  `#N` (1-based) to the second and later occurrences of an
+  already-issued `merged:<millis>` / `imported:<millis>` value
+  before publishing it, e.g. `merged:1777079000000#2`.
+- `ISessionListener.sessionRemoved(session)` — remove from owning
+  run's `sessions`. If `sessions.isEmpty()` after removal, drop the
+  `CoverageRun`. (Single removed session in a multi-dump run leaves
+  the run intact — its remaining dumps are still valid.)
+- `ISessionListener.sessionActivated(session)` — update
+  `activeCoverageId` field. `null` argument means "no active
+  session" (last session removed).
+- `IJavaCoverageListener.coverageChanged()` — fired by
+  `JavaCoverageLoader` on `LOADING` / `null` / completed-analysis
+  transitions of the active session. Bridge updates active run's
+  `analysisLoading` / `analysisReady` and emits stream events.
+
+Merge classification: `SessionManager.mergeSessions` accumulates
+input data outside the lock (lines 165-189: `session.accept(memory,
+memory)` per input, `executiondatafiles.newFile(memory)`), then takes
+`SessionManager.lock` for the publication block (lines 192-197) where
+it calls `addSession(merged, true, null)` followed by
+`removeSession(input)` per input. Because `lock` is reentrant and the
+inner `addSession`/`removeSession` re-enter it, all listener callbacks
+within those calls (`sessionAdded(merged)`, `sessionActivated(merged)`,
+`sessionRemoved(input)` × N) fire on the caller thread while the
+outer lock acquisition is still held — no other `addSession` /
+`removeSession` can interleave. `SessionImporter.importSession` fires
+`sessionAdded(imported)` + `sessionActivated(imported)` only — no
+`sessionRemoved` burst follows. The bridge classifies on whether the
+publication block produced a `sessionRemoved` burst before the outer
+lock released.
+
+## CoverageAnalyzer (bridge-side analysis cache)
+
+JaCoCo `IJavaModelCoverage` is computed by `SessionAnalyzer.processSession`
+which walks every `IPackageFragmentRoot` in the session's scope and
+parses class files. On large workspaces this is multi-second.
+EclEmma's `JavaCoverageLoader` caches result for the **active**
+session only.
+
+The bridge owns `CoverageAnalyzer` to extend caching to all sessions:
+
+```
+Map<ICoverageSession, CachedAnalysis>
+
+CachedAnalysis {
+  modelCoverage      : IJavaModelCoverage
+  jacocoSessionInfos : List<SessionInfo>
+  jacocoExecData     : Collection<ExecutionData>
+  computedAt         : long
+}
+```
+
+`CoverageAnalyzer.ensureAnalyzed(session)` is the single entry point:
+
+- For the active session: bridge runs its own `SessionAnalyzer.processSession`
+  on first call to capture `getSessionInfos()` and `getExecutionData()`
+  alongside `CoverageTools.getJavaModelCoverage()` — EclEmma's
+  `JavaCoverageLoader` exposes only `IJavaModelCoverage`, not the
+  raw `SessionInfo` / `ExecutionData` lists. Subsequent calls return
+  the bridge cache.
+- For non-active session: synchronous `SessionAnalyzer.processSession`
+  with `NullProgressMonitor`, populate cache, return.
+
+Invalidation: only `ISessionListener.sessionRemoved` removes a cache
+entry. Sessions are immutable (`CoverageSession` final fields),
+analysis is deterministic given the same `executionDataSource` and
+scope.
+
+## HTTP endpoints
+
+### `GET /coverage/run`
+
+Start a coverage launch.
+
+Params:
+- `configId` (required)
+- `args` (optional, URL-encoded extra arguments — same semantics as
+  `GET /launch/run`)
+
+Activation of the resulting session is governed by
+`ICorePreferences.getActivateNewSessions()` read by EclEmma's
+`AgentServer` at the `addSession(...)` call.
+
+Validation order:
+1. `LaunchManager.getLaunchConfigurations()` contains a config named
+   `configId` → else `coverage-config-not-found`
+2. Config's type has a delegate registered for mode `"coverage"`:
+   `ILaunchDelegate[] delegates = config.getType().getDelegates(Set.of("coverage"))`;
+   `delegates.length >= 1` AND `delegates[0].getDelegate() instanceof ICoverageLauncher`
+   (path mirrors EclEmma's own `CoverageLauncher.getLaunchDelegate(launchtype)`
+   at `CoverageLauncher.java:72-73`). Else `coverage-mode-not-supported`
+   with `:supportedTypeIds` listing every type ID for which the same
+   resolution succeeds.
+
+Action:
+- `ILaunch launch = config.launch("coverage", null, true)`
+- `coverageId = configId + ":" + launch.getAttribute(ATTR_LAUNCH_TIMESTAMP)`
+- `launchId = configId + ":" + processPid` (mirrors `/launch/run`)
+
+Response on success:
+```json
+{
+  "ok": true,
+  "configId": "MyTest",
+  "coverageId": "MyTest:1777078913423",
+  "launchId": "MyTest:6408",
+  "configType": "JUnit Plug-in Test",
+  "configTypeId": "org.eclipse.pde.ui.JunitLaunchConfig",
+  "coverageScope": [
+    "=MyProject/src\\/main\\/java",
+    "=MyProject/src\\/test\\/java"
+  ],
+  "launchTimestamp": 1777078913423,
+  "processPid": "6408",
+  "cmdline": "java -javaagent:.../jacocoagent.jar=output=tcpclient,port=51234,includes=...,excludes=... ..."
+}
+```
+
+`coverageScope` entries are JDT handle identifiers
+(`IPackageFragmentRoot.getHandleIdentifier()` — same form EclEmma
+stores in `ATTR_SCOPE_IDS`). They survive workspace restart and
+disambiguate roots that share a path. Conversion to human paths
+happens in CLI rendering, not in the wire format.
+
+### `POST /coverage/dump`
+
+Eclipse: `dumpExecutionData` (`DumpExecutionDataHandler`).
+
+Body:
+```json
+{ "coverageId": "MyTest:1777078913423", "reset": false }
+```
+
+`reset` defaults to `false` when omitted.
+
+Resolves `coverageId` to `CoverageRun.launch`, casts to
+`ICoverageLaunch`, calls `requestDump(reset)`. The dump path crosses
+the Eclipse↔target-JVM TCP boundary opened by `AgentServer`:
+
+- **Eclipse-side** (`org.eclipse.eclemma.internal.core.launching`):
+  `AgentServer.requestDump(reset)` → `RemoteControlWriter.visitDumpCommand(true, reset)`
+  writes a `BLOCK_CMDDUMP` frame on the socket.
+- **Target-JVM-side** (JaCoCo agent's `org.jacoco.agent.rt.internal.output.TcpClientOutput`):
+  the agent's `RemoteControlReader.readDumpCommand` decodes the frame
+  and invokes the agent's `IAgent.dump(reset)`, which calls
+  `RuntimeData.collect(execVisitor, sessionInfoVisitor, reset)`. When
+  `reset == true`, after `store.accept(...)`, `RuntimeData.reset()`
+  calls `store.reset()` (iterates `entries.values()`,
+  `Arrays.fill(probes, false)` on every `ExecutionData`).
+- **Eclipse-side** receives the resulting execution data over the
+  same socket via `MemoryExecutionDataSource.readFrom(reader)` in
+  `AgentServer.run()` (`AgentServer.java:113-125`); each non-empty
+  receipt creates a new `CoverageSession` and registers it.
+
+Response: `{"ok": true}`.
+
+Errors:
+- `coverage-not-found`
+- `coverage-launch-terminated` (`CoverageRun.terminated == true`)
+- `coverage-launch-not-live` (merged session has no launch)
+
+### `POST /coverage/refresh`
+
+Eclipse: `org.eclipse.ui.file.refresh` (F5) → `RefreshSessionHandler`
+in Coverage View popup menu.
+
+Empty body. Calls `sessionManager.refreshActiveSession()` which
+re-fires `sessionActivated` for the current active. `JavaCoverageLoader`
+cancels its in-flight `LoadSessionJob` and schedules a new one.
+
+Enabled only when `sessionManager.getActiveSession() != null` — else
+`coverage-no-active-session`.
+
+Response: `{"ok": true, "activeCoverageId": "MyTest:1777078913423"}`.
+
+### `POST /coverage/relaunch`
+
+Eclipse: `relaunchSession` (`RelaunchSessionHandler`) toolbar button.
+
+Empty body. Reads `activeSession = sessionManager.getActiveSession()`,
+checks `activeSession.getLaunchConfiguration() != null`. Eclipse's
+handler uses `DebugUITools.launch(config, CoverageTools.LAUNCH_MODE)`
+(`RelaunchSessionHandler.java:41`) which integrates with launch
+history and shows the launch dialog on validation errors. The bridge
+runs headless and instead calls
+`config.launch(CoverageTools.LAUNCH_MODE, null, true)` directly —
+behavior diverges from Eclipse only on the validation-error path,
+which the bridge surfaces as `CoreException` returned to the caller.
+
+Enabled only when there is an active session whose
+`launchConfiguration != null` — else `coverage-no-active-session` or
+`coverage-launch-not-live`.
+
+Response — same shape as `GET /coverage/run` (header for the new
+launch).
+
+### `GET /coverage/runs`
+
+Eclipse: list shown in `selectActiveSession` ListDialog and
+`SelectActiveSessionsItems` toolbar dropdown — `sessionManager.getSessions()`.
+
+Params: filtered by `ProjectScope` (bridge session header).
+
+Returns metadata only — no counters. Counters arrive via
+`GET /coverage/session` per `coverageId`.
+
+Response:
+```json
+[
+  {
+    "coverageId": "MyTest:1777078913423",
+    "coverageSessionKind": "live",
+    "configId": "MyTest",
+    "launchId": "MyTest:6408",
+    "configType": "JUnit Plug-in Test",
+    "configTypeId": "org.eclipse.pde.ui.JunitLaunchConfig",
+    "description": "MyTest (Apr 25, 2026 03:14:25 AM)",
+    "coverageScope": ["=MyProject/src\\/main\\/java", "=MyProject/src\\/test\\/java"],
+    "active": true,
+    "terminated": false,
+    "dataReceived": true,
+    "analysisLoading": false,
+    "analysisReady": true,
+    "dumpCount": 1,
+    "launchTimestamp": 1777078913423,
+    "terminatedAt": null
+  },
+  {
+    "coverageId": "merged:1777079000000",
+    "coverageSessionKind": "merged",
+    "configId": null,
+    "launchId": null,
+    "configType": null,
+    "configTypeId": null,
+    "description": "Merged (Apr 25, 2026 03:14:25 AM)",
+    "coverageScope": ["=ProjectA/src", "=ProjectB/src"],
+    "active": false,
+    "terminated": true,
+    "dataReceived": true,
+    "analysisLoading": false,
+    "analysisReady": false,
+    "dumpCount": 1,
+    "launchTimestamp": null,
+    "terminatedAt": 1777079000000,
+    "consumedCoverageIds": ["MyTest:1777078913423", "OtherTest:1777078815046"]
+  },
+  {
+    "coverageId": "imported:1777080500000",
+    "coverageSessionKind": "imported",
+    "configId": null,
+    "launchId": null,
+    "configType": null,
+    "configTypeId": null,
+    "description": "<value passed to SessionImporter.setDescription via SessionImportWizard>",
+    "coverageScope": ["=ProjectA/src/main/java"],
+    "active": false,
+    "terminated": true,
+    "dataReceived": true,
+    "analysisLoading": false,
+    "analysisReady": false,
+    "dumpCount": 1,
+    "launchTimestamp": null,
+    "terminatedAt": 1777080500000
+  }
+]
+```
+
+`analysisLoading` / `analysisReady` reflect EclEmma's
+`JavaCoverageLoader` for the active session only (`true`/`true` is
+impossible — they're mutually exclusive). For non-active sessions
+both are `false` — analysis happens on `GET /coverage/session`
+through `CoverageAnalyzer`.
+
+### `GET /coverage/session`
+
+Bridge-only — Eclipse activates a session before viewing its tree;
+this endpoint reads any session's analysis without changing
+activation, via `CoverageAnalyzer.ensureAnalyzed(session)`.
+
+Params:
+- `coverageId` (required, with optional `:N` dump suffix)
+
+Triggers `CoverageAnalyzer.ensureAnalyzed(session)` on first call —
+returns immediately if cached, else runs synchronous analysis. The
+endpoint blocks during analysis. Use `GET /coverage/session/stream`
+to follow without blocking.
+
+Response: same shape as one entry from `/coverage/runs` plus:
+
+```json
+{
+  ...all fields from /coverage/runs entry...,
+  "counters": {
+    "instruction": { ...counter shape... },
+    "branch":      { ...counter shape... },
+    "line":        { ...counter shape... },
+    "complexity":  { ...counter shape... },
+    "method":      { ...counter shape... },
+    "class":       { ...counter shape... }
+  },
+  "jacocoSessionInfos": [
+    {
+      "jacocoSessionId": "<JaCoCo-generated>",
+      "agentStartTimestamp": 1777078913100,
+      "dumpTimestamp": 1777078920000
+    }
+  ]
+}
+```
+
+SSOT for the additional fields:
+
+| Field | SSOT type | API path |
+|---|---|---|
+| `counters.instruction` | `ICounter` (JaCoCo) | `IJavaModelCoverage.getInstructionCounter()` (where `IJavaModelCoverage` comes from `CoverageAnalyzer.ensureAnalyzed(session)`) |
+| `counters.branch` | `ICounter` | `…getBranchCounter()` |
+| `counters.line` | `ICounter` | `…getLineCounter()` |
+| `counters.complexity` | `ICounter` | `…getComplexityCounter()` |
+| `counters.method` | `ICounter` | `…getMethodCounter()` |
+| `counters.class` | `ICounter` | `…getClassCounter()` |
+| `jacocoSessionInfos[i].jacocoSessionId` | `SessionInfo` (JaCoCo) | `SessionInfo.getId()` — generated by JaCoCo agent at session start (EclEmma does not set `AgentOptions.SESSIONID`, so it's a JaCoCo-internal random string) |
+| `jacocoSessionInfos[i].agentStartTimestamp` | `SessionInfo` | `SessionInfo.getStartTimeStamp()` |
+| `jacocoSessionInfos[i].dumpTimestamp` | `SessionInfo` | `SessionInfo.getDumpTimeStamp()` |
+
+`counters` present iff `CoverageAnalyzer.ensureAnalyzed(session)`
+returned successfully (it always runs synchronously when called —
+either reads bridge cache or invokes `SessionAnalyzer.processSession`).
+
+`jacocoSessionInfos` length comes from
+`SessionInfoStore.getInfos()` after `session.accept(execStore,
+sessionInfoStore)`. Per kind:
+- `live` per single dump (selected via `coverageId` or `coverageId:N`):
+  one `SessionInfo` (`RuntimeData.collect(...)` builds exactly one
+  `new SessionInfo(sessionId, startTimeStamp, currentTimeMillis())`
+  and emits it via `sessionInfoVisitor.visitSessionInfo(info)` per
+  invocation)
+- `merged`: sum of input dumps' `SessionInfo`s — `mergeSessions`
+  accumulates via `session.accept(memory, memory)` per input
+  (`SessionManager.java:178`), so each input's `SessionInfo` ends
+  up in the merged source's `SessionInfoStore`
+- `imported`: whatever the imported `.exec` file contains, parsed
+  by `URLExecutionDataSource.accept` via
+  `ExecutionDataReader.read()`
+
+### `GET /coverage/session/stream`
+
+Bridge-only streaming variant of `GET /coverage/session` —
+follows state transitions until terminal state without blocking
+the caller.
+
+Params:
+- `coverageId` (required)
+
+Streams JSONL transition events. One line per event. Stream closes
+when `terminated == true && analysisLoading == false` (analysis
+finished or never started).
+
+Replay: emits current snapshot first, then live events.
+
+Events:
+```jsonl
+{"event":"snapshot","coverageId":"MyTest:1777078913423","terminated":false,"dataReceived":false,"analysisLoading":false,"analysisReady":false,"dumpCount":0}
+{"event":"dumped","coverageId":"MyTest:1777078913423","dumpIndex":1,"dumpTimestamp":1777078918000}
+{"event":"analysisLoading","coverageId":"MyTest:1777078913423","dumpIndex":1}
+{"event":"analysisReady","coverageId":"MyTest:1777078913423","dumpIndex":1,"counters":{...}}
+{"event":"dumped","coverageId":"MyTest:1777078913423","dumpIndex":2,"dumpTimestamp":1777078921000}
+{"event":"analysisLoading","coverageId":"MyTest:1777078913423","dumpIndex":2}
+{"event":"analysisReady","coverageId":"MyTest:1777078913423","dumpIndex":2,"counters":{...}}
+{"event":"terminated","coverageId":"MyTest:1777078913423","terminatedAt":1777078925000}
+```
+
+`analysisLoading` event corresponds to
+`JavaCoverageLoader.coverage = IJavaModelCoverage.LOADING` transition;
+`analysisReady` event corresponds to `coverage` becoming a populated
+`JavaModelCoverage` instance (both detected via
+`IJavaCoverageListener.coverageChanged()`).
+
+If the launch terminates without any dump (`AgentServer.dataReceived
+== false`):
+```jsonl
+{"event":"snapshot","coverageId":"MyTest:1777078913423","terminated":false,"dataReceived":false,"analysisLoading":false,"analysisReady":false,"dumpCount":0}
+{"event":"terminated","coverageId":"MyTest:1777078913423","terminatedAt":...,"dataReceived":false}
+```
+
+If `LoadSessionJob` was cancelled mid-flight (e.g. by another
+activation, `Job.getJobManager().cancel(LOADJOB)`):
+```jsonl
+{"event":"failed","coverageId":"MyTest:1777078913423","dumpIndex":1,"reason":"analysis-cancelled"}
+```
+
+The bridge filters `IJavaCoverageListener.coverageChanged` events to
+the subscribed `coverageId` only — listeners on other sessions are
+not woken up.
+
+### `GET /coverage/active`
+
+Eclipse: `sessionManager.getActiveSession()`; description shown in
+Coverage View title bar via `setContentDescription`.
+
+Response:
+```json
+{ "activeCoverageId": "MyTest:1777078913423" }
+```
+
+Or `{"activeCoverageId": null}` if no active session.
+
+### `POST /coverage/activate`
+
+Eclipse: `selectActiveSession` (`SelectActiveSessionHandler`) /
+`SelectActiveSessionsItems` radio menu →
+`sessionManager.activateSession(session)`.
+
+Body:
+```json
+{ "coverageId": "MyTest:1777078913423" }
+```
+
+Resolves to latest dump's `ICoverageSession`, calls
+`sessionManager.activateSession(session)`. Triggers
+`JavaCoverageLoader` to schedule `LoadSessionJob` for the new active.
+
+Response:
+```json
+{
+  "ok": true,
+  "activeCoverageId": "MyTest:1777078913423",
+  "previousActiveCoverageId": "OtherRun:1777078815046"
+}
+```
+
+### `POST /coverage/merge`
+
+Eclipse: `mergeSessions` (`MergeSessionsHandler`) →
+`MergeSessionsDialog` → `sessionManager.mergeSessions(...)`.
+
+Body:
+```json
+{
+  "coverageIds": ["MyTest:1777078913423", "OtherTest:1777078815046"],
+  "description": "Combined run"
+}
+```
+
+Constraints:
+- `coverageIds.size() >= 2` — else `coverage-merge-too-few-inputs`
+- All IDs resolve — else `coverage-not-found` with the missing ID
+  in `:context/missing`
+
+Resolves each `coverageId` to the run's flattened
+`List<ICoverageSession>` (all dumps), then
+`sessionManager.mergeSessions(allSessions, description, monitor)`.
+
+`description` defaults to the same template Eclipse uses in the
+Merge Sessions dialog: `MergeSessionsDialogDescriptionDefault_value`
+from `uimessages.properties:59` =
+`Merged ({0,date,medium} {0,time,medium})`, formatted via
+`MessageFormat.format(template, new Date())` at request time on the
+Eclipse host — locale-dependent (e.g. `Merged (Apr 25, 2026 03:14:25 AM)`
+in en-US, `Merged (25 апр. 2026 г. 07:22:12)` in ru-RU). Mirrors
+`MergeSessionsHandler.execute():56-57`.
+
+EclEmma's merge:
+- Unions `Set<IPackageFragmentRoot>` from inputs
+- Accumulates execution data via `MemoryExecutionDataSource` →
+  `executionDataFiles.newFile(memory)`
+- Adopts `launchConfiguration` only if all inputs share exactly one
+  unique value (else `null`)
+- `addSession(merged, activate=true, launch=null)` then
+  `removeSession(input)` for each input
+
+Old `coverageId`s become `coverage-not-found` immediately after.
+
+Response:
+```json
+{
+  "ok": true,
+  "mergedCoverageId": "merged:1777079000000",
+  "consumedCoverageIds": ["MyTest:1777078913423", "OtherTest:1777078815046"],
+  "active": true
+}
+```
+
+### `POST /coverage/remove`
+
+Eclipse: `removeActiveSession` (`RemoveActiveSessionHandler`) /
+`removeAllSessions` (`RemoveAllSessionsHandler`).
+
+Body — one of:
+```json
+{}
+{ "all": true }
+```
+
+Empty body: `sessionManager.removeSession(sessionManager.getActiveSession())`.
+Enabled only when `getActiveSession() != null` — else
+`coverage-no-active-session`.
+
+`all: true`: `sessionManager.removeAllSessions()`.
+
+Response:
+```json
+{
+  "ok": true,
+  "removedCoverageIds": ["MyTest:1777078913423"]
+}
+```
+
+## Counter shape
+
+Single canonical shape for `ICounter` across every endpoint that
+emits counters. Field names mirror JaCoCo's `ICounter` API one-to-one
+— no abbreviation, no synthesized fields beyond what JaCoCo exposes.
+
+```json
+{
+  "coveredCount": 12345,
+  "missedCount": 678,
+  "totalCount": 13023,
+  "coveredRatio": 0.948,
+  "missedRatio": 0.052,
+  "coverageStatus": "PARTLY_COVERED"
+}
+```
+
+| Field | Source | Notes |
+|---|---|---|
+| `coveredCount` | `ICounter.getCoveredCount()` | int |
+| `missedCount` | `ICounter.getMissedCount()` | int |
+| `totalCount` | `ICounter.getTotalCount()` | int, equals `coveredCount + missedCount` |
+| `coveredRatio` | `ICounter.getCoveredRatio()` | double, `null` JSON when JaCoCo returns `NaN` (i.e. `totalCount == 0`) |
+| `missedRatio` | `ICounter.getMissedRatio()` | double, same NaN→null rule |
+| `coverageStatus` | `ICounter.getStatus()` mapped to constant name | one of `EMPTY`, `NOT_COVERED`, `FULLY_COVERED`, `PARTLY_COVERED` (= `NOT_COVERED \| FULLY_COVERED`, bit-flag in JaCoCo) |
+
+`coverageStatus` value is the literal name of the constant — it
+disambiguates from `coverageState` (run lifecycle) and any other
+"status" in the surface.
+
+## Plugin classes
+
+| Class | Role |
+|---|---|
+| `CoverageHandler` | `/coverage/run`, `/coverage/dump`, `/coverage/refresh`, `/coverage/relaunch`. |
+| `CoverageSessionHandler` | `/coverage/runs`, `/coverage/session`, `/coverage/active`, `/coverage/activate`, `/coverage/merge`, `/coverage/remove`. |
+| `CoverageProgressStreamer` | `/coverage/session/stream`. Filters `ISessionListener` and `IJavaCoverageListener` events by `coverageId`. |
+| `CoverageTracker` | `Map<coverageId, CoverageRun>`. Implements `ISessionListener` + `ILaunchesListener2`. |
+| `CoverageAnalyzer` | Wraps `SessionAnalyzer.processSession` with cache `IdentityHashMap<ICoverageSession, CachedAnalysis>`. Entry point `ensureAnalyzed(session)`. |
+| `CoverageTypes` | Computes the supported launch type ID set by querying `LaunchManager.getLaunchConfigurationType(typeId).getDelegates(Set.of("coverage"))` for each of the 9 EclEmma-registered candidates. |
+
+All six classes load lazily — the bridge imports no EclEmma class at
+plugin start.
+
+## EclEmma absence handling
+
+`org.eclipse.eclemma.core` is declared `Require-Bundle` with
+`resolution:=optional` in the bridge `MANIFEST.MF`.
+
+Coverage classes live in a separate package
+`io.github.kaluchi.jdtbridge.coverage` that gets loaded only through
+a single guarded entry in `HttpServer.dispatch`:
+
+```java
+case "/coverage/run", "/coverage/dump", "/coverage/refresh",
+     "/coverage/relaunch",
+     "/coverage/runs", "/coverage/session", "/coverage/session/stream",
+     "/coverage/active", "/coverage/activate",
+     "/coverage/merge", "/coverage/remove" ->
+    CoverageBridge.isAvailable()
+        ? CoverageBridge.dispatch(path, params, body)
+        : Response.json(coverageNotInstalledError());
+```
+
+`CoverageBridge.isAvailable()`:
+`Platform.getBundle("org.eclipse.eclemma.core") != null`, cached
+after first call. Loads no EclEmma class.
+
+`/coverage/*` and `/test/run?coverage=true` are the only routes
+gated by this check.
+
+## Test integration: `coverage` flag on `/test/run`
+
+`GET /test/run?class=<fqn>&...&coverage=true`
+
+When `coverage=true` is present:
+- `TestHandler.prepareLaunch(...)` runs unchanged (config find-or-create
+  by 4 attributes, PDE-headless attributes for plugin tests). See
+  [bridge-test-spec § Config reuse](bridge-test-spec.md#config-reuse).
+- The launch type is validated against `CoverageTypes.SUPPORTED` —
+  if not supported, `coverage-mode-not-supported` error.
+- `pl.config().launch("coverage", null, true)` instead of `RUN_MODE`.
+- Response includes `coverageId` and `launchMode: "coverage"` alongside
+  the usual `testRunId`, `launchId`, `configId`. `coverageId` and
+  `testRunId` are byte-identical strings (same `ATTR_LAUNCH_TIMESTAMP`).
+
+```json
+{
+  "ok": true,
+  "configId": "MyTest",
+  "launchId": "MyTest:6408",
+  "testRunId": "MyTest:1777078913423",
+  "coverageId": "MyTest:1777078913423",
+  "reused": true,
+  "project": "my-project",
+  "runner": "JUnit 5",
+  "launchMode": "coverage",
+  "processPid": "6408"
+}
+```
+
+The `launchMode` field is omitted when `coverage=false` (i.e. the
+existing `/test/run` shape is unchanged for the no-coverage path).
+
+## Errors
+
+| kind | thrown | When |
+|---|---|---|
+| `coverage-not-installed` | `CoverageNotInstalled` | EclEmma bundle absent |
+| `coverage-config-not-found` | `CoverageConfigNotFound` | `configId` missing in `LaunchManager` |
+| `coverage-mode-not-supported` | `CoverageModeNotSupported` | launch type lacks coverage delegate; `:supportedTypeIds` in context |
+| `coverage-not-found` | `CoverageNotFound` | `coverageId` missing in `CoverageTracker` |
+| `coverage-dump-not-found` | `CoverageDumpNotFound` | `coverageId:N` with N out of range |
+| `coverage-launch-terminated` | `CoverageLaunchTerminated` | `dump` on terminated `CoverageRun` |
+| `coverage-launch-not-live` | `CoverageLaunchNotLive` | `dump` / `relaunch` on session whose `coverageSessionKind != "live"` (merged or imported has no `ILaunch`) |
+| `coverage-no-active-session` | `CoverageNoActiveSession` | `refresh` / `relaunch` / `remove` (no body) when `getActiveSession() == null` |
+| `coverage-merge-too-few-inputs` | `CoverageMergeTooFewInputs` | `/coverage/merge` with `<2` IDs |
+| `coverage-no-data` | `CoverageNoData` | live launch terminated with `AgentServer.hasDataReceived() == false` (no dumps ever arrived from agent) |
+| `coverage-analysis-failed` | `CoverageAnalysisFailed` | `SessionAnalyzer.processSession` threw |
+| `coverage-analysis-cancelled` | `CoverageAnalysisCancelled` | `LoadSessionJob` cancelled mid-flight (e.g. by activation switch) |
+| `coverage-agent-jar-missing` | `CoverageAgentJarMissing` | maps EclEmma's `NO_LOCAL_AGENTJAR_ERROR` (5000) — JaCoCo agent jar not extractable |
+| `coverage-exec-file-error` | `CoverageExecFileError` | maps `EXEC_FILE_CREATE_ERROR` (5004) / `EXEC_FILE_READ_ERROR` (5005) |
+
+EclEmma `EclEmmaStatus` codes (5000-5008, 5011-5014, 5101 — see
+`EclEmmaStatus.java:69-149`) are mapped into the categories above
+where they bubble up to API. Codes that stay internal to EclEmma's
+UI (prompts, dialogs) do not surface.
+
+## Constraints
+
+- **`ICoverageSession` is identity-only.** `CoverageSession.equals` is
+  not overridden. The bridge's `Map<coverageId, CoverageRun>` is the
+  only stable identifier surface.
+
+- **Sessions are session-scoped.** Restarting Eclipse clears
+  `SessionManager.getSessions()`. Bridge tracker rebuilds empty —
+  no persistence of `coverageId` across Eclipse restarts. (`.exec`
+  files in `<plugin-state>/.execdata/` are deleted on plugin start
+  and stop, see `ExecutionDataFiles.deleteTemporaryFiles`.)
+
+- **Method coverage resolution is lazy.**
+  `JavaModelCoverage.getCoverageFor(IMethod)` triggers
+  `MethodLocator(parentType)` on first hit per type. Not thread-safe
+  (`HashMap`, no synchronization). Bridge serializes `CoverageAnalyzer`
+  access per session to avoid races.
+
+- **Activation cancels in-flight analysis.**
+  `JavaCoverageLoader.sessionListener.sessionActivated` calls
+  `Job.getJobManager().cancel(LOADJOB)` before scheduling a new
+  `LoadSessionJob`. The previous active session's analysis is
+  partial — bridge re-runs it through `CoverageAnalyzer.ensureAnalyzed`
+  if a query for it arrives, since the bridge cache entry was
+  populated only on `ready` event.
+
+- **`coverageScope` wire format is JDT handle identifiers.**
+  `IPackageFragmentRoot.getHandleIdentifier()` returns strings like
+  `=MyProject/src\\/main\\/java`. CLI rendering converts to human
+  paths via `JavaCore.create(handleId).getResource().getLocation()`.
+
+- **`coverageScope` is `getConfiguredScope`, not `getOverallScope`.**
+  `ScopeUtils.getConfiguredScope(config)` applies either the
+  explicit `ATTR_SCOPE_IDS` selection or `DefaultScopeFilter` from
+  preferences (`getDefaultScopeSourceFoldersOnly` filters out binary
+  roots by default). The wire `coverageScope` field reflects what
+  EclEmma actually instruments, not the broader `getOverallScope` set.
+
+## Files
+
+  coverage/CoverageBridge.java          — guard + dispatch
+  coverage/CoverageHandler.java         — `/coverage/run`, `/dump`, `/refresh`, `/relaunch`
+  coverage/CoverageSessionHandler.java  — `/coverage/runs`, `/session`, `/active`, `/activate`, `/merge`, `/remove`
+  coverage/CoverageProgressStreamer.java — `/coverage/session/stream`
+  coverage/CoverageTracker.java         — `Map<coverageId, CoverageRun>`
+  coverage/CoverageAnalyzer.java        — analysis cache
+  coverage/CoverageTypes.java           — supported launch type IDs
+  HttpServer.java                       — dispatch for `/coverage/*`
+  TestHandler.java                      — `coverage=true` flag
+  MANIFEST.MF                           — `org.eclipse.eclemma.core;resolution:=optional`

--- a/docs/jdt-coverage-spec.md
+++ b/docs/jdt-coverage-spec.md
@@ -1,0 +1,427 @@
+# jdt coverage — Design Spec
+
+CLI surface for Eclipse coverage workflow.
+Server-side contract: [bridge-coverage-spec](bridge-coverage-spec.md).
+This spec references HTTP endpoints, bridge wire fields, and
+user-facing Eclipse GUI labels.
+
+## Eclipse GUI → CLI map
+
+| Eclipse user-facing action | HTTP endpoint | CLI command |
+|---|---|---|
+| Right-click → Coverage As (on a config or class) | `GET /coverage/run` or `GET /test/run?coverage=true` | `jdt coverage run <configId>` / `jdt test run <fqn> --coverage` |
+| Coverage View title bar — active session description | `GET /coverage/active` | `jdt coverage active` |
+| Coverage View toolbar dropdown — list of all sessions to pick active | `GET /coverage/runs` + `POST /coverage/activate` | `jdt coverage runs` + `jdt coverage activate <coverageId>` |
+| Coverage View popup → Refresh (F5) | `POST /coverage/refresh` | `jdt coverage refresh` |
+| Coverage View toolbar — Relaunch Session | `POST /coverage/relaunch` | `jdt coverage relaunch` |
+| Coverage View toolbar — Remove Active Session | `POST /coverage/remove` (empty body) | `jdt coverage remove` |
+| Coverage View toolbar — Remove All Sessions | `POST /coverage/remove` (`all:true`) | `jdt coverage remove --all` |
+| Coverage View toolbar — Merge Sessions… | `POST /coverage/merge` | `jdt coverage merge <coverageId> <coverageId> [...]` |
+| Coverage View toolbar dropdown — Dump Execution Data per running launch | `POST /coverage/dump` (with `reset` body field) | `jdt coverage dump <coverageId> [--reset]` |
+| Console / Debug View — Stop on running coverage launch | `GET /launch/stop` | `jdt coverage stop <coverageId>` (delegates to `jdt launch stop`) |
+
+Eclipse's Import Session, Export Session, and Open Session Execution
+Data commands have no CLI counterpart. Sessions imported through the
+Eclipse Coverage View popup appear in `jdt coverage runs` with
+`coverageSessionKind: "imported"` (read-only).
+
+## Identity vocabulary
+
+Three high-entropy domain keys, never aliased and never shortened:
+
+| Key | Format | Identifies |
+|---|---|---|
+| `coverageId` | live: `<configId>:<launchTimestamp>` (with `:<dumpIndex>` suffix to address a specific dump); merged: `merged:<millis>`; imported: `imported:<millis>` (full composition rules — including intra-millisecond collision suffix — in [bridge-coverage-spec § Identity](bridge-coverage-spec.md#identity)) | one coverage session |
+| `launchId` | `<configId>:<processPid>` | a running/terminated process |
+| `configId` | the launch config name | a saved launch configuration |
+
+These are never called "id", "name", "key", or "ref" anywhere in the
+CLI surface — neither in flags, nor in JSON output, nor in error
+messages. Composition rules and the relationship `coverageId ==
+testRunId` (when both refer to the same launch) live in
+[bridge-coverage-spec § Identity](bridge-coverage-spec.md#identity).
+
+For a long-running launch with multiple `coverage dump` calls, each
+dump produces its own session under the same launch — addressable
+as `<coverageId>:<dumpIndex>` (1-based). Without a numeric suffix,
+`<coverageId>` resolves to the latest dump.
+
+## Commands
+
+### `jdt coverage run <configId> [-f] [-q] [-- args...]`
+
+Launch a coverage run. Non-blocking.
+
+Flags:
+- `-f, --follow` — stream state events until analysis reaches a
+  terminal state
+- `-q, --quiet` — suppress the onboarding guide
+- `-- args...` — extra arguments appended to the launch config (same
+  semantics as `jdt launch run -- args`)
+- `--json` — JSON snapshot output
+
+Whether the new session becomes active is a server-side
+preference (see [bridge-coverage-spec](bridge-coverage-spec.md)).
+
+```bash
+jdt coverage run MyTest
+jdt coverage run MyTest -f
+jdt coverage run my-server -- --port 8080
+```
+
+### `jdt coverage runs [--json]`
+
+Calls `GET /coverage/runs` and renders the array as a table.
+Mirrors Eclipse's session-selection dropdown in the Coverage View
+toolbar.
+
+```
+COVERAGEID                        CONFIGID            ACTIVE  DUMPS  STATUS
+MyTest:1777078913423              MyTest              *       1      running, analysis ready, started 30s ago
+HttpServerBindTest:1777078815046  HttpServerBindTest          1      finished 5m ago, analysis ready
+LongServer:1777078500000          my-server                   3      finished 12m ago
+merged:1777079000000              —                           1      merged 2 sessions
+imported:1777080500000            —                           1      imported
+```
+
+Columns (each backed by a JSON field from the endpoint response):
+- `COVERAGEID` — `coverageId`
+- `CONFIGID` — `configId` (`—` when JSON returns `null`)
+- `ACTIVE` — `*` when `active == true`
+- `DUMPS` — `dumpCount`
+- `STATUS` — composed from `terminated` / `dataReceived` /
+  `analysisLoading` / `analysisReady` / `coverageSessionKind` /
+  `dumpCount` / `terminatedAt` (see § STATUS composition)
+
+### `jdt coverage status <coverageId> [-f] [--json]`
+
+Snapshot of one session.
+
+Flags:
+- `-f, --follow` — stream state events to `/coverage/session/stream`
+  until terminal state reached
+- `--json` — JSONL when streaming, JSON snapshot otherwise
+
+`<coverageId>` accepts:
+- full form `MyTest:1777078913423` — latest dump
+- with dump suffix `MyTest:1777078913423:2` — specific dump
+- bare `configId` (e.g. `MyTest`) — most recent run for that config
+
+Snapshot output (text):
+```
+#### MyTest:1777078913423 (MyTest) — running, ready, active
+
+CoverageScope:
+  /MyProject/src/main/java
+  /MyProject/src/test/java
+Description:   MyTest (Apr 25, 2026 03:14:25 AM)
+ConfigType:    JUnit Plug-in Test
+LaunchId:      MyTest:6408
+DumpCount:     1
+LaunchedAt:    2026-04-25 03:14:25
+TerminatedAt:  —
+
+Instructions   coveredCount=12345  missedCount=678  totalCount=13023  coveredRatio=94.8%  PARTLY_COVERED
+Branches       coveredCount=234    missedCount=56   totalCount=290    coveredRatio=80.7%  PARTLY_COVERED
+Lines          coveredCount=1900   missedCount=100  totalCount=2000   coveredRatio=95.0%  PARTLY_COVERED
+Complexity     coveredCount=75     missedCount=25   totalCount=100    coveredRatio=75.0%  PARTLY_COVERED
+Methods        coveredCount=50     missedCount=0    totalCount=50     coveredRatio=100%   FULLY_COVERED
+Classes        coveredCount=10     missedCount=0    totalCount=10     coveredRatio=100%   FULLY_COVERED
+```
+
+Counter rows shown only when `analysisReady == true`. For
+`analysisLoading == true` the top header shows `analysis loading`
+and the counter section is omitted; for `dataReceived == false` after
+termination, top shows `no data received`.
+
+Counter row formatting rules (each row consumes one entry from
+the JSON `counters` map — see [bridge-coverage-spec § Counter shape](bridge-coverage-spec.md#counter-shape)):
+- Row labels: `Instructions`, `Branches`, `Lines`, `Complexity`,
+  `Methods`, `Classes` — one per `counters.<key>`
+- Numeric columns are wire fields verbatim: `coveredCount`,
+  `missedCount`, `totalCount`, `coveredRatio`
+- `coverageStatus` value rendered as the literal string from the
+  wire (`EMPTY`, `NOT_COVERED`, `FULLY_COVERED`, `PARTLY_COVERED`)
+- Color: `FULLY_COVERED` green, `PARTLY_COVERED` yellow,
+  `NOT_COVERED` red, `EMPTY` dim
+- For `totalCount == 0`: `—  EMPTY` instead of the full breakdown
+
+Streaming output (`-f`) — one line per state event:
+```
+[03:14:25] snapshot: running, pending, 0 dumps
+[03:14:30] dumped #1 at 03:14:30
+[03:14:30] analyzing #1
+[03:14:32] ready #1 — instructions 94.8%, branches 80.7%, lines 95.0%, complexity 75%, methods 100%, classes 100%
+[03:14:45] dumped #2 at 03:14:45
+[03:14:45] analyzing #2
+[03:14:47] ready #2 — instructions 95.1%, branches 81.0%, lines 95.2%, complexity 76%, methods 100%, classes 100%
+[03:15:01] terminated at 03:15:01
+```
+
+### `jdt coverage dump <coverageId> [--reset] [--json]`
+
+Eclipse: Coverage View toolbar → Dump Execution Data button.
+Calls `POST /coverage/dump` with body `{coverageId, reset}`.
+
+`--reset` sets the body's `reset` field to `true` — agent flushes
+current data and zeroes its probes; next dump only contains data
+since the reset. Without `--reset` (`reset:false`) dumps are
+cumulative. Behavior detail: see
+[bridge-coverage-spec § `POST /coverage/dump`](bridge-coverage-spec.md#post-coveragedump).
+
+```bash
+jdt coverage dump MyTest:1777078913423
+jdt coverage dump MyTest:1777078913423 --reset
+```
+
+### `jdt coverage refresh [--json]`
+
+Eclipse: Coverage View popup → Refresh (F5).
+Calls `POST /coverage/refresh` (empty body). Re-runs analysis for
+the active session.
+
+```bash
+jdt coverage refresh
+```
+
+### `jdt coverage relaunch [--json]`
+
+Eclipse: Coverage View toolbar → Relaunch Session.
+Calls `POST /coverage/relaunch` (empty body). Re-launches the active
+session's source config in coverage mode. Returns the same shape as
+`jdt coverage run`.
+
+```bash
+jdt coverage relaunch
+```
+
+### `jdt coverage activate <coverageId> [--json]`
+
+Eclipse: Coverage View toolbar dropdown radio menu / Select Active
+Session dialog. Calls `POST /coverage/activate` with body
+`{coverageId}`.
+
+```
+$ jdt coverage activate HttpServerBindTest:1777078815046
+Activated HttpServerBindTest:1777078815046
+Previous: MyTest:1777078913423
+```
+
+### `jdt coverage active [--json]`
+
+Eclipse: title bar of Coverage View (description of currently
+selected session). Calls `GET /coverage/active`, prints
+`activeCoverageId` from the response.
+
+```
+$ jdt coverage active
+MyTest:1777078913423
+```
+
+`none` when JSON returns `{"activeCoverageId": null}`.
+
+### `jdt coverage merge <coverageId> <coverageId> [<coverageId>...] [--name <description>] [--json]`
+
+Eclipse: Coverage View toolbar → Merge Sessions… (opens dialog with
+selectable input list and editable description).
+Calls `POST /coverage/merge` with body `{coverageIds, description}`.
+Response carries `mergedCoverageId` plus `consumedCoverageIds`
+(inputs become unresolvable after merge).
+
+Flags:
+- `--name <description>` — passed as the `description` body field.
+  When omitted the bridge supplies a default mirroring Eclipse's
+  Merge Sessions dialog default.
+- `--json`
+
+```bash
+jdt coverage merge MyTest:1777078913423 OtherTest:1777078815046
+jdt coverage merge unit-tests integration-tests --name "Combined run"
+```
+
+Output:
+```
+#### Merged 2 sessions → merged:1777079000000
+
+Consumed:
+  MyTest:1777078913423           removed
+  OtherTest:1777078815046         removed
+
+Active session: merged:1777079000000
+  jdt coverage status merged:1777079000000 -f
+```
+
+### `jdt coverage remove [--all] [--json]`
+
+Eclipse: Coverage View toolbar → Remove Active Session / Remove All
+Sessions. Calls `POST /coverage/remove` with empty body or
+`{all: true}`.
+
+```bash
+jdt coverage remove          # remove active
+jdt coverage remove --all    # remove all
+```
+
+Output:
+```
+Removed 1 coverage session
+```
+
+### `jdt coverage stop <coverageId>`
+
+Eclipse: Console / Debug View → Stop button on the running coverage
+launch. Resolves `coverageId` to `launchId` and delegates to
+`jdt launch stop` (HTTP `GET /launch/stop`).
+
+```bash
+jdt coverage stop MyTest:1777078913423
+```
+
+Errors:
+- `coverage-launch-terminated` — already terminated
+- `coverage-launch-not-live` — session has no live launch (merged or imported)
+
+## Test integration: `--coverage` flag
+
+`jdt test run` accepts `--coverage` to launch tests in coverage mode.
+
+```bash
+jdt test run com.example.MyTest --coverage
+jdt test run com.example.MyTest#testFoo --coverage -f
+jdt test run --project my-tests --coverage
+```
+
+When `--coverage` is set:
+- CLI calls `GET /test/run?…&coverage=true` (server-side handling
+  in [bridge-coverage-spec § Test integration](bridge-coverage-spec.md#test-integration-coverage-flag-on-testrun))
+- Response carries `coverageId` and `launchMode: "coverage"`
+  alongside the existing `testRunId`, `launchId`, `configId`.
+  `coverageId` and `testRunId` are byte-identical strings.
+- Header is the standard test header (see
+  [jdt-test-spec § Header](jdt-test-spec.md)) with these deltas:
+  - `CoverageId:` line inserted right after `TestRunId:`
+  - `CoverageScope:` block inserted right after `CoverageId:`
+    (rendered as in § Header format below)
+  - `LaunchMode: coverage` appended at the end (omitted when
+    `--coverage` is not used)
+  - `Config:` label renamed to `LaunchConfig:` for disambiguation
+    (this rename also propagates to the no-coverage `jdt test run`
+    output for consistency)
+- Onboarding guide includes both `jdt test status …` and
+  `jdt coverage status …` paths
+
+## Header format — `jdt coverage run`
+
+Mirrors `jdt test run` header (see [jdt-test-spec](jdt-test-spec.md)):
+markdown-friendly heading, backtick-wrapped values, fixed-width labels.
+
+```
+#### Coverage: MyTest
+CoverageId:    `MyTest:1777078913423`
+CoverageScope:
+  /MyProject/src/main/java
+  /MyProject/src/test/java
+LaunchId:      `MyTest:6408`
+ConfigId:      `MyTest`
+ConfigType:    JUnit Plug-in Test
+LaunchMode:    coverage
+```
+
+## Onboarding guide — `jdt coverage run`
+
+Printed after non-blocking launch unless `-q`. Four sections plus
+trailer, mirrors `jdt test run` guide.
+
+```
+**Coverage status** (coverageId = MyTest:1777078913423):
+  `jdt coverage status MyTest:1777078913423`             snapshot
+  `jdt coverage status MyTest:1777078913423 -f`          follow until ready
+  `jdt coverage active`                                  show active session
+
+**Console output** (launchId = MyTest:6408):
+  `jdt launch logs MyTest:6408`
+  `jdt launch logs MyTest:6408 --tail 50`
+
+**Manage running launch:**
+  `jdt coverage dump MyTest:1777078913423`               request a dump
+  `jdt coverage dump MyTest:1777078913423 --reset`       dump + reset agent probes
+  `jdt coverage stop MyTest:1777078913423`               terminate
+
+**Sessions:**
+  `jdt coverage runs`                                    list all sessions
+  `jdt coverage activate MyTest:1777078913423`           switch IDE display
+  `jdt coverage refresh`                                 re-analyze active
+  `jdt coverage relaunch`                                re-launch active in coverage mode
+  `jdt coverage merge <coverageId> <coverageId>`         merge two or more
+  `jdt coverage remove`                                  remove active
+  `jdt coverage remove --all`                            remove all
+
+Add `-q` to suppress this guide.
+```
+
+## STATUS composition
+
+CLI composes the STATUS string from the four boolean signals plus
+`dumpCount` and `coverageSessionKind` returned by the bridge.
+
+Two token groups, joined by `, `:
+
+**Group A — launch/origin** (exactly one token):
+| Condition | Token |
+|---|---|
+| `coverageSessionKind == "merged"` | `merged N sessions` (`N` = `consumedCoverageIds.size()`) |
+| `coverageSessionKind == "imported"` | `imported` |
+| `coverageSessionKind == "live" && terminated == false` | `running` |
+| `coverageSessionKind == "live" && terminated == true` | `finished Xm ago` |
+
+**Group B — data/analysis** (zero or more tokens, in order):
+| Condition | Token |
+|---|---|
+| `dataReceived == false && terminated == true` | `no data received` |
+| `dumpCount > 1` | `<N> dumps` |
+| `analysisLoading == true` | `analysis loading` |
+| `analysisReady == true` | `analysis ready` |
+| `analysisLoading == false && analysisReady == false && terminated == true && dataReceived == true` | `analysis pending` |
+
+**Group C — relative time** (at most one token, appended last):
+| Condition | Token |
+|---|---|
+| `coverageSessionKind == "live" && terminated == false` | `started <relative> ago` (from `launchTimestamp`) |
+
+Examples:
+- `running, analysis ready, started 30s ago`
+- `running, 3 dumps, analysis loading`
+- `finished 5m ago, analysis ready`
+- `finished 12m ago, no data received`
+- `merged 2 sessions, analysis ready`
+- `imported, analysis pending`
+
+## Files
+
+  commands/coverage-run.mjs        — `jdt coverage run`
+  commands/coverage-runs.mjs       — `jdt coverage runs`
+  commands/coverage-status.mjs     — `jdt coverage status` (snapshot + stream)
+  commands/coverage-dump.mjs       — `jdt coverage dump`
+  commands/coverage-refresh.mjs    — `jdt coverage refresh`
+  commands/coverage-relaunch.mjs   — `jdt coverage relaunch`
+  commands/coverage-active.mjs     — `jdt coverage active` / `activate`
+  commands/coverage-merge.mjs      — `jdt coverage merge`
+  commands/coverage-remove.mjs     — `jdt coverage remove`
+  commands/coverage-stop.mjs       — `jdt coverage stop`
+  format/coverage-status.mjs       — header, state events, guide, follow
+  format/coverage-runs.mjs         — runs table
+  format/coverage-state.mjs        — STATUS line composition
+  commands/test-run.mjs            — extended with `--coverage` flag
+
+## Cross-references
+
+- **[bridge-coverage-spec](bridge-coverage-spec.md)** — server HTTP
+  contract, lifecycle, error categories, plugin classes, identity
+  composition rules.
+- **[jdt-launch-spec](jdt-launch-spec.md)** — coverage launches
+  appear in `jdt launch list`; `coverage stop` delegates to
+  `launch stop`; console output via `launch logs <launchId>`.
+- **[jdt-test-spec](jdt-test-spec.md)** — `jdt test run --coverage`
+  reuses test launch infrastructure; the `coverageId` field in
+  the response equals the `testRunId` field byte-for-byte (same
+  underlying launch).

--- a/jdtbridge-ci.target
+++ b/jdtbridge-ci.target
@@ -22,5 +22,11 @@
             <repository location="https://download.eclipse.org/egit/updates/"/>
             <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true"
+                  includeMode="planner" includeSource="false"
+                  type="InstallableUnit">
+            <repository location="https://download.eclipse.org/jacoco/"/>
+            <unit id="org.eclipse.eclemma.feature.feature.group" version="0.0.0"/>
+        </location>
     </locations>
 </target>

--- a/jdtbridge-ci.target
+++ b/jdtbridge-ci.target
@@ -25,7 +25,7 @@
         <location includeAllPlatforms="false" includeConfigurePhase="true"
                   includeMode="planner" includeSource="false"
                   type="InstallableUnit">
-            <repository location="https://download.eclipse.org/jacoco/"/>
+            <repository location="https://update.eclemma.org/"/>
             <unit id="org.eclipse.eclemma.feature.feature.group" version="0.0.0"/>
         </location>
     </locations>

--- a/plugin.tests/META-INF/MANIFEST.MF
+++ b/plugin.tests/META-INF/MANIFEST.MF
@@ -7,6 +7,8 @@ Bundle-Version: 2.6.0.qualifier
 Fragment-Host: io.github.kaluchi.jdtbridge
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api;bundle-version="5.14",
- org.opentest4j
+ org.opentest4j,
+ org.eclipse.eclemma.core;resolution:=optional,
+ org.jacoco.core;resolution:=optional
 Import-Package: com.google.gson
 Automatic-Module-Name: io.github.kaluchi.jdtbridge.tests

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestFixture.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestFixture.java
@@ -52,10 +52,10 @@ import org.eclipse.jdt.core.JavaCore;
  *   ImportTarget         — unused imports (organize-imports tests)
  * </pre>
  */
-class TestFixture {
+public class TestFixture {
 
-    static final String PROJECT_NAME = "jdtbridge-test";
-    static final String NON_JAVA_PROJECT_NAME = "jdtbridge-test-nonjava";
+    public static final String PROJECT_NAME = "jdtbridge-test";
+    public static final String NON_JAVA_PROJECT_NAME = "jdtbridge-test-nonjava";
 
     private static final String ANIMAL_SRC = """
             package test.model;
@@ -442,7 +442,7 @@ class TestFixture {
             }
             """;
 
-    static void create() throws Exception {
+    public static void create() throws Exception {
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
         IProject project = root.getProject(PROJECT_NAME);
 
@@ -615,7 +615,7 @@ class TestFixture {
         return null;
     }
 
-    static void destroy() throws Exception {
+    public static void destroy() throws Exception {
         IWorkspaceRoot root =
                 ResourcesPlugin.getWorkspace().getRoot();
         for (String name : new String[] {
@@ -628,7 +628,7 @@ class TestFixture {
     }
 
     /** Create a plain project without Java nature. */
-    static void createNonJavaProject() throws Exception {
+    public static void createNonJavaProject() throws Exception {
         IWorkspaceRoot root =
                 ResourcesPlugin.getWorkspace().getRoot();
         IProject project = root.getProject(NON_JAVA_PROJECT_NAME);

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageAnalyzerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageAnalyzerTest.java
@@ -1,0 +1,182 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.IExecutionDataSource;
+import org.eclipse.eclemma.core.ISessionImporter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CoverageAnalyzer}. Drives analysis through real
+ * {@link org.eclipse.eclemma.core.ISessionImporter} sessions so the
+ * underlying {@link org.eclipse.eclemma.internal.core.analysis
+ * .SessionAnalyzer} actually runs end-to-end.
+ */
+public class CoverageAnalyzerTest {
+
+    private CoverageAnalyzer analyzer;
+    private CoverageTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        analyzer = new CoverageAnalyzer();
+        tracker = new CoverageTracker(analyzer);
+        tracker.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        tracker.stop();
+        CoverageTools.getSessionManager().removeAllSessions();
+    }
+
+    @Nested
+    class EnsureAnalyzed {
+
+        @Test
+        void returnsNonNullAnalysisForImportedSession() throws Exception {
+            ICoverageSession session = importEmpty("ensure-1");
+            CoverageAnalyzer.CachedAnalysis ca =
+                    analyzer.ensureAnalyzed(session);
+            assertNotNull(ca);
+            assertNotNull(ca.modelCoverage);
+            assertNotNull(ca.jacocoSessionInfos);
+            assertNotNull(ca.jacocoExecData);
+            assertTrue(ca.computedAtMillis > 0);
+        }
+
+        @Test
+        void emptyExecDataYieldsEmptyInfos() throws Exception {
+            ICoverageSession session = importEmpty("ensure-empty");
+            CoverageAnalyzer.CachedAnalysis ca =
+                    analyzer.ensureAnalyzed(session);
+            // No execution data was emitted, so JaCoCo's
+            // SessionInfoStore is empty.
+            assertTrue(ca.jacocoSessionInfos.isEmpty());
+            assertTrue(ca.jacocoExecData.isEmpty());
+        }
+
+        @Test
+        void cachesResultAcrossCalls() throws Exception {
+            ICoverageSession session = importEmpty("cache-hit");
+            CoverageAnalyzer.CachedAnalysis first =
+                    analyzer.ensureAnalyzed(session);
+            CoverageAnalyzer.CachedAnalysis second =
+                    analyzer.ensureAnalyzed(session);
+            // Identity equality — second call must hit cache.
+            assertSame(first, second);
+        }
+
+        @Test
+        void cacheSizeReflectsUniqueSessions() throws Exception {
+            ICoverageSession a = importEmpty("size-1");
+            ICoverageSession b = importEmpty("size-2");
+            assertEquals(0, analyzer.cacheSize());
+            analyzer.ensureAnalyzed(a);
+            assertEquals(1, analyzer.cacheSize());
+            analyzer.ensureAnalyzed(b);
+            assertEquals(2, analyzer.cacheSize());
+            analyzer.ensureAnalyzed(a);
+            assertEquals(2, analyzer.cacheSize());
+        }
+    }
+
+    @Nested
+    class Invalidation {
+
+        @Test
+        void invalidateRemovesEntry() throws Exception {
+            ICoverageSession session = importEmpty("invalidate-1");
+            analyzer.ensureAnalyzed(session);
+            assertTrue(analyzer.isCached(session));
+            analyzer.invalidate(session);
+            assertFalse(analyzer.isCached(session));
+        }
+
+        @Test
+        void invalidateUnknownIsNoop() {
+            // Should not throw on a session never analyzed.
+            ICoverageSession fake = new TestSessionStub();
+            analyzer.invalidate(fake);
+            assertEquals(0, analyzer.cacheSize());
+        }
+
+        @Test
+        void clearDropsAllEntries() throws Exception {
+            analyzer.ensureAnalyzed(importEmpty("clear-1"));
+            analyzer.ensureAnalyzed(importEmpty("clear-2"));
+            assertEquals(2, analyzer.cacheSize());
+            analyzer.clear();
+            assertEquals(0, analyzer.cacheSize());
+        }
+
+        @Test
+        void trackerRemovalInvalidatesCache() throws Exception {
+            ICoverageSession session = importEmpty("tracker-removal");
+            analyzer.ensureAnalyzed(session);
+            assertTrue(analyzer.isCached(session));
+            // Tracker is wired with this analyzer; the session
+            // listener removes it from cache on session removal.
+            CoverageTools.getSessionManager().removeAllSessions();
+            assertFalse(analyzer.isCached(session));
+        }
+    }
+
+    // -- helpers --
+
+    private ICoverageSession importEmpty(String description)
+            throws Exception {
+        ISessionImporter importer = CoverageTools.getImporter();
+        importer.setDescription(description);
+        importer.setScope(Set.of());
+        importer.setExecutionDataSource(emptyDataSource());
+        importer.setCopy(false);
+        importer.importSession(new NullProgressMonitor());
+        Job.getJobManager().join(
+                CoverageTracker.CLASSIFY_FAMILY, null);
+        // Fetch back the just-imported session by description.
+        return CoverageTools.getSessionManager().getSessions().stream()
+                .filter(s -> description.equals(s.getDescription()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No session " + description));
+    }
+
+    private static IExecutionDataSource emptyDataSource() {
+        return (execVisitor, sessionInfoVisitor) -> {
+            // empty
+        };
+    }
+
+    /** Bare stub used only for {@link
+     *  Invalidation#invalidateUnknownIsNoop} where we need an
+     *  ICoverageSession instance that isn't from EclEmma. */
+    private static final class TestSessionStub
+            implements ICoverageSession {
+        @Override public String getDescription() { return "stub"; }
+        @Override public Set<org.eclipse.jdt.core.IPackageFragmentRoot>
+                getScope() { return Set.of(); }
+        @Override public org.eclipse.debug.core.ILaunchConfiguration
+                getLaunchConfiguration() { return null; }
+        @Override public void accept(
+                org.jacoco.core.data.IExecutionDataVisitor execVisitor,
+                org.jacoco.core.data.ISessionInfoVisitor
+                        sessionInfoVisitor) { }
+        @Override public <T> T getAdapter(Class<T> adapter) {
+            return null;
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridgeTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridgeTest.java
@@ -47,6 +47,35 @@ public class CoverageBridgeTest {
     }
 
     @Nested
+    class StreamNotInstalledEvent {
+
+        @Test
+        void usesEventFailedShape() {
+            String json = CoverageBridge.streamNotInstalledEvent();
+            var obj = JsonParser.parseString(json).getAsJsonObject();
+            assertEquals("failed",
+                    obj.get("event").getAsString());
+            assertEquals("coverage-not-installed",
+                    obj.get("reason").getAsString());
+        }
+
+        @Test
+        void doesNotUseDispatchErrorShape() {
+            // Dispatch errors use {"error":"...","message":"..."};
+            // stream events use {"event":"failed","reason":"..."}.
+            // Stream consumers parse by event field — the dispatch
+            // shape would be invisible to them.
+            String json = CoverageBridge.streamNotInstalledEvent();
+            var obj = JsonParser.parseString(json).getAsJsonObject();
+            assertTrue(obj.has("event"),
+                    "Stream error must carry event field: " + json);
+            assertTrue(!obj.has("error"),
+                    "Stream error must NOT use dispatch shape: "
+                            + json);
+        }
+    }
+
+    @Nested
     class IsAvailable {
 
         // The test runtime imports EclEmma as resolution:=optional;

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridgeTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridgeTest.java
@@ -1,0 +1,112 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import com.google.gson.JsonParser;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.github.kaluchi.jdtbridge.ProjectScope;
+
+/**
+ * Tests for {@link CoverageBridge} — the guarded entry point for
+ * {@code /coverage/*} routes. Covers both the EclEmma-present
+ * dispatch path and the EclEmma-absent error JSON.
+ */
+public class CoverageBridgeTest {
+
+    @Nested
+    class NotInstalledError {
+
+        @Test
+        void hasErrorKind() {
+            String json = CoverageBridge.notInstalledError();
+            var obj = JsonParser.parseString(json).getAsJsonObject();
+            assertEquals("coverage-not-installed",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void includesBundleId() {
+            String json = CoverageBridge.notInstalledError();
+            assertTrue(json.contains("org.eclipse.eclemma.core"),
+                    "Should mention EclEmma bundle: " + json);
+        }
+
+        @Test
+        void mentionsEclipseInstance() {
+            String json = CoverageBridge.notInstalledError();
+            assertTrue(json.contains("Eclipse"),
+                    "Should mention Eclipse instance: " + json);
+        }
+    }
+
+    @Nested
+    class IsAvailable {
+
+        // The test runtime imports EclEmma as resolution:=optional;
+        // when running under the user's local Eclipse target,
+        // EclEmma is present, so isAvailable() returns true.
+        // The CI target also pulls in EclEmma; absence is only a
+        // production scenario when a user installs the bridge into
+        // an Eclipse without EclEmma.
+        @Test
+        void returnsBooleanWithoutCrashing() {
+            // No assertion on the value — both true and false are
+            // legitimate outcomes depending on the target. Just
+            // verify the call is safe.
+            CoverageBridge.isAvailable();
+        }
+    }
+
+    @Nested
+    class Dispatch {
+
+        private final CoverageBridge bridge = new CoverageBridge();
+
+        @Test
+        void unknownPathReturnsCoverageUnknownPath() {
+            String json = bridge.dispatch("/coverage/nope",
+                    Map.of(), null, ProjectScope.ALL);
+            // Either the bridge returns "not-installed" (EclEmma
+            // missing) or the router returns "coverage-unknown-path".
+            // Both are valid; we just assert one of them.
+            assertTrue(json.contains("coverage-not-installed")
+                            || json.contains("coverage-unknown-path"),
+                    "Unexpected error kind: " + json);
+        }
+
+        @Test
+        void knownPathReturnsValidJson() {
+            String json = bridge.dispatch("/coverage/runs",
+                    Map.of(), null, ProjectScope.ALL);
+            // Phase 1: stub returns coverage-not-implemented;
+            // when EclEmma absent: coverage-not-installed. Both
+            // produce parseable JSON.
+            var parsed = JsonParser.parseString(json);
+            assertFalse(parsed.isJsonNull(),
+                    "Should produce non-null JSON: " + json);
+        }
+
+        @Test
+        void everyKnownPathRoutes() {
+            String[] paths = {
+                    "/coverage/run", "/coverage/dump",
+                    "/coverage/refresh", "/coverage/relaunch",
+                    "/coverage/runs", "/coverage/session",
+                    "/coverage/active", "/coverage/activate",
+                    "/coverage/merge", "/coverage/remove"
+            };
+            for (String path : paths) {
+                String json = bridge.dispatch(path, Map.of(), null,
+                        ProjectScope.ALL);
+                JsonParser.parseString(json);
+            }
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBusTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBusTest.java
@@ -1,0 +1,172 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct unit tests for the per-{@code coverageId} listener bus.
+ * Behaviour-only — no EclEmma classes touched; uses {@link
+ * CountingListener} that no-ops every {@code on*} method.
+ */
+public class CoverageEventBusTest {
+
+    private CoverageEventBus bus;
+
+    @BeforeEach
+    void setUp() {
+        bus = new CoverageEventBus();
+    }
+
+    @Nested
+    class SubscribeFire {
+
+        @Test
+        void fireWithoutSubscribersIsNoop() {
+            // Should not throw on missing key.
+            bus.fire("X:1", l -> l.onTerminated(null));
+        }
+
+        @Test
+        void singleSubscriberReceivesEvent() {
+            CountingListener l = new CountingListener();
+            bus.subscribe("X:1", l);
+            bus.fire("X:1", x -> x.onAnalysisLoading(null));
+            assertEquals(1, l.loading.get());
+        }
+
+        @Test
+        void multipleSubscribersAllFire() {
+            CountingListener a = new CountingListener();
+            CountingListener b = new CountingListener();
+            CountingListener c = new CountingListener();
+            bus.subscribe("X:1", a);
+            bus.subscribe("X:1", b);
+            bus.subscribe("X:1", c);
+            bus.fire("X:1", l -> l.onTerminated(null));
+            assertEquals(1, a.terminated.get());
+            assertEquals(1, b.terminated.get());
+            assertEquals(1, c.terminated.get());
+        }
+
+        @Test
+        void differentCoverageIdsAreIsolated() {
+            CountingListener a = new CountingListener();
+            CountingListener b = new CountingListener();
+            bus.subscribe("A:1", a);
+            bus.subscribe("B:1", b);
+            bus.fire("A:1", l -> l.onTerminated(null));
+            assertEquals(1, a.terminated.get());
+            assertEquals(0, b.terminated.get());
+        }
+    }
+
+    @Nested
+    class Unsubscribe {
+
+        @Test
+        void unsubscribeStopsFurtherDelivery() {
+            CountingListener l = new CountingListener();
+            bus.subscribe("X:1", l);
+            bus.fire("X:1", x -> x.onTerminated(null));
+            bus.unsubscribe("X:1", l);
+            bus.fire("X:1", x -> x.onTerminated(null));
+            assertEquals(1, l.terminated.get());
+        }
+
+        @Test
+        void unsubscribeUnknownIsNoop() {
+            CountingListener never = new CountingListener();
+            bus.unsubscribe("Bogus:9", never);
+            // No exception, no delivery
+            assertEquals(0, never.terminated.get());
+        }
+
+        @Test
+        void unsubscribeOneOfManyKeepsRest() {
+            CountingListener a = new CountingListener();
+            CountingListener b = new CountingListener();
+            bus.subscribe("X:1", a);
+            bus.subscribe("X:1", b);
+            bus.unsubscribe("X:1", a);
+            bus.fire("X:1", l -> l.onTerminated(null));
+            assertEquals(0, a.terminated.get());
+            assertEquals(1, b.terminated.get());
+        }
+    }
+
+    @Nested
+    class ExceptionIsolation {
+
+        @Test
+        void thrownByOneListenerDoesNotBlockOthers() {
+            CountingListener after = new CountingListener();
+            bus.subscribe("X:1", new CoverageTracker.CoverageEventListener() {
+                @Override public void onDumped(CoverageRun r, int i, long t) {}
+                @Override public void onAnalysisLoading(CoverageRun r) {}
+                @Override public void onAnalysisReady(CoverageRun r) {}
+                @Override public void onTerminated(CoverageRun r) {
+                    throw new RuntimeException("intentional");
+                }
+                @Override public void onFailed(CoverageRun r, String reason) {}
+            });
+            bus.subscribe("X:1", after);
+            bus.fire("X:1", l -> l.onTerminated(null));
+            assertEquals(1, after.terminated.get());
+        }
+    }
+
+    @Nested
+    class Clear {
+
+        @Test
+        void clearDropsAllSubscribers() {
+            CountingListener a = new CountingListener();
+            CountingListener b = new CountingListener();
+            bus.subscribe("A:1", a);
+            bus.subscribe("B:1", b);
+            bus.clear();
+            bus.fire("A:1", l -> l.onTerminated(null));
+            bus.fire("B:1", l -> l.onTerminated(null));
+            assertEquals(0, a.terminated.get());
+            assertEquals(0, b.terminated.get());
+        }
+    }
+
+    /** Listener that just counts how many times each callback
+     *  was invoked. CoverageRun arg is ignored — bus
+     *  contract is just "deliver call-by-call". */
+    private static final class CountingListener
+            implements CoverageTracker.CoverageEventListener {
+        final AtomicInteger dumped = new AtomicInteger();
+        final AtomicInteger loading = new AtomicInteger();
+        final AtomicInteger ready = new AtomicInteger();
+        final AtomicInteger terminated = new AtomicInteger();
+        final AtomicInteger failed = new AtomicInteger();
+        final List<String> failedReasons = new ArrayList<>();
+
+        @Override public void onDumped(CoverageRun r, int i, long t) {
+            dumped.incrementAndGet();
+        }
+        @Override public void onAnalysisLoading(CoverageRun r) {
+            loading.incrementAndGet();
+        }
+        @Override public void onAnalysisReady(CoverageRun r) {
+            ready.incrementAndGet();
+        }
+        @Override public void onTerminated(CoverageRun r) {
+            terminated.incrementAndGet();
+        }
+        @Override public void onFailed(CoverageRun r, String reason) {
+            failed.incrementAndGet();
+            failedReasons.add(reason);
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
@@ -1,0 +1,242 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.IExecutionDataSource;
+import org.eclipse.eclemma.core.ISessionImporter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests for {@link CoverageHandler}. Validation paths are unit-style
+ * (no real launch); the {@code /refresh} happy path and a relaunch
+ * precondition are exercised against a real imported session.
+ */
+public class CoverageHandlerTest {
+
+    private CoverageTracker tracker;
+    private CoverageHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new CoverageTracker();
+        tracker.start();
+        handler = new CoverageHandler(tracker);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tracker.stop();
+        CoverageTools.getSessionManager().removeAllSessions();
+    }
+
+    @Nested
+    class HandleRun {
+
+        @Test
+        void missingConfigIdReturnsConfigNotFound() {
+            JsonObject obj = parseObj(handler.handleRun(Map.of()));
+            assertEquals("coverage-config-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void blankConfigIdReturnsConfigNotFound() {
+            JsonObject obj = parseObj(handler.handleRun(
+                    Map.of("configId", "   ")));
+            assertEquals("coverage-config-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownConfigReturnsConfigNotFound() {
+            JsonObject obj = parseObj(handler.handleRun(Map.of(
+                    "configId", "definitely-not-a-real-config-xyz-9z")));
+            assertEquals("coverage-config-not-found",
+                    obj.get("error").getAsString());
+        }
+    }
+
+    @Nested
+    class HandleDump {
+
+        @Test
+        void missingBodyReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleDump(null));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void emptyBodyReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleDump(""));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void invalidJsonReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{not valid json"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void missingCoverageIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"reset\":true}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownCoverageIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"Bogus:9999\"}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void importedSessionReturnsLaunchNotLive() {
+            String coverageId = importAndAwait("dump-on-imported");
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"" + coverageId + "\"}"));
+            assertEquals("coverage-launch-not-live",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void resetDefaultsToFalseWhenOmitted() {
+            // No assertion on side-effect (no live launch), only
+            // that the missing-reset path doesn't throw a parse
+            // error before the coverage-not-found check.
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"unknown\"}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+    }
+
+    @Nested
+    class HandleRefresh {
+
+        @Test
+        void noActiveSessionReturnsNoActiveError() {
+            CoverageTools.getSessionManager().removeAllSessions();
+            JsonObject obj = parseObj(handler.handleRefresh());
+            assertEquals("coverage-no-active-session",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void withActiveSessionReturnsOk() {
+            String coverageId = importAndAwait("refresh-test");
+            JsonObject obj = parseObj(handler.handleRefresh());
+            assertTrue(obj.get("ok").getAsBoolean(),
+                    "Expected ok=true: " + obj);
+            assertEquals(coverageId,
+                    obj.get("activeCoverageId").getAsString());
+        }
+    }
+
+    @Nested
+    class HandleRelaunch {
+
+        @Test
+        void noActiveSessionReturnsNoActiveError() {
+            CoverageTools.getSessionManager().removeAllSessions();
+            JsonObject obj = parseObj(handler.handleRelaunch());
+            assertEquals("coverage-no-active-session",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void importedActiveReturnsLaunchNotLive() {
+            // Imported session has launchConfiguration == null,
+            // so relaunch can't reconstruct a launch from it.
+            importAndAwait("relaunch-imported");
+            JsonObject obj = parseObj(handler.handleRelaunch());
+            assertEquals("coverage-launch-not-live",
+                    obj.get("error").getAsString());
+        }
+    }
+
+    @Nested
+    class ErrorJsonShape {
+
+        @Test
+        void everyErrorHasErrorAndMessage() {
+            // Iterate the validation paths that don't require a
+            // real launch and assert the error JSON shape.
+            String[] errorJsons = {
+                    handler.handleRun(Map.of()),
+                    handler.handleRun(
+                            Map.of("configId", "unknown")),
+                    handler.handleDump(null),
+                    handler.handleDump(""),
+                    handler.handleDump("{not json"),
+                    handler.handleDump(
+                            "{\"coverageId\":\"unknown\"}"),
+                    handler.handleRefresh(),
+                    handler.handleRelaunch()
+            };
+            for (String json : errorJsons) {
+                JsonObject obj = parseObj(json);
+                assertNotNull(obj.get("error"),
+                        "Missing error field: " + json);
+                assertTrue(obj.get("error").getAsString()
+                                .startsWith("coverage-"),
+                        "Error kind must use coverage- prefix: "
+                                + json);
+            }
+        }
+    }
+
+    // -- helpers --
+
+    private static JsonObject parseObj(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    private String importAndAwait(String description) {
+        ISessionImporter importer = CoverageTools.getImporter();
+        importer.setDescription(description);
+        importer.setScope(Set.of());
+        importer.setExecutionDataSource(emptyDataSource());
+        importer.setCopy(false);
+        try {
+            importer.importSession(new NullProgressMonitor());
+            Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return tracker.snapshot().values().stream()
+                .filter(r -> description.equals(r.description))
+                .map(r -> r.coverageId)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static IExecutionDataSource emptyDataSource() {
+        return (execVisitor, sessionInfoVisitor) -> {
+            // Intentionally empty.
+        };
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -240,6 +240,52 @@ public class CoverageProgressStreamerTest {
         }
 
         @Test
+        void terminatedDuringLoadingDoesNotCloseUntilReady()
+                throws Exception {
+            // Real coverage launches fire terminated BEFORE
+            // analysisReady (LoadSessionJob completes after the
+            // JVM exits). Stream must stay open through the
+            // terminated event and close only when analysisReady
+            // arrives — otherwise consumers never see counters.
+            String coverageId = importAndAwait("late-ready");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+            run.analysisLoading = true;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Thread worker = new Thread(() ->
+                    CoverageProgressStreamer.stream(out, coverageId,
+                            tracker, analyzer));
+            worker.start();
+            awaitListener(coverageId);
+
+            // Step 1: terminate — stream still has analysisLoading
+            // pending, must NOT close.
+            run.terminated = true;
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onTerminated(run));
+            // Yield + brief sleep so the worker observes the
+            // event without false-completing.
+            Thread.sleep(100);
+            assertTrue(worker.isAlive(),
+                    "Stream must stay open after terminated when"
+                            + " analysisLoading is still true");
+
+            // Step 2: analysis finishes — now stream closes.
+            run.analysisLoading = false;
+            run.analysisReady = true;
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onAnalysisReady(run));
+            worker.join(5000);
+
+            String body = out.toString(StandardCharsets.UTF_8);
+            assertTrue(body.contains("\"event\":\"terminated\""),
+                    "terminated event must be present: " + body);
+            assertTrue(body.contains("\"event\":\"analysisReady\""),
+                    "analysisReady must be present after terminated"
+                            + ": " + body);
+        }
+
+        @Test
         void dumpedEventCarriesIndexAndTimestamp() throws Exception {
             String coverageId = importAndAwait("dumped-test");
             CoverageRun run = tracker.byCoverageId(coverageId);

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -1,0 +1,225 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Set;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.IExecutionDataSource;
+import org.eclipse.eclemma.core.ISessionImporter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests for {@link CoverageProgressStreamer}. Streams against
+ * imported (already-terminal) sessions: the streamer emits
+ * {@code snapshot} + {@code terminated} and returns immediately,
+ * which is enough to assert the JSONL wire shape and event order
+ * without spawning a real launch.
+ */
+public class CoverageProgressStreamerTest {
+
+    private CoverageAnalyzer analyzer;
+    private CoverageTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        analyzer = new CoverageAnalyzer();
+        tracker = new CoverageTracker(analyzer);
+        tracker.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        tracker.stop();
+        CoverageTools.getSessionManager().removeAllSessions();
+    }
+
+    @Nested
+    class GuardErrors {
+
+        @Test
+        void missingCoverageIdEmitsFailedEvent() {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, null, tracker);
+            JsonObject obj = parseLine(out, 0);
+            assertEquals("failed",
+                    obj.get("event").getAsString());
+            assertEquals("missing-coverageId",
+                    obj.get("reason").getAsString());
+        }
+
+        @Test
+        void blankCoverageIdEmitsFailedEvent() {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, "  ", tracker);
+            JsonObject obj = parseLine(out, 0);
+            assertEquals("failed",
+                    obj.get("event").getAsString());
+        }
+
+        @Test
+        void unknownCoverageIdEmitsFailed() {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, "Bogus:9999",
+                    tracker);
+            JsonObject obj = parseLine(out, 0);
+            assertEquals("failed",
+                    obj.get("event").getAsString());
+            assertEquals("coverage-not-found",
+                    obj.get("reason").getAsString());
+        }
+    }
+
+    @Nested
+    class TerminalSession {
+
+        @Test
+        void importedSessionEmitsSnapshotThenTerminated() {
+            String coverageId = importAndAwait("stream-terminal");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, coverageId,
+                    tracker);
+            String[] lines = lines(out);
+            assertEquals(2, lines.length,
+                    "Expected snapshot + terminated lines, got: "
+                            + java.util.Arrays.toString(lines));
+            JsonObject snap = JsonParser.parseString(lines[0])
+                    .getAsJsonObject();
+            JsonObject term = JsonParser.parseString(lines[1])
+                    .getAsJsonObject();
+            assertEquals("snapshot",
+                    snap.get("event").getAsString());
+            assertEquals(coverageId,
+                    snap.get("coverageId").getAsString());
+            assertEquals("terminated",
+                    term.get("event").getAsString());
+            assertEquals(coverageId,
+                    term.get("coverageId").getAsString());
+        }
+
+        @Test
+        void snapshotCarriesAllStatusFlags() {
+            String coverageId = importAndAwait("snap-flags");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, coverageId,
+                    tracker);
+            JsonObject snap = parseLine(out, 0);
+            for (String key : new String[] {
+                    "coverageId", "coverageSessionKind",
+                    "terminated", "dataReceived",
+                    "analysisLoading", "analysisReady",
+                    "dumpCount"
+            }) {
+                assertTrue(snap.has(key),
+                        "Missing snapshot field '" + key + "': "
+                                + snap);
+            }
+        }
+
+        @Test
+        void terminatedEventCarriesDataReceived() {
+            String coverageId = importAndAwait("term-data");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, coverageId,
+                    tracker);
+            JsonObject term = parseLine(out, 1);
+            assertTrue(term.get("dataReceived").getAsBoolean());
+            assertNotNull(term.get("terminatedAt"),
+                    "terminated event should carry terminatedAt: "
+                            + term);
+        }
+
+        @Test
+        void importedRunSessionKindIsImported() {
+            String coverageId = importAndAwait("kind-imported");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, coverageId,
+                    tracker);
+            JsonObject snap = parseLine(out, 0);
+            assertEquals("imported",
+                    snap.get("coverageSessionKind").getAsString());
+        }
+    }
+
+    @Nested
+    class Newlines {
+
+        @Test
+        void everyEventIsOneLine() {
+            String coverageId = importAndAwait("oneline");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, coverageId,
+                    tracker);
+            String body = out.toString(
+                    java.nio.charset.StandardCharsets.UTF_8);
+            // Expect exactly two LF-terminated records.
+            long lfCount = body.chars().filter(c -> c == '\n').count();
+            assertEquals(2, lfCount,
+                    "Expected 2 newlines, got " + lfCount + " in: "
+                            + body);
+        }
+
+        @Test
+        void noTrailingTextAfterLastNewline() {
+            String coverageId = importAndAwait("no-trailer");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            CoverageProgressStreamer.stream(out, coverageId,
+                    tracker);
+            String body = out.toString(
+                    java.nio.charset.StandardCharsets.UTF_8);
+            assertTrue(body.endsWith("\n"),
+                    "Body must end with newline: " + body);
+        }
+    }
+
+    // -- helpers --
+
+    private static JsonObject parseLine(ByteArrayOutputStream out,
+            int index) {
+        return JsonParser.parseString(lines(out)[index])
+                .getAsJsonObject();
+    }
+
+    private static String[] lines(ByteArrayOutputStream out) {
+        String body = out.toString(
+                java.nio.charset.StandardCharsets.UTF_8);
+        return body.split("\n");
+    }
+
+    private String importAndAwait(String description) {
+        ISessionImporter importer = CoverageTools.getImporter();
+        importer.setDescription(description);
+        importer.setScope(Set.of());
+        importer.setExecutionDataSource(emptyDataSource());
+        importer.setCopy(false);
+        try {
+            importer.importSession(new NullProgressMonitor());
+            Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return tracker.snapshot().values().stream()
+                .filter(r -> description.equals(r.description))
+                .map(r -> r.coverageId)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static IExecutionDataSource emptyDataSource() {
+        return (execVisitor, sessionInfoVisitor) -> {
+            // Intentionally empty.
+        };
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -51,7 +51,7 @@ public class CoverageProgressStreamerTest {
         @Test
         void missingCoverageIdEmitsFailedEvent() {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            CoverageProgressStreamer.stream(out, null, tracker);
+            CoverageProgressStreamer.stream(out, null, tracker, analyzer);
             JsonObject obj = parseLine(out, 0);
             assertEquals("failed",
                     obj.get("event").getAsString());
@@ -62,7 +62,7 @@ public class CoverageProgressStreamerTest {
         @Test
         void blankCoverageIdEmitsFailedEvent() {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            CoverageProgressStreamer.stream(out, "  ", tracker);
+            CoverageProgressStreamer.stream(out, "  ", tracker, analyzer);
             JsonObject obj = parseLine(out, 0);
             assertEquals("failed",
                     obj.get("event").getAsString());
@@ -72,7 +72,7 @@ public class CoverageProgressStreamerTest {
         void unknownCoverageIdEmitsFailed() {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, "Bogus:9999",
-                    tracker);
+                    tracker, analyzer);
             JsonObject obj = parseLine(out, 0);
             assertEquals("failed",
                     obj.get("event").getAsString());
@@ -89,7 +89,7 @@ public class CoverageProgressStreamerTest {
             String coverageId = importAndAwait("stream-terminal");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
-                    tracker);
+                    tracker, analyzer);
             String[] lines = lines(out);
             assertEquals(2, lines.length,
                     "Expected snapshot + terminated lines, got: "
@@ -113,7 +113,7 @@ public class CoverageProgressStreamerTest {
             String coverageId = importAndAwait("snap-flags");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
-                    tracker);
+                    tracker, analyzer);
             JsonObject snap = parseLine(out, 0);
             for (String key : new String[] {
                     "coverageId", "coverageSessionKind",
@@ -132,7 +132,7 @@ public class CoverageProgressStreamerTest {
             String coverageId = importAndAwait("term-data");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
-                    tracker);
+                    tracker, analyzer);
             JsonObject term = parseLine(out, 1);
             assertTrue(term.get("dataReceived").getAsBoolean());
             assertNotNull(term.get("terminatedAt"),
@@ -145,7 +145,7 @@ public class CoverageProgressStreamerTest {
             String coverageId = importAndAwait("kind-imported");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
-                    tracker);
+                    tracker, analyzer);
             JsonObject snap = parseLine(out, 0);
             assertEquals("imported",
                     snap.get("coverageSessionKind").getAsString());
@@ -160,7 +160,7 @@ public class CoverageProgressStreamerTest {
             String coverageId = importAndAwait("oneline");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
-                    tracker);
+                    tracker, analyzer);
             String body = out.toString(
                     java.nio.charset.StandardCharsets.UTF_8);
             // Expect exactly two LF-terminated records.
@@ -175,7 +175,7 @@ public class CoverageProgressStreamerTest {
             String coverageId = importAndAwait("no-trailer");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
-                    tracker);
+                    tracker, analyzer);
             String body = out.toString(
                     java.nio.charset.StandardCharsets.UTF_8);
             assertTrue(body.endsWith("\n"),

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -1,10 +1,14 @@
 package io.github.kaluchi.jdtbridge.coverage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -153,6 +157,191 @@ public class CoverageProgressStreamerTest {
     }
 
     @Nested
+    class LiveEvents {
+
+        /** Drive the streamer through a non-terminal run by forcing
+         *  {@code terminated=false} on a freshly imported session
+         *  (imported sessions are normally terminal). Lets us
+         *  exercise the listener-loop path without spawning a real
+         *  coverage launch. */
+        @Test
+        void analysisReadyEventCarriesCounters() throws Exception {
+            String coverageId = importAndAwait("ready-counters");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Thread worker = new Thread(() ->
+                    CoverageProgressStreamer.stream(out, coverageId,
+                            tracker, analyzer));
+            worker.start();
+            awaitListener(coverageId);
+
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onAnalysisReady(run));
+
+            run.terminated = true;
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onTerminated(run));
+            worker.join(5000);
+
+            JsonObject readyEvent = findEvent(out, "analysisReady");
+            assertNotNull(readyEvent,
+                    "Expected analysisReady event in stream output");
+            assertTrue(readyEvent.has("counters"),
+                    "analysisReady must carry counters: "
+                            + readyEvent);
+        }
+
+        @Test
+        void onFailedEmitsAnalysisCancelledEvent() throws Exception {
+            String coverageId = importAndAwait("cancel-test");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Thread worker = new Thread(() ->
+                    CoverageProgressStreamer.stream(out, coverageId,
+                            tracker, analyzer));
+            worker.start();
+            awaitListener(coverageId);
+
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onFailed(run, "analysis-cancelled"));
+            worker.join(5000);
+
+            JsonObject failedEvent = findEvent(out, "failed");
+            assertNotNull(failedEvent,
+                    "Expected failed event in stream output");
+            assertEquals("analysis-cancelled",
+                    failedEvent.get("reason").getAsString());
+            assertEquals(coverageId,
+                    failedEvent.get("coverageId").getAsString());
+        }
+
+        @Test
+        void analysisLoadingEventFiresThroughBus() throws Exception {
+            String coverageId = importAndAwait("loading-test");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Thread worker = new Thread(() ->
+                    CoverageProgressStreamer.stream(out, coverageId,
+                            tracker, analyzer));
+            worker.start();
+            awaitListener(coverageId);
+
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onAnalysisLoading(run));
+            run.terminated = true;
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onTerminated(run));
+            worker.join(5000);
+
+            assertNotNull(findEvent(out, "analysisLoading"));
+        }
+
+        @Test
+        void dumpedEventCarriesIndexAndTimestamp() throws Exception {
+            String coverageId = importAndAwait("dumped-test");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Thread worker = new Thread(() ->
+                    CoverageProgressStreamer.stream(out, coverageId,
+                            tracker, analyzer));
+            worker.start();
+            awaitListener(coverageId);
+
+            long t = System.currentTimeMillis();
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onDumped(run, 7, t));
+            run.terminated = true;
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onTerminated(run));
+            worker.join(5000);
+
+            JsonObject dumped = findEvent(out, "dumped");
+            assertNotNull(dumped);
+            assertEquals(7, dumped.get("dumpIndex").getAsInt());
+            assertEquals(t, dumped.get("dumpTimestamp").getAsLong());
+        }
+    }
+
+    @Nested
+    class ListenerCleanup {
+
+        /** Reproduces the leak fixed by safeWrite: when a listener
+         *  callback throws StreamClosedException because the peer
+         *  has gone away, the streamer must trip its latch and
+         *  unsubscribe — not sit on done.await() forever with an
+         *  orphaned listener still registered. */
+        @Test
+        void brokenPipeUnsubscribesListenerAndExits()
+                throws Exception {
+            String coverageId = importAndAwait("leak-test");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+
+            BreakAfterFirstLine out = new BreakAfterFirstLine();
+            Thread worker = new Thread(() ->
+                    CoverageProgressStreamer.stream(out, coverageId,
+                            tracker, analyzer));
+            worker.start();
+            awaitListener(coverageId);
+
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onDumped(run, 1, 0L));
+            worker.join(5000);
+
+            assertFalse(worker.isAlive(),
+                    "Streamer thread should have exited after"
+                            + " broken-pipe event");
+            assertFalse(tracker.eventBus().hasListeners(coverageId),
+                    "Listener must be unsubscribed after"
+                            + " broken-pipe failure (leak fix)");
+        }
+
+        @Test
+        void multipleSubscribersIndependent() throws Exception {
+            String coverageId = importAndAwait("multi-sub");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.terminated = false;
+
+            ByteArrayOutputStream a = new ByteArrayOutputStream();
+            ByteArrayOutputStream b = new ByteArrayOutputStream();
+            Thread wa = new Thread(() ->
+                    CoverageProgressStreamer.stream(a, coverageId,
+                            tracker, analyzer));
+            Thread wb = new Thread(() ->
+                    CoverageProgressStreamer.stream(b, coverageId,
+                            tracker, analyzer));
+            wa.start(); wb.start();
+
+            // Wait until both worker threads have registered as
+            // subscribers. CoverageEventBus.hasListeners returns
+            // true once the first subscribes; we want both, so we
+            // also wait for both to write the snapshot line.
+            for (int i = 0; i < 5000 && (
+                    countLines(a.toString(StandardCharsets.UTF_8)) < 1
+                    || countLines(b.toString(StandardCharsets.UTF_8)) < 1
+                    ); i++) {
+                Thread.sleep(1);
+            }
+
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onAnalysisReady(run));
+            run.terminated = true;
+            tracker.eventBus().fire(coverageId,
+                    l -> l.onTerminated(run));
+
+            wa.join(5000);
+            wb.join(5000);
+
+            assertNotNull(findEvent(a, "analysisReady"));
+            assertNotNull(findEvent(b, "analysisReady"));
+        }
+    }
+
+    @Nested
     class Newlines {
 
         @Test
@@ -221,5 +410,73 @@ public class CoverageProgressStreamerTest {
         return (execVisitor, sessionInfoVisitor) -> {
             // Intentionally empty.
         };
+    }
+
+    /** Wait for the streamer's listener to register before firing
+     *  events. 5s budget — test-only, real flow doesn't need this. */
+    private void awaitListener(String coverageId)
+            throws InterruptedException {
+        for (int i = 0; i < 5000
+                && !tracker.eventBus().hasListeners(coverageId); i++) {
+            Thread.sleep(1);
+        }
+        if (!tracker.eventBus().hasListeners(coverageId)) {
+            throw new AssertionError(
+                    "Streamer never subscribed for " + coverageId);
+        }
+    }
+
+    /** Locate the first JSONL line in {@code out} whose {@code event}
+     *  field equals {@code name}. Returns {@code null} when absent. */
+    private static JsonObject findEvent(ByteArrayOutputStream out,
+            String name) {
+        for (String line : lines(out)) {
+            if (line.isEmpty()) continue;
+            JsonObject obj;
+            try {
+                obj = JsonParser.parseString(line).getAsJsonObject();
+            } catch (Exception e) {
+                continue;
+            }
+            if (obj.has("event")
+                    && name.equals(obj.get("event").getAsString())) {
+                return obj;
+            }
+        }
+        return null;
+    }
+
+    private static int countLines(String body) {
+        return (int) body.chars().filter(c -> c == '\n').count();
+    }
+
+    /** OutputStream that succeeds for the first JSONL record (so the
+     *  snapshot lands and the listener registers) and fails on any
+     *  subsequent write — simulates a peer that disconnects after
+     *  the first line. */
+    private static final class BreakAfterFirstLine extends OutputStream {
+        private boolean broken = false;
+        @Override
+        public void write(int b) throws IOException {
+            if (broken) {
+                throw new IOException("simulated broken pipe");
+            }
+            if (b == '\n') {
+                broken = true;
+            }
+        }
+        @Override
+        public void flush() throws IOException {
+            // Snapshot path calls flush after writing all bytes;
+            // first call must succeed, later calls behave like the
+            // pipe stayed broken.
+            if (broken) {
+                // After the newline turned `broken` true the next
+                // listener-callback write will hit it. flush itself
+                // is a no-op for ByteArrayOutputStream-style sinks,
+                // so leave it intact here — the failure path is
+                // exercised by `write` above.
+            }
+        }
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageRunTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageRunTest.java
@@ -1,0 +1,267 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.Launch;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CoverageRun} factories and accessors. Pure-data
+ * tests — no listeners, no SessionManager interaction.
+ */
+public class CoverageRunTest {
+
+    @Nested
+    class LiveFactory {
+
+        private final ILaunch launch = new Launch(null, "coverage", null);
+
+        @Test
+        void kindIsLive() {
+            CoverageRun run = CoverageRun.live(
+                    "MyTest:1700000000000", "MyTest", "JUnit",
+                    "org.eclipse.jdt.junit.launchconfig", launch,
+                    1700000000000L, Set.of());
+            assertEquals(CoverageRun.Kind.LIVE, run.kind);
+            assertEquals("live", run.kind.wireName());
+        }
+
+        @Test
+        void copiesInputs() {
+            CoverageRun run = CoverageRun.live(
+                    "MyTest:1700000000000", "MyTest", "JUnit",
+                    "org.eclipse.jdt.junit.launchconfig", launch,
+                    1700000000000L, Set.of());
+            assertEquals("MyTest:1700000000000", run.coverageId);
+            assertEquals("MyTest", run.configId);
+            assertEquals("JUnit", run.configType);
+            assertEquals("org.eclipse.jdt.junit.launchconfig",
+                    run.configTypeId);
+            assertSame(launch, run.launch);
+            assertEquals(1700000000000L, run.launchTimestamp);
+        }
+
+        @Test
+        void initialFlags() {
+            CoverageRun run = CoverageRun.live("X:1", "X", null,
+                    null, launch, 1L, Set.of());
+            assertFalse(run.terminated);
+            assertFalse(run.dataReceived);
+            assertFalse(run.analysisLoading);
+            assertFalse(run.analysisReady);
+            assertNull(run.terminatedAt);
+            assertEquals(0, run.dumpCount());
+            assertTrue(run.consumedCoverageIds.isEmpty());
+        }
+
+        @Test
+        void createdAtIsRecent() {
+            long before = System.currentTimeMillis();
+            CoverageRun run = CoverageRun.live("X:1", "X", null,
+                    null, launch, 1L, Set.of());
+            long after = System.currentTimeMillis();
+            assertTrue(run.createdAtMillis >= before
+                    && run.createdAtMillis <= after);
+        }
+    }
+
+    @Nested
+    class MergedFactory {
+
+        @Test
+        void kindIsMerged() {
+            CoverageRun run = CoverageRun.merged(
+                    "merged:1700000000000", null, null, null,
+                    Set.of(), "Merged (...)",
+                    List.of("A:1", "B:2"));
+            assertEquals(CoverageRun.Kind.MERGED, run.kind);
+            assertEquals("merged", run.kind.wireName());
+        }
+
+        @Test
+        void preTerminatedWithDataReceived() {
+            CoverageRun run = CoverageRun.merged(
+                    "merged:1", null, null, null,
+                    Set.of(), "desc", List.of("A:1", "B:2"));
+            assertTrue(run.terminated);
+            assertTrue(run.dataReceived);
+            assertNotNull(run.terminatedAt);
+        }
+
+        @Test
+        void consumedIdsCopied() {
+            List<String> inputs = List.of("A:1", "B:2", "C:3");
+            CoverageRun run = CoverageRun.merged(
+                    "merged:1", null, null, null,
+                    Set.of(), "d", inputs);
+            assertEquals(inputs, run.consumedCoverageIds);
+        }
+
+        @Test
+        void noLaunchOrTimestamp() {
+            CoverageRun run = CoverageRun.merged(
+                    "merged:1", null, null, null,
+                    Set.of(), "d", List.of("A:1", "B:2"));
+            assertNull(run.launch);
+            assertNull(run.launchTimestamp);
+        }
+
+        @Test
+        void allowsAdoptedLaunchConfigMetadata() {
+            CoverageRun run = CoverageRun.merged(
+                    "merged:1", "SharedConfig", "JUnit",
+                    "org.eclipse.jdt.junit.launchconfig",
+                    Set.of(), "d", List.of("A:1", "B:2"));
+            assertEquals("SharedConfig", run.configId);
+            assertEquals("JUnit", run.configType);
+        }
+    }
+
+    @Nested
+    class ImportedFactory {
+
+        @Test
+        void kindIsImported() {
+            CoverageRun run = CoverageRun.imported(
+                    "imported:1", Set.of(), "Imported file");
+            assertEquals(CoverageRun.Kind.IMPORTED, run.kind);
+            assertEquals("imported", run.kind.wireName());
+        }
+
+        @Test
+        void preTerminatedWithDataReceived() {
+            CoverageRun run = CoverageRun.imported(
+                    "imported:1", Set.of(), "d");
+            assertTrue(run.terminated);
+            assertTrue(run.dataReceived);
+            assertNotNull(run.terminatedAt);
+        }
+
+        @Test
+        void noConfigOrLaunchInfo() {
+            CoverageRun run = CoverageRun.imported(
+                    "imported:1", Set.of(), "d");
+            assertNull(run.configId);
+            assertNull(run.configType);
+            assertNull(run.configTypeId);
+            assertNull(run.launch);
+            assertNull(run.launchTimestamp);
+        }
+
+        @Test
+        void emptyConsumedIds() {
+            CoverageRun run = CoverageRun.imported(
+                    "imported:1", Set.of(), "d");
+            assertTrue(run.consumedCoverageIds.isEmpty());
+        }
+    }
+
+    @Nested
+    class ResolveSession {
+
+        private CoverageRun runWithDumps(int n) {
+            CoverageRun run = CoverageRun.live("X:1", "X", null,
+                    null, new Launch(null, "coverage", null), 1L,
+                    Set.of());
+            for (int i = 0; i < n; i++) {
+                run.sessions.add(new FakeSession("dump-" + i));
+                run.dumpedAt.add((long) i);
+            }
+            return run;
+        }
+
+        @Test
+        void emptyReturnsNull() {
+            CoverageRun run = runWithDumps(0);
+            assertNull(run.resolveSession(null));
+            assertNull(run.resolveSession(1));
+        }
+
+        @Test
+        void nullSelectsLatest() {
+            CoverageRun run = runWithDumps(3);
+            ICoverageSession s = run.resolveSession(null);
+            assertNotNull(s);
+            assertEquals("dump-2", s.getDescription());
+        }
+
+        @Test
+        void oneIsFirst() {
+            CoverageRun run = runWithDumps(3);
+            ICoverageSession s = run.resolveSession(1);
+            assertEquals("dump-0", s.getDescription());
+        }
+
+        @Test
+        void exactNumberOfDumpsReturnsLast() {
+            CoverageRun run = runWithDumps(3);
+            ICoverageSession s = run.resolveSession(3);
+            assertEquals("dump-2", s.getDescription());
+        }
+
+        @Test
+        void outOfRangeReturnsNull() {
+            CoverageRun run = runWithDumps(2);
+            assertNull(run.resolveSession(0));
+            assertNull(run.resolveSession(3));
+            assertNull(run.resolveSession(-1));
+        }
+
+        @Test
+        void dumpCountMatchesSessionsSize() {
+            CoverageRun run = runWithDumps(5);
+            assertEquals(5, run.dumpCount());
+        }
+    }
+
+    /** Bare-bones {@link ICoverageSession} stub for resolve tests —
+     *  only {@code getDescription()} is queried. */
+    private static final class FakeSession
+            implements ICoverageSession {
+        private final String desc;
+
+        FakeSession(String desc) {
+            this.desc = desc;
+        }
+
+        @Override
+        public String getDescription() {
+            return desc;
+        }
+
+        @Override
+        public Set<org.eclipse.jdt.core.IPackageFragmentRoot>
+                getScope() {
+            return Set.of();
+        }
+
+        @Override
+        public org.eclipse.debug.core.ILaunchConfiguration
+                getLaunchConfiguration() {
+            return null;
+        }
+
+        @Override
+        public void accept(
+                org.jacoco.core.data.IExecutionDataVisitor execVisitor,
+                org.jacoco.core.data.ISessionInfoVisitor
+                        sessionInfoVisitor) {
+        }
+
+        @Override
+        public <T> T getAdapter(Class<T> adapter) {
+            return null;
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -1,0 +1,420 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.IExecutionDataSource;
+import org.eclipse.eclemma.core.ISessionImporter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.github.kaluchi.jdtbridge.ProjectScope;
+
+/**
+ * Tests for {@link CoverageSessionHandler}. Drives state through
+ * the real {@link CoverageTools#getSessionManager()} via
+ * {@link ISessionImporter}.
+ */
+public class CoverageSessionHandlerTest {
+
+    private CoverageAnalyzer analyzer;
+    private CoverageTracker tracker;
+    private CoverageSessionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        analyzer = new CoverageAnalyzer();
+        tracker = new CoverageTracker(analyzer);
+        tracker.start();
+        handler = new CoverageSessionHandler(tracker, analyzer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tracker.stop();
+        CoverageTools.getSessionManager().removeAllSessions();
+    }
+
+    @Nested
+    class HandleRuns {
+
+        @Test
+        void emptyTrackerReturnsEmptyArray() {
+            String json = handler.handleRuns(ProjectScope.ALL);
+            assertEquals("[]", json);
+        }
+
+        @Test
+        void importedSessionAppearsInRuns() {
+            String coverageId = importAndAwait("runs-test");
+            JsonArray arr = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray();
+            assertEquals(1, arr.size());
+            JsonObject entry = arr.get(0).getAsJsonObject();
+            assertEquals(coverageId,
+                    entry.get("coverageId").getAsString());
+            assertEquals("imported",
+                    entry.get("coverageSessionKind").getAsString());
+        }
+
+        @Test
+        void entryShapeHasAllRequiredFields() {
+            importAndAwait("shape-test");
+            JsonArray arr = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray();
+            JsonObject entry = arr.get(0).getAsJsonObject();
+            for (String required : new String[] {
+                    "coverageId", "coverageSessionKind",
+                    "configId", "configType", "configTypeId",
+                    "launchId", "description", "coverageScope",
+                    "dumpCount", "terminated", "dataReceived",
+                    "analysisLoading", "analysisReady",
+                    "launchTimestamp", "terminatedAt"
+            }) {
+                assertTrue(entry.has(required),
+                        "Missing required field '" + required
+                                + "': " + entry);
+            }
+        }
+
+        @Test
+        void importedRunHasNullConfigFields() {
+            importAndAwait("null-config-test");
+            JsonObject entry = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray().get(0).getAsJsonObject();
+            assertTrue(entry.get("configId").isJsonNull());
+            assertTrue(entry.get("configType").isJsonNull());
+            assertTrue(entry.get("configTypeId").isJsonNull());
+            assertTrue(entry.get("launchId").isJsonNull());
+            assertTrue(entry.get("launchTimestamp").isJsonNull());
+        }
+
+        @Test
+        void importedRunIsTerminated() {
+            importAndAwait("terminated-test");
+            JsonObject entry = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray().get(0).getAsJsonObject();
+            assertTrue(entry.get("terminated").getAsBoolean());
+            assertTrue(entry.get("dataReceived").getAsBoolean());
+            assertEquals(1, entry.get("dumpCount").getAsInt());
+        }
+
+        @Test
+        void scopeFilteringExcludesUnscopedImported() {
+            importAndAwait("scope-out");
+            // Imported with empty scope set — containsAnyOfRoots
+            // returns false for any non-null projects scope.
+            ProjectScope filtered = ProjectScope.of(
+                    Set.of("nonexistent-project-name"));
+            assertEquals("[]", handler.handleRuns(filtered));
+        }
+    }
+
+    @Nested
+    class HandleSession {
+
+        @Test
+        void missingIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(
+                    handler.handleSession(Map.of()));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleSession(
+                    Map.of("coverageId", "Bogus:9999")));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void importedSessionHasCountersAndInfos() {
+            String coverageId = importAndAwait("session-test");
+            JsonObject obj = parseObj(handler.handleSession(
+                    Map.of("coverageId", coverageId)));
+            assertNotNull(obj.get("counters"),
+                    "Missing counters field: " + obj);
+            JsonObject counters = obj.getAsJsonObject("counters");
+            for (String c : new String[] {
+                    "instruction", "branch", "line",
+                    "complexity", "method", "class"
+            }) {
+                assertTrue(counters.has(c),
+                        "Missing counter '" + c + "': " + counters);
+            }
+            assertTrue(obj.has("jacocoSessionInfos"));
+        }
+
+        @Test
+        void emptyExecDataYieldsZeroCounters() {
+            String coverageId = importAndAwait("zero-counters");
+            JsonObject obj = parseObj(handler.handleSession(
+                    Map.of("coverageId", coverageId)));
+            JsonObject instr = obj.getAsJsonObject("counters")
+                    .getAsJsonObject("instruction");
+            assertEquals(0, instr.get("coveredCount").getAsInt());
+            assertEquals(0, instr.get("missedCount").getAsInt());
+            assertEquals(0, instr.get("totalCount").getAsInt());
+        }
+
+        @Test
+        void zeroTotalsYieldNullRatios() {
+            String coverageId = importAndAwait("nan-ratios");
+            JsonObject instr = parseObj(handler.handleSession(
+                            Map.of("coverageId", coverageId)))
+                    .getAsJsonObject("counters")
+                    .getAsJsonObject("instruction");
+            // ICounter returns NaN for ratios when totalCount==0;
+            // bridge maps NaN → JSON null.
+            assertTrue(instr.get("coveredRatio").isJsonNull(),
+                    "coveredRatio should be null for empty: "
+                            + instr);
+            assertTrue(instr.get("missedRatio").isJsonNull());
+        }
+
+        @Test
+        void coverageStatusIsConstantName() {
+            String coverageId = importAndAwait("status-test");
+            String status = parseObj(handler.handleSession(
+                            Map.of("coverageId", coverageId)))
+                    .getAsJsonObject("counters")
+                    .getAsJsonObject("instruction")
+                    .get("coverageStatus").getAsString();
+            // Empty execution data → EMPTY status from JaCoCo.
+            assertEquals("EMPTY", status);
+        }
+    }
+
+    @Nested
+    class HandleActive {
+
+        @Test
+        void noActiveReturnsNull() {
+            CoverageTools.getSessionManager().removeAllSessions();
+            JsonObject obj = parseObj(handler.handleActive());
+            assertTrue(obj.get("activeCoverageId").isJsonNull());
+        }
+
+        @Test
+        void activeReturnsId() {
+            String coverageId = importAndAwait("active-test");
+            JsonObject obj = parseObj(handler.handleActive());
+            assertEquals(coverageId,
+                    obj.get("activeCoverageId").getAsString());
+        }
+    }
+
+    @Nested
+    class HandleActivate {
+
+        @Test
+        void missingBodyReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleActivate(null));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleActivate(
+                    "{\"coverageId\":\"Bogus:1\"}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void activatesAndReturnsPrevious() {
+            String firstId = importAndAwait("activate-1");
+            String secondId = importAndAwait("activate-2");
+            // After two imports, second one is active by default
+            // (importer activates new). Activate the first.
+            JsonObject obj = parseObj(handler.handleActivate(
+                    "{\"coverageId\":\"" + firstId + "\"}"));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertEquals(firstId,
+                    obj.get("activeCoverageId").getAsString());
+            assertEquals(secondId,
+                    obj.get("previousActiveCoverageId").getAsString());
+        }
+    }
+
+    @Nested
+    class HandleMerge {
+
+        @Test
+        void missingArrayReturnsTooFewInputs() {
+            JsonObject obj = parseObj(handler.handleMerge("{}"));
+            assertEquals("coverage-merge-too-few-inputs",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void singleInputReturnsTooFewInputs() {
+            String single = importAndAwait("merge-1");
+            JsonObject obj = parseObj(handler.handleMerge(
+                    "{\"coverageIds\":[\"" + single + "\"]}"));
+            assertEquals("coverage-merge-too-few-inputs",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownIdSurfacesContextMissing() {
+            String first = importAndAwait("merge-known");
+            JsonObject obj = parseObj(handler.handleMerge(
+                    "{\"coverageIds\":[\"" + first
+                            + "\",\"BogusUnknown:1\"]}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+            assertEquals("BogusUnknown:1",
+                    obj.getAsJsonObject("context")
+                            .get("missing").getAsString());
+        }
+
+        @Test
+        void twoImportedSessionsMergeSuccessfully() {
+            String a = importAndAwait("merge-a");
+            String b = importAndAwait("merge-b");
+            JsonObject obj = parseObj(handler.handleMerge(
+                    "{\"coverageIds\":[\"" + a + "\",\""
+                            + b + "\"],\"description\":\"combined\"}"));
+            assertTrue(obj.get("ok").getAsBoolean(),
+                    "Expected ok: " + obj);
+            String mergedId = obj.get("mergedCoverageId").getAsString();
+            assertNotNull(mergedId);
+            assertTrue(mergedId.startsWith("merged:"),
+                    "Expected merged: prefix: " + mergedId);
+            assertEquals(2, obj.getAsJsonArray(
+                    "consumedCoverageIds").size());
+        }
+
+        @Test
+        void mergedRunHasMergedKindAndConsumedIds() throws Exception {
+            String a = importAndAwait("kind-a");
+            String b = importAndAwait("kind-b");
+            String mergedId = parseObj(handler.handleMerge(
+                            "{\"coverageIds\":[\"" + a + "\",\""
+                                    + b + "\"]}"))
+                    .get("mergedCoverageId").getAsString();
+            CoverageRun run = tracker.byCoverageId(mergedId);
+            assertNotNull(run);
+            assertEquals(CoverageRun.Kind.MERGED, run.kind);
+            assertEquals(2, run.consumedCoverageIds.size());
+        }
+
+        @Test
+        void omittedDescriptionUsesEclipseDefault() {
+            String a = importAndAwait("desc-a");
+            String b = importAndAwait("desc-b");
+            String mergedId = parseObj(handler.handleMerge(
+                            "{\"coverageIds\":[\"" + a + "\",\""
+                                    + b + "\"]}"))
+                    .get("mergedCoverageId").getAsString();
+            CoverageRun run = tracker.byCoverageId(mergedId);
+            assertTrue(run.description.startsWith("Merged ("),
+                    "Expected Eclipse default template, got: "
+                            + run.description);
+        }
+    }
+
+    @Nested
+    class HandleRemove {
+
+        @Test
+        void emptyBodyWithNoActiveReturnsNoActiveError() {
+            CoverageTools.getSessionManager().removeAllSessions();
+            JsonObject obj = parseObj(handler.handleRemove("{}"));
+            assertEquals("coverage-no-active-session",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void emptyBodyRemovesActiveOnly() {
+            importAndAwait("remove-keep");
+            String activeId = importAndAwait("remove-active");
+            JsonObject obj = parseObj(handler.handleRemove("{}"));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertEquals(1, obj.getAsJsonArray(
+                    "removedCoverageIds").size());
+            assertEquals(activeId, obj.getAsJsonArray(
+                    "removedCoverageIds").get(0).getAsString());
+            // The other session survives.
+            assertEquals(1, tracker.snapshot().size());
+        }
+
+        @Test
+        void allTrueRemovesEverything() {
+            importAndAwait("all-1");
+            importAndAwait("all-2");
+            JsonObject obj = parseObj(handler.handleRemove(
+                    "{\"all\":true}"));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertEquals(2, obj.getAsJsonArray(
+                    "removedCoverageIds").size());
+            assertEquals(0, tracker.snapshot().size());
+        }
+
+        @Test
+        void allFalseDefaultsToActiveRemoval() {
+            importAndAwait("default-keep");
+            String activeId = importAndAwait("default-active");
+            JsonObject obj = parseObj(handler.handleRemove(
+                    "{\"all\":false}"));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertEquals(activeId, obj.getAsJsonArray(
+                    "removedCoverageIds").get(0).getAsString());
+        }
+    }
+
+    // -- helpers --
+
+    private static JsonObject parseObj(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    private String importAndAwait(String description) {
+        ISessionImporter importer = CoverageTools.getImporter();
+        importer.setDescription(description);
+        importer.setScope(Set.of());
+        importer.setExecutionDataSource(emptyDataSource());
+        importer.setCopy(false);
+        try {
+            importer.importSession(new NullProgressMonitor());
+            Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return tracker.snapshot().values().stream()
+                .filter(r -> description.equals(r.description))
+                .map(r -> r.coverageId)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static IExecutionDataSource emptyDataSource() {
+        return (execVisitor, sessionInfoVisitor) -> {
+            // Intentionally empty.
+        };
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -86,7 +86,7 @@ public class CoverageSessionHandlerTest {
                     "launchId", "description", "coverageScope",
                     "dumpCount", "terminated", "dataReceived",
                     "analysisLoading", "analysisReady",
-                    "launchTimestamp", "terminatedAt"
+                    "launchTimestamp", "terminatedAt", "active"
             }) {
                 assertTrue(entry.has(required),
                         "Missing required field '" + required
@@ -119,6 +119,39 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
+        void activeRunMarkedActiveTrue() {
+            String coverageId = importAndAwait("active-marker");
+            JsonArray arr = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray();
+            JsonObject entry = arr.get(0).getAsJsonObject();
+            assertTrue(entry.get("active").getAsBoolean(),
+                    "Imported session is auto-activated, runs"
+                            + " must mark it active=true");
+            assertEquals(coverageId,
+                    entry.get("coverageId").getAsString());
+        }
+
+        @Test
+        void inactiveRunsMarkedActiveFalse() {
+            importAndAwait("first");
+            String activeId = importAndAwait("second");
+            JsonArray arr = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray();
+            int activeCount = 0;
+            for (var el : arr) {
+                if (el.getAsJsonObject().get("active").getAsBoolean()) {
+                    activeCount++;
+                    assertEquals(activeId, el.getAsJsonObject()
+                            .get("coverageId").getAsString());
+                }
+            }
+            assertEquals(1, activeCount,
+                    "Exactly one run must be active at a time");
+        }
+
+        @Test
         void scopeFilteringExcludesUnscopedImported() {
             importAndAwait("scope-out");
             // Imported with empty scope set — containsAnyOfRoots
@@ -145,6 +178,15 @@ public class CoverageSessionHandlerTest {
             JsonObject obj = parseObj(handler.handleSession(
                     Map.of("coverageId", "Bogus:9999")));
             assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownDumpSuffixReturnsDumpNotFound() {
+            String coverageId = importAndAwait("dump-out-of-range");
+            JsonObject obj = parseObj(handler.handleSession(
+                    Map.of("coverageId", coverageId + ":99")));
+            assertEquals("coverage-dump-not-found",
                     obj.get("error").getAsString());
         }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -338,6 +338,87 @@ public class CoverageSessionHandlerTest {
     }
 
     @Nested
+    class ParseDumpIndex {
+
+        @Test
+        void nullReturnsNull() {
+            assertNull(CoverageSessionHandler.parseDumpIndex(null));
+        }
+
+        @Test
+        void noColonReturnsNull() {
+            assertNull(CoverageSessionHandler.parseDumpIndex("MyTest"));
+        }
+
+        @Test
+        void singleColonNotADumpIndex() {
+            // "MyTest:1700000000000" — bare configId:timestamp,
+            // no dump suffix.
+            assertNull(CoverageSessionHandler.parseDumpIndex(
+                    "MyTest:1700000000000"));
+        }
+
+        @Test
+        void doubleColonReturnsDumpIndex() {
+            assertEquals(2,
+                    (int) CoverageSessionHandler.parseDumpIndex(
+                            "MyTest:1700000000000:2"));
+        }
+
+        @Test
+        void importedHasNoDumpIndex() {
+            assertNull(CoverageSessionHandler.parseDumpIndex(
+                    "imported:1700000000000"));
+        }
+
+        @Test
+        void mergedHasNoDumpIndex() {
+            assertNull(CoverageSessionHandler.parseDumpIndex(
+                    "merged:1700000000000"));
+        }
+
+        @Test
+        void collisionSuffixIsNotDumpIndex() {
+            // "merged:1700000000000#2" — # in suffix, not digits.
+            assertNull(CoverageSessionHandler.parseDumpIndex(
+                    "merged:1700000000000#2"));
+        }
+
+        @Test
+        void colonInConfigIdWithTimestampDoesNotOverflow() {
+            // Regression — fix for PR review: configIds with ':'
+            // produce three-or-more colon ids; the trailing
+            // 13-digit timestamp overflows Integer.parseInt and
+            // used to throw NumberFormatException. Now must
+            // return null gracefully.
+            Integer result = CoverageSessionHandler.parseDumpIndex(
+                    "Foo:Bar:1700000000000");
+            assertNull(result, "13-digit timestamp must NOT be"
+                    + " interpreted as a dump index: got "
+                    + result);
+        }
+
+        @Test
+        void colonInConfigIdWithRealDumpIndexResolves() {
+            // "Foo:Bar:1700000000000:3" — three-colon id with a
+            // small int tail. The current heuristic (last colon
+            // tail must be parseable) treats the last segment as
+            // the dump index. This is best-effort given the
+            // ambiguity introduced by ':' in configIds; documented.
+            assertEquals(3,
+                    (int) CoverageSessionHandler.parseDumpIndex(
+                            "Foo:Bar:1700000000000:3"));
+        }
+
+        @Test
+        void zeroIsNotAValidDumpIndex() {
+            // Dump indices are 1-based.
+            assertNull(CoverageSessionHandler.parseDumpIndex(
+                    "MyTest:1700000000000:0"));
+        }
+    }
+
+    @Nested
     class HandleRemove {
 
         @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
@@ -1,6 +1,7 @@
 package io.github.kaluchi.jdtbridge.coverage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -154,6 +155,31 @@ public class CoverageTrackerTest {
             String coverageId = importAndAwait(description);
             CoverageRun run = tracker.byCoverageId(coverageId);
             assertEquals(description, run.description);
+        }
+    }
+
+    @Nested
+    class ActivationFlagReset {
+
+        @Test
+        void switchingActiveSessionClearsPreviousAnalysisFlags() {
+            String firstId = importAndAwait("first");
+            CoverageRun first = tracker.byCoverageId(firstId);
+            // Pretend EclEmma had finished analysis on first.
+            first.analysisLoading = false;
+            first.analysisReady = true;
+
+            String secondId = importAndAwait("second");
+            // Importing a second session activates it; the
+            // first is no longer the analysis target.
+
+            CoverageRun firstAgain = tracker.byCoverageId(firstId);
+            assertNotNull(firstAgain);
+            assertFalse(firstAgain.analysisReady,
+                    "Previous active run must have analysisReady"
+                            + " cleared when another session"
+                            + " becomes active");
+            assertFalse(firstAgain.analysisLoading);
         }
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
@@ -1,0 +1,235 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.IExecutionDataSource;
+import org.eclipse.eclemma.core.ISessionImporter;
+import org.eclipse.eclemma.core.ISessionManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CoverageTracker}. Lifecycle / resolution paths
+ * exercise pure tracker state; the deferred-classification path is
+ * driven through the real EclEmma {@link ISessionManager} via
+ * {@link CoverageTools#getImporter()}.
+ */
+public class CoverageTrackerTest {
+
+    private CoverageTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new CoverageTracker();
+        tracker.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        tracker.stop();
+        // Clear any sessions this test added so subsequent tests
+        // start from a clean SessionManager.
+        ISessionManager sm = CoverageTools.getSessionManager();
+        sm.removeAllSessions();
+    }
+
+    @Nested
+    class Lifecycle {
+
+        @Test
+        void startIsIdempotent() {
+            tracker.start();
+            tracker.start();
+            // No assertion beyond "did not throw" — duplicate
+            // start should be a no-op.
+        }
+
+        @Test
+        void stopThenStartReregisters() {
+            tracker.stop();
+            tracker.start();
+            // Listener registration must succeed — verify by
+            // firing an import and seeing the run appear.
+            String coverageId = importAndAwait("alpha");
+            assertNotNull(tracker.byCoverageId(coverageId));
+        }
+
+        @Test
+        void snapshotIsImmutable() {
+            var snapshot = tracker.snapshot();
+            org.junit.jupiter.api.Assertions.assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> snapshot.put("X", null));
+        }
+    }
+
+    @Nested
+    class Resolution {
+
+        @Test
+        void byCoverageIdNullReturnsNull() {
+            assertNull(tracker.byCoverageId(null));
+        }
+
+        @Test
+        void byCoverageIdUnknownReturnsNull() {
+            assertNull(tracker.byCoverageId("Bogus:9999"));
+        }
+
+        @Test
+        void byCoverageIdResolvesAfterImport() {
+            String coverageId = importAndAwait("resolution-test");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertNotNull(run);
+            assertEquals(coverageId, run.coverageId);
+        }
+
+        @Test
+        void byCoverageIdStripsDumpSuffix() {
+            String coverageId = importAndAwait("suffix-test");
+            // Imported runs only have one session, so :1 suffix
+            // resolves to the same run.
+            CoverageRun viaSuffix = tracker.byCoverageId(
+                    coverageId + ":1");
+            CoverageRun viaPlain = tracker.byCoverageId(coverageId);
+            assertNotNull(viaSuffix);
+            assertSame(viaPlain, viaSuffix);
+        }
+    }
+
+    @Nested
+    class ImportClassification {
+
+        @Test
+        void importedSessionGetsImportedKind() {
+            String coverageId = importAndAwait("imp-kind");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(CoverageRun.Kind.IMPORTED, run.kind);
+        }
+
+        @Test
+        void importedCoverageIdHasImportedPrefix() {
+            String coverageId = importAndAwait("imp-prefix");
+            assertTrue(coverageId.startsWith("imported:"),
+                    "Expected imported: prefix, got: " + coverageId);
+        }
+
+        @Test
+        void importedRunIsTerminated() {
+            String coverageId = importAndAwait("imp-term");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertTrue(run.terminated);
+            assertTrue(run.dataReceived);
+        }
+
+        @Test
+        void importedRunHasOneSession() {
+            String coverageId = importAndAwait("imp-one");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(1, run.dumpCount());
+        }
+
+        @Test
+        void importedRunHasNoConsumedIds() {
+            String coverageId = importAndAwait("imp-none");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertTrue(run.consumedCoverageIds.isEmpty());
+        }
+
+        @Test
+        void descriptionMirroredFromSession() {
+            String description = "imp-desc-" + System.nanoTime();
+            String coverageId = importAndAwait(description);
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(description, run.description);
+        }
+    }
+
+    @Nested
+    class Activation {
+
+        @Test
+        void importedSessionBecomesActive() {
+            String coverageId = importAndAwait("active-test");
+            // Importer activates by default — see
+            // SessionImporter.importSession.
+            assertEquals(coverageId, tracker.activeCoverageId());
+        }
+
+        @Test
+        void removeAllClearsActive() {
+            importAndAwait("clear-test");
+            CoverageTools.getSessionManager().removeAllSessions();
+            assertNull(tracker.activeCoverageId());
+        }
+    }
+
+    @Nested
+    class CollisionSuffix {
+
+        @Test
+        void twoImportsInSameMillisecondGetUniqueIds()
+                throws Exception {
+            // Force the issue by reusing the same start time —
+            // we can't fully control Java's clock granularity, but
+            // calling import twice back-to-back routinely lands
+            // both events in the same millisecond on modern CPUs.
+            String firstId = importAndAwait("collide-1");
+            String secondId = importAndAwait("collide-2");
+            assertNotNull(firstId);
+            assertNotNull(secondId);
+            // The two coverage IDs must differ regardless of
+            // millisecond clock alignment.
+            org.junit.jupiter.api.Assertions.assertNotEquals(
+                    firstId, secondId);
+        }
+    }
+
+    /** Trigger {@code SessionImporter.importSession} with a no-op
+     *  execution-data source, then block until the deferred
+     *  classification job has run. Returns the assigned
+     *  {@code coverageId}. */
+    private String importAndAwait(String description) {
+        ISessionImporter importer = CoverageTools.getImporter();
+        importer.setDescription(description);
+        importer.setScope(Set.of());
+        importer.setExecutionDataSource(emptyDataSource());
+        importer.setCopy(false);
+        try {
+            importer.importSession(new NullProgressMonitor());
+            Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        // Find the run whose latest dump's description matches —
+        // gives us the coverageId without depending on the
+        // System.currentTimeMillis() value the tracker assigned.
+        return tracker.snapshot().values().stream()
+                .filter(r -> description.equals(r.description))
+                .map(r -> r.coverageId)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No run with description " + description));
+    }
+
+    /** Empty {@link IExecutionDataSource} — emits no data and no
+     *  session info. SessionImporter accepts it without error. */
+    private static IExecutionDataSource emptyDataSource() {
+        return (execVisitor, sessionInfoVisitor) -> {
+            // Intentionally empty — no exec data, no session info.
+        };
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTypesTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTypesTest.java
@@ -1,0 +1,144 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CoverageTypes}. The 9 candidate IDs are static
+ * (mirrored from EclEmma's {@code plugin.xml}); the runtime-resolved
+ * subset depends on which optional host bundles (PDE, TestNG, RAP,
+ * SWTBot, Scala) are installed alongside EclEmma.
+ */
+public class CoverageTypesTest {
+
+    @Nested
+    class Candidates {
+
+        @Test
+        void sizeIsNine() {
+            assertEquals(9,
+                    CoverageTypes.CANDIDATE_TYPE_IDS.size());
+        }
+
+        @Test
+        void includesJavaApplication() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.jdt.launching.localJavaApplication"));
+        }
+
+        @Test
+        void includesPlainJUnit() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.jdt.junit.launchconfig"));
+        }
+
+        @Test
+        void includesPdeJUnit() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.pde.ui.JunitLaunchConfig"));
+        }
+
+        @Test
+        void includesEclipseApplication() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.pde.ui.RuntimeWorkbench"));
+        }
+
+        @Test
+        void includesEquinox() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.pde.ui.EquinoxLauncher"));
+        }
+
+        @Test
+        void includesTestNg() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.testng.eclipse.launchconfig"));
+        }
+
+        @Test
+        void includesRap() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.rap.ui.launch.RAPJUnitTestLauncher"));
+        }
+
+        @Test
+        void includesSwtBot() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "org.eclipse.swtbot.eclipse.ui.launcher"
+                            + ".JunitLaunchConfig"));
+        }
+
+        @Test
+        void includesScala() {
+            assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS.contains(
+                    "scala.application"));
+        }
+    }
+
+    @Nested
+    class Resolution {
+
+        @Test
+        void supportedIsSubsetOfCandidates() {
+            Set<String> supported = CoverageTypes.supported();
+            assertNotNull(supported);
+            for (String typeId : supported) {
+                assertTrue(CoverageTypes.CANDIDATE_TYPE_IDS
+                        .contains(typeId),
+                        "Resolved type ID not in candidate list: "
+                                + typeId);
+            }
+        }
+
+        @Test
+        void supportedIsCachedAcrossCalls() {
+            Set<String> first = CoverageTypes.supported();
+            Set<String> second = CoverageTypes.supported();
+            // Cached set should be the same reference (or at least
+            // equal contents — we accept equals here).
+            assertEquals(first, second);
+        }
+
+        @Test
+        void refreshRecomputes() {
+            Set<String> first = CoverageTypes.supported();
+            CoverageTypes.refresh();
+            Set<String> after = CoverageTypes.supported();
+            // Workspace state stable inside one test, so contents
+            // must match — but the refresh path executed at least.
+            assertEquals(first, after);
+        }
+
+        @Test
+        void unknownTypeIdNotSupported() {
+            assertFalse(CoverageTypes.isSupported(
+                    "io.example.bogus.never-registered.type"));
+        }
+
+        @Test
+        void launchModeConstant() {
+            assertEquals("coverage", CoverageTypes.LAUNCH_MODE);
+        }
+
+        @Test
+        void whenEclEmmaPresentJavaApplicationIsSupported() {
+            // This assertion is conditional on the EclEmma bundle
+            // being present in the test runtime — true under the
+            // local Eclipse target (which has EclEmma installed)
+            // and the CI target (which pulls EclEmma from p2).
+            if (!CoverageBridge.isAvailable()) return;
+            assertTrue(CoverageTypes.isSupported(
+                    "org.eclipse.jdt.launching.localJavaApplication"),
+                    "Java App should have a coverage delegate when"
+                            + " EclEmma is installed");
+        }
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
@@ -76,6 +76,46 @@ public class TestRunCoverageFlagTest {
             assertFalse(json.contains("\"coverageId\""),
                     "coverage=false → no coverageId: " + json);
         }
+
+        @Test
+        void coverageEmptyDoesNotEnableCoverage() throws Exception {
+            // Empty value (?coverage=) deliberately does NOT
+            // enable coverage — fix for the empty-string surprise
+            // flagged in PR review.
+            Map<String, String> params = new HashMap<>();
+            params.put("class", "no.such.TestClass");
+            params.put("no-refresh", "");
+            params.put("coverage", "");
+            String json = handler.handleTestRun(params);
+            assertFalse(json.contains("\"coverageId\""),
+                    "coverage='' → no coverageId: " + json);
+            assertFalse(json.contains("\"launchMode\""),
+                    "coverage='' → no launchMode: " + json);
+        }
+
+        @Test
+        void coverageOneEnablesCoverage() throws Exception {
+            // Spec accepts "true" or "1".
+            if (!CoverageTypes.isSupported(
+                    "org.eclipse.jdt.junit.launchconfig")) {
+                return;
+            }
+            org.osgi.framework.Bundle eclemmaUi =
+                    org.eclipse.core.runtime.Platform.getBundle(
+                            "org.eclipse.eclemma.ui");
+            if (eclemmaUi == null
+                    || eclemmaUi.getState()
+                            < org.osgi.framework.Bundle.ACTIVE) {
+                return;
+            }
+            Map<String, String> params = new HashMap<>();
+            params.put("class", "test.edge.SimpleTest");
+            params.put("no-refresh", "");
+            params.put("coverage", "1");
+            String json = handler.handleTestRun(params);
+            assertTrue(json.contains("\"launchMode\":\"coverage\""),
+                    "coverage=1 must enable coverage mode: " + json);
+        }
     }
 
     @Nested

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
@@ -1,0 +1,149 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.eclemma.core.CoverageTools;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.github.kaluchi.jdtbridge.TestFixture;
+import io.github.kaluchi.jdtbridge.TestHandler;
+
+/**
+ * Tests for the {@code coverage=true} flag on {@code /test/run}
+ * (handled in {@link TestHandler#handleTestRun}). Validation paths
+ * are exercised against the {@link TestFixture} workspace project;
+ * happy-path tests skip unless the local Eclipse runtime has a
+ * coverage delegate registered for the JUnit launch type (which it
+ * does whenever EclEmma is installed).
+ */
+public class TestRunCoverageFlagTest {
+
+    private static final TestHandler handler = new TestHandler();
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        TestFixture.create();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        TestFixture.destroy();
+    }
+
+    @AfterEach
+    void cleanupCoverageSessions() {
+        // Active coverage launches and their sessions accumulate
+        // across tests in the same Eclipse runtime — drop them.
+        CoverageTools.getSessionManager().removeAllSessions();
+    }
+
+    @Nested
+    class FlagParsing {
+
+        @Test
+        void coverageAbsentDoesNotEnableCoverage() throws Exception {
+            // No coverage param → response must not carry the
+            // coverage fields, regardless of the prepare result.
+            Map<String, String> params = new HashMap<>();
+            params.put("class", "no.such.TestClass");
+            params.put("no-refresh", "");
+            String json = handler.handleTestRun(params);
+            assertFalse(json.contains("\"coverageId\""),
+                    "No coverage param → no coverageId: " + json);
+            assertFalse(json.contains("\"launchMode\""),
+                    "No coverage param → no launchMode: " + json);
+        }
+
+        @Test
+        void coverageFalseDoesNotEnableCoverage() throws Exception {
+            Map<String, String> params = new HashMap<>();
+            params.put("class", "no.such.TestClass");
+            params.put("no-refresh", "");
+            params.put("coverage", "false");
+            String json = handler.handleTestRun(params);
+            assertFalse(json.contains("\"coverageId\""),
+                    "coverage=false → no coverageId: " + json);
+        }
+    }
+
+    @Nested
+    class ErrorPaths {
+
+        @Test
+        void unknownClassReturnsTypeNotFound() throws Exception {
+            Map<String, String> params = new HashMap<>();
+            params.put("class", "no.such.TestClass");
+            params.put("no-refresh", "");
+            params.put("coverage", "true");
+            String json = handler.handleTestRun(params);
+            // prepareLaunch fails first → "Type not found" surfaces
+            // before coverage-mode-not-supported has a chance.
+            assertTrue(json.contains("not found"),
+                    "Should report type not found: " + json);
+        }
+
+        @Test
+        void unknownProjectReturnsProjectNotFound() throws Exception {
+            Map<String, String> params = new HashMap<>();
+            params.put("project", "nonexistent-project-xyz");
+            params.put("no-refresh", "");
+            params.put("coverage", "true");
+            String json = handler.handleTestRun(params);
+            assertTrue(json.contains("error"),
+                    "Should error: " + json);
+        }
+    }
+
+    @Nested
+    class HappyPath {
+
+        @Test
+        void coverageTrueLaunchesInCoverageMode() throws Exception {
+            // Skip when the headless runtime can't actually drive
+            // a coverage launch end-to-end. Two preconditions:
+            // (a) JUnit type has a coverage delegate registered;
+            // (b) EclEmma UI bundle is activated (the launch path
+            //     goes through UIPreferences for default scope).
+            if (!CoverageTypes.isSupported(
+                    "org.eclipse.jdt.junit.launchconfig")) {
+                return;
+            }
+            org.osgi.framework.Bundle eclemmaUi =
+                    org.eclipse.core.runtime.Platform.getBundle(
+                            "org.eclipse.eclemma.ui");
+            if (eclemmaUi == null
+                    || eclemmaUi.getState()
+                            < org.osgi.framework.Bundle.ACTIVE) {
+                return;
+            }
+            Map<String, String> params = new HashMap<>();
+            params.put("class", "test.edge.SimpleTest");
+            params.put("no-refresh", "");
+            params.put("coverage", "true");
+            String json = handler.handleTestRun(params);
+            JsonObject obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            assertTrue(obj.get("ok").getAsBoolean(),
+                    "Expected ok: " + json);
+            assertEquals("coverage",
+                    obj.get("launchMode").getAsString());
+            assertTrue(obj.has("coverageId"),
+                    "Expected coverageId: " + json);
+            assertEquals(obj.get("testRunId").getAsString(),
+                    obj.get("coverageId").getAsString(),
+                    "coverageId must equal testRunId byte-for-byte");
+        }
+    }
+}

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -25,7 +25,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.core,
  org.eclipse.egit.core,
  org.eclipse.jgit,
- org.eclipse.core.variables
+ org.eclipse.core.variables,
+ org.eclipse.eclemma.core;resolution:=optional,
+ org.eclipse.eclemma.ui;resolution:=optional,
+ org.jacoco.core;resolution:=optional,
+ org.jacoco.report;resolution:=optional
 Import-Package: com.google.gson,
  org.osgi.framework;version="1.3.0"
 Export-Package: io.github.kaluchi.jdtbridge

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -280,6 +280,10 @@ public class HttpServer {
                 handleTestStatusStream(socket, params);
                 return;
             }
+            if ("/coverage/session/stream".equals(path)) {
+                handleCoverageSessionStream(socket, params);
+                return;
+            }
 
             // Telemetry — POST enqueues, GET drains
             if ("/telemetry".equals(path)) {
@@ -480,6 +484,35 @@ public class HttpServer {
         } catch (IOException
                 | TestProgressStreamer.StreamClosedException e) {
             // Client disconnected — normal for Ctrl+C
+        }
+    }
+
+    /** Streaming /coverage/session/stream — bypasses dispatch,
+     *  delegates to CoverageBridge through the same guard pattern
+     *  as other /coverage/* routes. */
+    private void handleCoverageSessionStream(Socket socket,
+            Map<String, String> params) {
+        String coverageId = params.get("coverageId");
+        if (coverageId == null || coverageId.isBlank()) {
+            try { sendError(socket, 400, "Missing coverageId"); }
+            catch (IOException e) { /* ignore */ }
+            return;
+        }
+        try {
+            socket.setSoTimeout(0);
+            OutputStream out = socket.getOutputStream();
+            out.write(("HTTP/1.1 200 OK\r\n"
+                    + "Content-Type: application/x-ndjson;"
+                    + " charset=utf-8\r\n"
+                    + "Connection: close\r\n"
+                    + "Cache-Control: no-cache\r\n\r\n")
+                    .getBytes(StandardCharsets.UTF_8));
+            coverageBridge.streamSession(out, coverageId);
+        } catch (IOException
+                | io.github.kaluchi.jdtbridge.coverage
+                        .CoverageProgressStreamer
+                        .StreamClosedException e) {
+            // Client disconnected — normal.
         }
     }
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -104,6 +104,7 @@ public class HttpServer {
     public void start(InetAddress bindAddress, int port)
             throws IOException {
         launchTracker.start();
+        coverageBridge.start();
         serverSocket = bindWithFallback(bindAddress, port);
         running = true;
         startAcceptLoop(serverSocket);
@@ -161,6 +162,7 @@ public class HttpServer {
 
 
     public void stop() {
+        coverageBridge.stop();
         launchTracker.stop();
         running = false;
         try {

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -39,6 +39,10 @@ public class HttpServer {
             new TestSessionHandler();
     private final TestHandler testHandler =
             new TestHandler();
+    private final io.github.kaluchi.jdtbridge.coverage
+            .CoverageBridge coverageBridge =
+            new io.github.kaluchi.jdtbridge.coverage
+                    .CoverageBridge();
     private final LogHandler logHandler = new LogHandler();
     private final SessionScope sessionScope = new SessionScope();
     private final RequestTracker requestTracker = new RequestTracker();
@@ -637,6 +641,13 @@ public class HttpServer {
                         launch.handleRun(params));
                 case "/launch/stop" -> Response.json(
                         launch.handleStop(params));
+                case "/coverage/run", "/coverage/dump",
+                        "/coverage/refresh", "/coverage/relaunch",
+                        "/coverage/runs", "/coverage/session",
+                        "/coverage/active", "/coverage/activate",
+                        "/coverage/merge", "/coverage/remove" ->
+                        Response.json(coverageBridge.dispatch(
+                                path, params, requestBody, scope));
                 default -> Response.json(jsonError(
                         "Unknown path: " + path));
             };

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchAttrs.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchAttrs.java
@@ -1,0 +1,59 @@
+package io.github.kaluchi.jdtbridge;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.IProcess;
+
+/**
+ * Shared accessors for {@link ILaunch} attributes used across
+ * the bridge plugin. Centralizes the bits of debug-core access
+ * that were copy-pasted in launch / test / coverage handlers.
+ */
+public final class LaunchAttrs {
+
+    private LaunchAttrs() {
+    }
+
+    public static ILaunchManager launchManager() {
+        DebugPlugin debug = DebugPlugin.getDefault();
+        return debug != null ? debug.getLaunchManager() : null;
+    }
+
+    /** First process PID under the launch, or {@code null} when no
+     *  process is registered yet (race window between
+     *  {@code launch()} and {@code DebugEvent.CREATE}). */
+    public static String firstPid(ILaunch launch) {
+        IProcess[] procs = launch.getProcesses();
+        if (procs.length == 0) {
+            return null;
+        }
+        return procs[0].getAttribute(IProcess.ATTR_PROCESS_ID);
+    }
+
+    /** {@code DebugPlugin.ATTR_LAUNCH_TIMESTAMP} parsed as
+     *  {@link Long}. Eclipse stores it as
+     *  {@code Long.toString(System.currentTimeMillis())}. Returns
+     *  {@code null} on missing or malformed value. */
+    public static Long launchTimestamp(ILaunch launch) {
+        return parseTimestamp(launch.getAttribute(
+                DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
+    }
+
+    public static Long parseTimestamp(String raw) {
+        if (raw == null) return null;
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** Launch identifier as used across the bridge wire format —
+     *  {@code configId:pid} when the process exists,
+     *  {@code configId} otherwise. */
+    public static String launchIdOf(String configId, ILaunch launch) {
+        String pid = firstPid(launch);
+        return pid != null ? configId + ":" + pid : configId;
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -109,7 +109,7 @@ class LaunchHandler {
     }
 
     private ILaunchManager launchManager() {
-        return DebugPlugin.getDefault().getLaunchManager();
+        return LaunchAttrs.launchManager();
     }
 
     String handleList(Map<String, String> params,
@@ -135,30 +135,20 @@ class LaunchHandler {
         String mode = launch.getLaunchMode();
         boolean terminated = launch.isTerminated();
 
-        String pid = null;
+        String pid = LaunchAttrs.firstPid(launch);
         IProcess[] processes = launch.getProcesses();
-        if (processes.length > 0) {
-            IProcess proc = processes[0];
-            pid = proc.getAttribute(
-                    IProcess.ATTR_PROCESS_ID);
-        }
 
         var entry = new JsonObject();
-        String launchId = pid != null
-                ? name + ":" + pid : name;
-        entry.addProperty("launchId", launchId);
+        entry.addProperty("launchId",
+                LaunchAttrs.launchIdOf(name, launch));
         entry.addProperty("configId", name);
         entry.addProperty("configType", type);
         entry.addProperty("mode", mode);
         entry.addProperty("terminated", terminated);
 
-        String startedAt = launch.getAttribute(
-                DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
+        Long startedAt = LaunchAttrs.launchTimestamp(launch);
         if (startedAt != null) {
-            try {
-                entry.addProperty("started",
-                        Long.parseLong(startedAt));
-            } catch (NumberFormatException e) { /* skip */ }
+            entry.addProperty("started", startedAt);
         }
 
         if (processes.length > 0) {
@@ -666,12 +656,8 @@ class LaunchHandler {
             response.addProperty("configType",
                     launchType(launch));
             addProcessMetadata(launch, response);
-            // Add launchId after process metadata (has pid)
-            String pid = response.has("pid")
-                    ? response.get("pid").getAsString() : null;
             response.addProperty("launchId",
-                    pid != null ? configId + ":" + pid
-                            : configId);
+                    LaunchAttrs.launchIdOf(configId, launch));
             return response.toString();
         } catch (Exception e) {
             return HttpServer.jsonError(e.getMessage());
@@ -766,10 +752,8 @@ class LaunchHandler {
         var obj = new JsonObject();
         obj.addProperty("configId", cId);
         addProcessMetadata(tl.launch, obj);
-        // Compose launchId from configId + first PID
-        if (obj.has("pid"))
-            obj.addProperty("launchId",
-                    cId + ":" + obj.get("pid").getAsString());
+        obj.addProperty("launchId",
+                LaunchAttrs.launchIdOf(cId, tl.launch));
         obj.addProperty("terminated", tl.terminated);
         obj.addProperty("output", result);
         return obj.toString();

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchTracker.java
@@ -162,17 +162,10 @@ class LaunchTracker implements ILaunchesListener2 {
             return new TrackedLaunch(launch);
         });
 
-        // Register under launchId (configId:pid) when PID available
-        IProcess[] procs = launch.getProcesses();
-        if (procs.length > 0) {
-            String pid = procs[0].getAttribute(
-                    IProcess.ATTR_PROCESS_ID);
-            if (pid != null) {
-                tracked.putIfAbsent(configId + ":" + pid, tl);
-            }
+        String pid = LaunchAttrs.firstPid(launch);
+        if (pid != null) {
+            tracked.putIfAbsent(configId + ":" + pid, tl);
         }
-
-        // Register under testRunId (configId:timestamp) if available
         String ts = launch.getAttribute(
                 DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
         if (ts != null) {
@@ -214,7 +207,6 @@ class LaunchTracker implements ILaunchesListener2 {
     }
 
     private static ILaunchManager launchManager() {
-        var debug = DebugPlugin.getDefault();
-        return debug != null ? debug.getLaunchManager() : null;
+        return LaunchAttrs.launchManager();
     }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/Log.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/Log.java
@@ -10,7 +10,7 @@ import org.eclipse.core.runtime.Status;
  * Messages appear in Error Log view and {@code <workspace>/.metadata/.log}.
  * Falls back to stderr when running outside OSGi (e.g. plain JUnit).
  */
-class Log {
+public class Log {
 
     private static final String BUNDLE_ID =
             "io.github.kaluchi.jdtbridge";
@@ -24,23 +24,23 @@ class Log {
         }
     }
 
-    static void info(String msg) {
+    public static void info(String msg) {
         log(IStatus.INFO, msg, null);
     }
 
-    static void warn(String msg) {
+    public static void warn(String msg) {
         log(IStatus.WARNING, msg, null);
     }
 
-    static void warn(String msg, Throwable t) {
+    public static void warn(String msg, Throwable t) {
         log(IStatus.WARNING, msg, t);
     }
 
-    static void error(String msg) {
+    public static void error(String msg) {
         log(IStatus.ERROR, msg, null);
     }
 
-    static void error(String msg, Throwable t) {
+    public static void error(String msg, Throwable t) {
         log(IStatus.ERROR, msg, t);
     }
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/ProjectScope.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/ProjectScope.java
@@ -45,7 +45,7 @@ public class ProjectScope {
     }
 
     /** Create a filtered scope for the given project names. */
-    static ProjectScope of(Set<String> projectNames) {
+    public static ProjectScope of(Set<String> projectNames) {
         if (projectNames == null || projectNames.isEmpty()) {
             return ALL;
         }
@@ -173,8 +173,31 @@ public class ProjectScope {
         }
     }
 
+    /** Check if any of the given JDT package-fragment roots
+     *  belongs to a project in this scope. Used by the coverage
+     *  bridge to filter merged / imported sessions whose only
+     *  project link is the scope set (no {@code ILaunch}, no
+     *  {@code ILaunchConfiguration}). */
+    public boolean containsAnyOfRoots(
+            java.util.Set<org.eclipse.jdt.core.IPackageFragmentRoot> roots) {
+        if (projects == null) {
+            return true;
+        }
+        if (roots == null || roots.isEmpty()) {
+            return false;
+        }
+        for (org.eclipse.jdt.core.IPackageFragmentRoot root : roots) {
+            org.eclipse.jdt.core.IJavaProject jp = root.getJavaProject();
+            if (jp != null
+                    && projects.contains(jp.getElementName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /** Check if a launch's configuration project is in scope. */
-    boolean containsLaunch(ILaunch launch) {
+    public boolean containsLaunch(ILaunch launch) {
         if (projects == null) return true;
         var config = launch.getLaunchConfiguration();
         return config == null || containsConfig(config);

--- a/plugin/src/io/github/kaluchi/jdtbridge/ProjectScope.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/ProjectScope.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
  * {@link #containsProject(String)}, {@link #containsConfig(ILaunchConfiguration)},
  * {@link #containsLaunch(ILaunch)}.
  */
-class ProjectScope {
+public class ProjectScope {
 
     private static final String ATTR_PROJECT_NAME =
             "org.eclipse.jdt.launching.PROJECT_ATTR";
@@ -36,7 +36,7 @@ class ProjectScope {
             "org.eclipse.jdt.launching.WORKING_DIRECTORY";
 
     /** Default scope — all projects visible, no filtering. */
-    static final ProjectScope ALL = new ProjectScope(null);
+    public static final ProjectScope ALL = new ProjectScope(null);
 
     private final Set<String> projects;
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -30,9 +30,9 @@ import java.util.jar.Manifest;
  * Handler for /test endpoint: run JUnit tests via Eclipse's
  * built-in runner.
  */
-class TestHandler {
+public class TestHandler {
 
-    TestHandler() {
+    public TestHandler() {
     }
 
     private static final String JUNIT_LAUNCH_TYPE =
@@ -211,15 +211,36 @@ class TestHandler {
     /**
      * Non-blocking test launch. Returns immediately with session
      * info. Progress tracked by {@link TestSessionTracker}.
+     * <p>
+     * When {@code coverage=true} is present in {@code params},
+     * the launch is started in EclEmma's coverage mode instead of
+     * run mode. The response then carries the additional
+     * {@code coverageId} and {@code launchMode: "coverage"}
+     * fields. {@code coverageId} and {@code testRunId} are
+     * byte-identical strings — they identify the same
+     * {@link ILaunch} from coverage and test perspectives.
      */
-    String handleTestRun(Map<String, String> params)
+    public String handleTestRun(Map<String, String> params)
             throws Exception {
+        boolean coverage = parseBool(params.get("coverage"));
+
         String[] errorOut = { null };
         PreparedLaunch pl = prepareLaunch(params, errorOut);
         if (pl == null) return errorOut[0];
 
-        ILaunch launch = pl.config().launch(
-                ILaunchManager.RUN_MODE,
+        if (coverage) {
+            String typeId = pl.config().getType().getIdentifier();
+            if (!io.github.kaluchi.jdtbridge.coverage
+                    .CoverageTypes.isSupported(typeId)) {
+                return coverageModeNotSupported(typeId);
+            }
+        }
+
+        String launchMode = coverage
+                ? io.github.kaluchi.jdtbridge.coverage
+                        .CoverageTypes.LAUNCH_MODE
+                : ILaunchManager.RUN_MODE;
+        ILaunch launch = pl.config().launch(launchMode,
                 new NullProgressMonitor(), true);
 
         String configId = pl.configName();
@@ -249,8 +270,36 @@ class TestHandler {
         response.addProperty("runner", pl.runner());
         if (pid != null)
             response.addProperty("pid", pid);
+        if (coverage) {
+            response.addProperty("coverageId", testRunId);
+            response.addProperty("launchMode",
+                    io.github.kaluchi.jdtbridge.coverage
+                            .CoverageTypes.LAUNCH_MODE);
+        }
 
         return response.toString();
+    }
+
+    private static boolean parseBool(String raw) {
+        return "true".equalsIgnoreCase(raw)
+                || "1".equals(raw)
+                || (raw != null && raw.isEmpty());
+    }
+
+    private static String coverageModeNotSupported(String typeId) {
+        var obj = new JsonObject();
+        obj.addProperty("error", "coverage-mode-not-supported");
+        obj.addProperty("message",
+                "Launch type does not support coverage mode: "
+                        + typeId);
+        var arr = new com.google.gson.JsonArray();
+        for (String supported
+                : io.github.kaluchi.jdtbridge.coverage
+                        .CoverageTypes.supported()) {
+            arr.add(supported);
+        }
+        obj.add("supportedTypeIds", arr);
+        return obj.toString();
     }
 
     private String formatRunner(String testKind) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -244,21 +244,12 @@ public class TestHandler {
                 new NullProgressMonitor(), true);
 
         String configId = pl.configName();
-        String pid = null;
-        var processes = launch.getProcesses();
-        if (processes.length > 0) {
-            pid = processes[0].getAttribute(
-                    org.eclipse.debug.core.model.IProcess
-                            .ATTR_PROCESS_ID);
-        }
-
+        String pid = LaunchAttrs.firstPid(launch);
         String launchTimestamp = launch.getAttribute(
                 DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
 
-        String launchId = pid != null
-                ? configId + ":" + pid : configId;
-        String testRunId = configId + ":"
-                + launchTimestamp;
+        String launchId = LaunchAttrs.launchIdOf(configId, launch);
+        String testRunId = configId + ":" + launchTimestamp;
 
         var response = new JsonObject();
         response.addProperty("ok", true);

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -1,6 +1,8 @@
 package io.github.kaluchi.jdtbridge;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import io.github.kaluchi.jdtbridge.coverage.CoverageTypes;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -230,15 +232,13 @@ public class TestHandler {
 
         if (coverage) {
             String typeId = pl.config().getType().getIdentifier();
-            if (!io.github.kaluchi.jdtbridge.coverage
-                    .CoverageTypes.isSupported(typeId)) {
+            if (!CoverageTypes.isSupported(typeId)) {
                 return coverageModeNotSupported(typeId);
             }
         }
 
         String launchMode = coverage
-                ? io.github.kaluchi.jdtbridge.coverage
-                        .CoverageTypes.LAUNCH_MODE
+                ? CoverageTypes.LAUNCH_MODE
                 : ILaunchManager.RUN_MODE;
         ILaunch launch = pl.config().launch(launchMode,
                 new NullProgressMonitor(), true);
@@ -273,17 +273,20 @@ public class TestHandler {
         if (coverage) {
             response.addProperty("coverageId", testRunId);
             response.addProperty("launchMode",
-                    io.github.kaluchi.jdtbridge.coverage
-                            .CoverageTypes.LAUNCH_MODE);
+                    CoverageTypes.LAUNCH_MODE);
         }
 
         return response.toString();
     }
 
+    /** Strict {@code true} parse: accepts {@code "true"}
+     *  (case-insensitive) and {@code "1"} only. The CLI always
+     *  sends {@code coverage=true}, so empty-string ambiguity
+     *  ({@code ?coverage=}) deliberately does NOT enable
+     *  coverage — clients that forgot the value get the
+     *  no-coverage path. */
     private static boolean parseBool(String raw) {
-        return "true".equalsIgnoreCase(raw)
-                || "1".equals(raw)
-                || (raw != null && raw.isEmpty());
+        return "true".equalsIgnoreCase(raw) || "1".equals(raw);
     }
 
     private static String coverageModeNotSupported(String typeId) {
@@ -292,10 +295,8 @@ public class TestHandler {
         obj.addProperty("message",
                 "Launch type does not support coverage mode: "
                         + typeId);
-        var arr = new com.google.gson.JsonArray();
-        for (String supported
-                : io.github.kaluchi.jdtbridge.coverage
-                        .CoverageTypes.supported()) {
+        var arr = new JsonArray();
+        for (String supported : CoverageTypes.supported()) {
             arr.add(supported);
         }
         obj.add("supportedTypeIds", arr);

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestSessionHandler.java
@@ -201,17 +201,12 @@ class TestSessionHandler {
             obj.addProperty("configId", configId);
             obj.addProperty("testRunId", testRunId(s));
 
-            // LaunchId from ILaunch → PID
             ILaunch launch = s.getLaunch();
             if (launch != null) {
-                var procs = launch.getProcesses();
-                if (procs.length > 0) {
-                    String pid = procs[0].getAttribute(
-                            org.eclipse.debug.core.model
-                                    .IProcess.ATTR_PROCESS_ID);
-                    if (pid != null)
-                        obj.addProperty("launchId",
-                                configId + ":" + pid);
+                String pid = LaunchAttrs.firstPid(launch);
+                if (pid != null) {
+                    obj.addProperty("launchId",
+                            configId + ":" + pid);
                 }
             }
 
@@ -238,11 +233,10 @@ class TestSessionHandler {
             obj.addProperty("time",
                     Double.isNaN(elapsed) ? 0.0 : elapsed);
             if (launch != null) {
-                String ts = launch.getAttribute(
-                        DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
-                if (ts != null)
-                    obj.addProperty("startedAt",
-                            Long.parseLong(ts));
+                Long ts = LaunchAttrs.launchTimestamp(launch);
+                if (ts != null) {
+                    obj.addProperty("startedAt", ts);
+                }
             }
             arr.add(obj);
         }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageAnalyzer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageAnalyzer.java
@@ -1,0 +1,121 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
+import org.eclipse.eclemma.internal.core.analysis.SessionAnalyzer;
+import org.jacoco.core.data.ExecutionData;
+import org.jacoco.core.data.SessionInfo;
+
+/**
+ * Bridge-side analysis cache. Wraps EclEmma's internal
+ * {@link SessionAnalyzer#processSession} so that
+ * {@link IJavaModelCoverage} plus the raw
+ * {@link SessionInfo} / {@link ExecutionData} streams are cached
+ * keyed by {@link ICoverageSession} identity.
+ * <p>
+ * EclEmma's {@code JavaCoverageLoader} only ever holds the analysis
+ * for the currently-active session, and exposes
+ * {@link IJavaModelCoverage} only — not the JaCoCo session-info /
+ * execution-data lists. The bridge needs all three on every
+ * {@code /coverage/session} request, so it runs its own analyzer
+ * pass and keeps the result.
+ * <p>
+ * Invalidation hooks into {@link CoverageTracker#sessionRemoved}:
+ * sessions are immutable, analysis is deterministic given the same
+ * scope + execution-data source, so the cache only needs to drop
+ * entries for sessions the manager has discarded.
+ */
+@SuppressWarnings("restriction")
+final class CoverageAnalyzer {
+
+    /** Snapshot returned by {@link #ensureAnalyzed}. The three
+     *  collections are immutable views — callers must not mutate. */
+    static final class CachedAnalysis {
+        final IJavaModelCoverage modelCoverage;
+        final List<SessionInfo> jacocoSessionInfos;
+        final Collection<ExecutionData> jacocoExecData;
+        final long computedAtMillis;
+
+        CachedAnalysis(IJavaModelCoverage modelCoverage,
+                List<SessionInfo> infos,
+                Collection<ExecutionData> data,
+                long computedAtMillis) {
+            this.modelCoverage = modelCoverage;
+            this.jacocoSessionInfos = infos;
+            this.jacocoExecData = data;
+            this.computedAtMillis = computedAtMillis;
+        }
+    }
+
+    /** Identity-keyed: {@link ICoverageSession#equals} is identity
+     *  too, but using {@link IdentityHashMap} makes that explicit
+     *  and eliminates the equals/hashCode round-trip. */
+    private final Map<ICoverageSession, CachedAnalysis> cache =
+            Collections.synchronizedMap(new IdentityHashMap<>());
+
+    /** Return a cached analysis if present, otherwise run
+     *  {@link SessionAnalyzer#processSession} synchronously and
+     *  cache the result.
+     *  <p>
+     *  May throw {@link CoreException} when the underlying analyzer
+     *  fails (typically on a workspace with stale class files or
+     *  unresolved package fragment roots). */
+    CachedAnalysis ensureAnalyzed(ICoverageSession session)
+            throws CoreException {
+        CachedAnalysis hit = cache.get(session);
+        if (hit != null) {
+            return hit;
+        }
+        synchronized (session) {
+            hit = cache.get(session);
+            if (hit != null) {
+                return hit;
+            }
+            SessionAnalyzer analyzer = new SessionAnalyzer();
+            IJavaModelCoverage modelCoverage =
+                    analyzer.processSession(session,
+                            new NullProgressMonitor());
+            List<SessionInfo> infos = new ArrayList<>(
+                    analyzer.getSessionInfos());
+            Collection<ExecutionData> data = new ArrayList<>(
+                    analyzer.getExecutionData());
+            CachedAnalysis fresh = new CachedAnalysis(modelCoverage,
+                    Collections.unmodifiableList(infos),
+                    Collections.unmodifiableCollection(data),
+                    System.currentTimeMillis());
+            cache.put(session, fresh);
+            return fresh;
+        }
+    }
+
+    /** Drop the cache entry for one session. Called by
+     *  {@link CoverageTracker#sessionRemoved}. */
+    void invalidate(ICoverageSession session) {
+        cache.remove(session);
+    }
+
+    /** Drop every cache entry. Called when the bridge stops. */
+    void clear() {
+        cache.clear();
+    }
+
+    /** Test/inspection accessor — count of cached sessions. */
+    int cacheSize() {
+        return cache.size();
+    }
+
+    /** Test/inspection accessor — true when this session has a
+     *  cached analysis. */
+    boolean isCached(ICoverageSession session) {
+        return cache.containsKey(session);
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
@@ -1,0 +1,74 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.Map;
+
+import org.eclipse.core.runtime.Platform;
+
+import com.google.gson.JsonObject;
+
+import io.github.kaluchi.jdtbridge.ProjectScope;
+
+/**
+ * Single guarded entry point for {@code /coverage/*} HTTP routes.
+ * <p>
+ * Loaded eagerly when {@code HttpServer} is constructed, but
+ * carefully avoids referencing any class that imports
+ * {@code org.eclipse.eclemma.*} or {@code org.jacoco.*} at class
+ * initialization. The downstream {@link CoverageRouter} is only
+ * loaded when {@link #dispatch} is called AND the EclEmma bundle is
+ * present — so an Eclipse without EclEmma installed never triggers
+ * a {@code NoClassDefFoundError}.
+ */
+public class CoverageBridge {
+
+    private static final String ECLEMMA_BUNDLE =
+            "org.eclipse.eclemma.core";
+
+    private static final boolean AVAILABLE =
+            Platform.getBundle(ECLEMMA_BUNDLE) != null;
+
+    /** Lazy-initialized {@link CoverageRouter} — {@code Object} type
+     *  keeps the class out of the field signature so it isn't
+     *  resolved until {@link #dispatch} is invoked. */
+    private volatile Object router;
+
+    /** True when the {@code org.eclipse.eclemma.core} bundle is
+     *  installed in the current Eclipse instance. */
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    /**
+     * Dispatch a {@code /coverage/*} request. When EclEmma is
+     * absent, returns {@link #notInstalledError()} JSON without
+     * touching any EclEmma class.
+     */
+    public String dispatch(String path, Map<String, String> params,
+            String body, ProjectScope scope) {
+        if (!AVAILABLE) {
+            return notInstalledError();
+        }
+        return ((CoverageRouter) router()).dispatch(
+                path, params, body, scope);
+    }
+
+    private synchronized Object router() {
+        if (router == null) {
+            router = new CoverageRouter();
+        }
+        return router;
+    }
+
+    /** JSON returned for any {@code /coverage/*} hit when the
+     *  EclEmma bundle is missing. Package-private so tests can
+     *  assert the exact shape without invoking {@link #dispatch}. */
+    static String notInstalledError() {
+        var obj = new JsonObject();
+        obj.addProperty("error", "coverage-not-installed");
+        obj.addProperty("message",
+                "EclEmma plugin (" + ECLEMMA_BUNDLE
+                        + ") is not installed in this Eclipse "
+                        + "instance.");
+        return obj.toString();
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
@@ -91,7 +91,7 @@ public class CoverageBridge {
         }
         CoverageRouter r = (CoverageRouter) router();
         CoverageProgressStreamer.stream(out, coverageId,
-                r.tracker());
+                r.tracker(), r.analyzer());
     }
 
     /** JSONL line emitted by {@link #streamSession} when EclEmma

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
@@ -73,6 +73,27 @@ public class CoverageBridge {
                 path, params, body, scope);
     }
 
+    /** {@code GET /coverage/session/stream} — write JSONL events
+     *  to {@code out}. Bypasses {@link #dispatch} because the HTTP
+     *  layer streams directly to the socket. */
+    public void streamSession(java.io.OutputStream out,
+            String coverageId) {
+        if (!AVAILABLE) {
+            try {
+                out.write(notInstalledError().getBytes(
+                        java.nio.charset.StandardCharsets.UTF_8));
+                out.write('\n');
+                out.flush();
+            } catch (java.io.IOException e) {
+                // peer gone — nothing to do
+            }
+            return;
+        }
+        CoverageRouter r = (CoverageRouter) router();
+        CoverageProgressStreamer.stream(out, coverageId,
+                r.tracker());
+    }
+
     private synchronized Object router() {
         if (router == null) {
             router = new CoverageRouter();

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
@@ -38,6 +38,27 @@ public class CoverageBridge {
         return AVAILABLE;
     }
 
+    /** Activate the EclEmma listeners (session manager, launch
+     *  manager, coverage loader). No-op when EclEmma absent. Safe
+     *  to call multiple times. */
+    public void start() {
+        if (!AVAILABLE) {
+            return;
+        }
+        ((CoverageRouter) router()).start();
+    }
+
+    /** Deregister the listeners and clear bridge state. */
+    public void stop() {
+        if (!AVAILABLE) {
+            return;
+        }
+        Object r = router;
+        if (r != null) {
+            ((CoverageRouter) r).stop();
+        }
+    }
+
     /**
      * Dispatch a {@code /coverage/*} request. When EclEmma is
      * absent, returns {@link #notInstalledError()} JSON without

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageBridge.java
@@ -80,7 +80,7 @@ public class CoverageBridge {
             String coverageId) {
         if (!AVAILABLE) {
             try {
-                out.write(notInstalledError().getBytes(
+                out.write(streamNotInstalledEvent().getBytes(
                         java.nio.charset.StandardCharsets.UTF_8));
                 out.write('\n');
                 out.flush();
@@ -92,6 +92,17 @@ public class CoverageBridge {
         CoverageRouter r = (CoverageRouter) router();
         CoverageProgressStreamer.stream(out, coverageId,
                 r.tracker());
+    }
+
+    /** JSONL line emitted by {@link #streamSession} when EclEmma
+     *  is absent — uses the {@code event}/{@code reason} shape
+     *  consumers of {@code /coverage/session/stream} expect, so
+     *  parsers don't have to special-case the not-installed path. */
+    static String streamNotInstalledEvent() {
+        var obj = new JsonObject();
+        obj.addProperty("event", "failed");
+        obj.addProperty("reason", "coverage-not-installed");
+        return obj.toString();
     }
 
     private synchronized Object router() {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBus.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBus.java
@@ -1,0 +1,56 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import io.github.kaluchi.jdtbridge.coverage.CoverageTracker.CoverageEventListener;
+
+/**
+ * Per-{@code coverageId} subscribe / fire bus for the streaming
+ * endpoint. Decoupled from {@link CoverageTracker} so the tracker
+ * doesn't carry the listener bookkeeping itself.
+ */
+final class CoverageEventBus {
+
+    private final ConcurrentHashMap<String,
+            List<CoverageEventListener>> listeners =
+            new ConcurrentHashMap<>();
+
+    void subscribe(String coverageId,
+            CoverageEventListener listener) {
+        listeners.computeIfAbsent(coverageId,
+                k -> new CopyOnWriteArrayList<>()).add(listener);
+    }
+
+    void unsubscribe(String coverageId,
+            CoverageEventListener listener) {
+        List<CoverageEventListener> list = listeners.get(coverageId);
+        if (list == null) return;
+        list.remove(listener);
+        if (list.isEmpty()) {
+            listeners.remove(coverageId, list);
+        }
+    }
+
+    /** Dispatch one event to every subscriber of {@code coverageId}.
+     *  RuntimeExceptions thrown by individual listeners are swallowed
+     *  so one bad subscriber can't prevent the rest from receiving. */
+    void fire(String coverageId,
+            Consumer<CoverageEventListener> event) {
+        List<CoverageEventListener> list = listeners.get(coverageId);
+        if (list == null) return;
+        for (CoverageEventListener l : list) {
+            try {
+                event.accept(l);
+            } catch (RuntimeException e) {
+                // ignore — one listener shouldn't break the rest
+            }
+        }
+    }
+
+    void clear() {
+        listeners.clear();
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBus.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBus.java
@@ -53,4 +53,11 @@ final class CoverageEventBus {
     void clear() {
         listeners.clear();
     }
+
+    /** Test/inspection accessor — true when at least one subscriber
+     *  is currently registered for {@code coverageId}. */
+    boolean hasListeners(String coverageId) {
+        List<CoverageEventListener> list = listeners.get(coverageId);
+        return list != null && !list.isEmpty();
+    }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
@@ -20,6 +20,8 @@ import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.optBool;
 import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.optString;
 import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.parseObjectBody;
 
+import io.github.kaluchi.jdtbridge.LaunchAttrs;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
@@ -168,7 +170,7 @@ class CoverageHandler {
     // -- helpers --
 
     private static ILaunchManager launchManager() {
-        return DebugPlugin.getDefault().getLaunchManager();
+        return LaunchAttrs.launchManager();
     }
 
     private static ILaunchConfiguration findConfig(String name) {
@@ -195,8 +197,7 @@ class CoverageHandler {
         String configId = config != null ? config.getName() : "";
         obj.addProperty("configId", configId);
 
-        Long timestamp = CoverageJson.parseLaunchTimestamp(
-                launch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
+        Long timestamp = LaunchAttrs.launchTimestamp(launch);
         String coverageId = timestamp != null
                 ? configId + ":" + timestamp
                 : configId;
@@ -205,17 +206,14 @@ class CoverageHandler {
             obj.addProperty("launchTimestamp", timestamp);
         }
 
-        IProcess[] procs = launch.getProcesses();
-        String pid = procs.length > 0
-                ? procs[0].getAttribute(IProcess.ATTR_PROCESS_ID)
-                : null;
+        String pid = LaunchAttrs.firstPid(launch);
         if (pid != null) {
             obj.addProperty("processPid", pid);
-            obj.addProperty("launchId", configId + ":" + pid);
-        } else {
-            obj.addProperty("launchId", configId);
         }
+        obj.addProperty("launchId",
+                LaunchAttrs.launchIdOf(configId, launch));
 
+        IProcess[] procs = launch.getProcesses();
         if (procs.length > 0) {
             String cmdline = procs[0].getAttribute(ATTR_CMDLINE);
             if (cmdline != null) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
@@ -1,0 +1,306 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.ISessionManager;
+import org.eclipse.eclemma.core.launching.ICoverageLaunch;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * HTTP handlers for the four mutating {@code /coverage/*}
+ * endpoints: {@code /run}, {@code /dump}, {@code /refresh},
+ * {@code /relaunch}.
+ * <p>
+ * Read-only / list endpoints live in
+ * {@link CoverageSessionHandler}; the streaming variant is
+ * {@link CoverageProgressStreamer}.
+ */
+class CoverageHandler {
+
+    static final String ATTR_CMDLINE =
+            "org.eclipse.debug.core.ATTR_CMDLINE";
+
+    private final CoverageTracker tracker;
+
+    CoverageHandler(CoverageTracker tracker) {
+        this.tracker = tracker;
+    }
+
+    /** {@code GET /coverage/run?configId=...} — start a new
+     *  coverage launch. */
+    String handleRun(Map<String, String> params) {
+        String configId = params.get("configId");
+        if (configId == null || configId.isBlank()) {
+            return error("coverage-config-not-found",
+                    "Missing 'configId' parameter");
+        }
+        ILaunchConfiguration config = findConfig(configId);
+        if (config == null) {
+            return error("coverage-config-not-found",
+                    "Launch configuration not found: " + configId);
+        }
+        String typeId;
+        try {
+            typeId = config.getType().getIdentifier();
+        } catch (CoreException e) {
+            return error("coverage-config-not-found",
+                    e.getMessage());
+        }
+        if (!CoverageTypes.isSupported(typeId)) {
+            return modeNotSupported(typeId);
+        }
+        try {
+            ILaunch launch = config.launch(
+                    CoverageTypes.LAUNCH_MODE, null, true);
+            return runResponse(launch);
+        } catch (CoreException e) {
+            return error("coverage-launch-failed",
+                    "Launch failed: " + e.getMessage());
+        }
+    }
+
+    /** {@code POST /coverage/dump} body {@code {coverageId, reset}}
+     *  — request a dump from the running JaCoCo agent. */
+    String handleDump(String requestBody) {
+        JsonObject body = parseBody(requestBody);
+        if (body == null) {
+            return error("coverage-not-found",
+                    "Missing or invalid request body");
+        }
+        String coverageId = optString(body, "coverageId");
+        boolean reset = optBool(body, "reset", false);
+        if (coverageId == null || coverageId.isBlank()) {
+            return error("coverage-not-found",
+                    "Missing 'coverageId' in body");
+        }
+        CoverageRun run = tracker.byCoverageId(coverageId);
+        if (run == null) {
+            return error("coverage-not-found", coverageId);
+        }
+        if (run.kind != CoverageRun.Kind.LIVE) {
+            return error("coverage-launch-not-live",
+                    "Session has no live launch: " + coverageId);
+        }
+        if (run.terminated) {
+            return error("coverage-launch-terminated",
+                    "Launch already terminated: " + coverageId);
+        }
+        if (!(run.launch instanceof ICoverageLaunch)) {
+            return error("coverage-launch-not-live",
+                    "Launch is not a coverage launch: "
+                            + coverageId);
+        }
+        try {
+            ((ICoverageLaunch) run.launch).requestDump(reset);
+            var ok = new JsonObject();
+            ok.addProperty("ok", true);
+            return ok.toString();
+        } catch (CoreException e) {
+            return error("coverage-launch-failed",
+                    "Dump failed: " + e.getMessage());
+        }
+    }
+
+    /** {@code POST /coverage/refresh} — re-fire
+     *  {@code sessionActivated} for the active session, which
+     *  causes {@link org.eclipse.eclemma.internal.core.JavaCoverageLoader}
+     *  to cancel any in-flight job and re-analyze. */
+    String handleRefresh() {
+        ISessionManager sm = CoverageTools.getSessionManager();
+        ICoverageSession active = sm.getActiveSession();
+        if (active == null) {
+            return error("coverage-no-active-session",
+                    "No active coverage session");
+        }
+        sm.refreshActiveSession();
+        var obj = new JsonObject();
+        obj.addProperty("ok", true);
+        obj.addProperty("activeCoverageId",
+                tracker.activeCoverageId());
+        return obj.toString();
+    }
+
+    /** {@code POST /coverage/relaunch} — relaunch the active
+     *  session's source config in coverage mode. The bridge runs
+     *  headless and calls {@code config.launch(LAUNCH_MODE, ...)}
+     *  directly instead of Eclipse's {@code DebugUITools.launch}. */
+    String handleRelaunch() {
+        ISessionManager sm = CoverageTools.getSessionManager();
+        ICoverageSession active = sm.getActiveSession();
+        if (active == null) {
+            return error("coverage-no-active-session",
+                    "No active coverage session");
+        }
+        ILaunchConfiguration config = active.getLaunchConfiguration();
+        if (config == null) {
+            return error("coverage-launch-not-live",
+                    "Active session has no associated launch "
+                            + "configuration");
+        }
+        try {
+            ILaunch launch = config.launch(
+                    CoverageTypes.LAUNCH_MODE, null, true);
+            return runResponse(launch);
+        } catch (CoreException e) {
+            return error("coverage-launch-failed",
+                    "Relaunch failed: " + e.getMessage());
+        }
+    }
+
+    // -- helpers --
+
+    private static ILaunchManager launchManager() {
+        return DebugPlugin.getDefault().getLaunchManager();
+    }
+
+    private static ILaunchConfiguration findConfig(String name) {
+        try {
+            for (ILaunchConfiguration c
+                    : launchManager().getLaunchConfigurations()) {
+                if (name.equals(c.getName())) {
+                    return c;
+                }
+            }
+        } catch (Exception e) {
+            // fall through to null
+        }
+        return null;
+    }
+
+    /** Build the response JSON for {@code /coverage/run} and
+     *  {@code /coverage/relaunch}. */
+    private static String runResponse(ILaunch launch) {
+        var obj = new JsonObject();
+        obj.addProperty("ok", true);
+
+        ILaunchConfiguration config = launch.getLaunchConfiguration();
+        String configId = config != null ? config.getName() : "";
+        obj.addProperty("configId", configId);
+
+        Long timestamp = parseLong(launch.getAttribute(
+                DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
+        String coverageId = timestamp != null
+                ? configId + ":" + timestamp
+                : configId;
+        obj.addProperty("coverageId", coverageId);
+        if (timestamp != null) {
+            obj.addProperty("launchTimestamp", timestamp);
+        }
+
+        IProcess[] procs = launch.getProcesses();
+        String pid = procs.length > 0
+                ? procs[0].getAttribute(IProcess.ATTR_PROCESS_ID)
+                : null;
+        if (pid != null) {
+            obj.addProperty("processPid", pid);
+            obj.addProperty("launchId", configId + ":" + pid);
+        } else {
+            obj.addProperty("launchId", configId);
+        }
+
+        if (procs.length > 0) {
+            String cmdline = procs[0].getAttribute(ATTR_CMDLINE);
+            if (cmdline != null) {
+                obj.addProperty("cmdline", cmdline);
+            }
+        }
+
+        if (config != null) {
+            try {
+                ILaunchConfigurationType type = config.getType();
+                if (type != null) {
+                    obj.addProperty("configType", type.getName());
+                    obj.addProperty("configTypeId",
+                            type.getIdentifier());
+                }
+            } catch (CoreException e) {
+                // skip type info on failure
+            }
+        }
+
+        if (launch instanceof ICoverageLaunch coverageLaunch) {
+            var arr = new JsonArray();
+            for (IPackageFragmentRoot root
+                    : coverageLaunch.getScope()) {
+                arr.add(root.getHandleIdentifier());
+            }
+            obj.add("coverageScope", arr);
+        }
+
+        return obj.toString();
+    }
+
+    private String modeNotSupported(String typeId) {
+        var obj = new JsonObject();
+        obj.addProperty("error", "coverage-mode-not-supported");
+        obj.addProperty("message",
+                "Launch type does not support coverage mode: "
+                        + typeId);
+        var arr = new JsonArray();
+        for (String supported : CoverageTypes.supported()) {
+            arr.add(supported);
+        }
+        obj.add("supportedTypeIds", arr);
+        return obj.toString();
+    }
+
+    private static String error(String kind, String message) {
+        var obj = new JsonObject();
+        obj.addProperty("error", kind);
+        if (message != null && !message.isEmpty()) {
+            obj.addProperty("message", message);
+        }
+        return obj.toString();
+    }
+
+    private static JsonObject parseBody(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(body);
+            if (parsed.isJsonObject()) {
+                return parsed.getAsJsonObject();
+            }
+        } catch (Exception e) {
+            // fall through to null
+        }
+        return null;
+    }
+
+    private static String optString(JsonObject body, String key) {
+        JsonElement el = body.get(key);
+        return el != null && !el.isJsonNull()
+                ? el.getAsString() : null;
+    }
+
+    private static boolean optBool(JsonObject body, String key,
+            boolean defaultValue) {
+        JsonElement el = body.get(key);
+        return el != null && !el.isJsonNull()
+                ? el.getAsBoolean() : defaultValue;
+    }
+
+    private static Long parseLong(String raw) {
+        if (raw == null) return null;
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
@@ -57,8 +57,9 @@ class CoverageHandler {
         try {
             typeId = config.getType().getIdentifier();
         } catch (CoreException e) {
-            return error("coverage-config-not-found",
-                    e.getMessage());
+            return error("coverage-launch-failed",
+                    "Failed to read launch configuration type: "
+                            + e.getMessage());
         }
         if (!CoverageTypes.isSupported(typeId)) {
             return modeNotSupported(typeId);
@@ -175,8 +176,8 @@ class CoverageHandler {
                     return c;
                 }
             }
-        } catch (Exception e) {
-            // fall through to null
+        } catch (CoreException e) {
+            return null;
         }
         return null;
     }
@@ -276,8 +277,8 @@ class CoverageHandler {
             if (parsed.isJsonObject()) {
                 return parsed.getAsJsonObject();
             }
-        } catch (Exception e) {
-            // fall through to null
+        } catch (com.google.gson.JsonParseException e) {
+            return null;
         }
         return null;
     }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
@@ -15,10 +15,13 @@ import org.eclipse.eclemma.core.ISessionManager;
 import org.eclipse.eclemma.core.launching.ICoverageLaunch;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.error;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.optBool;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.optString;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.parseObjectBody;
+
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 /**
  * HTTP handlers for the four mutating {@code /coverage/*}
@@ -77,7 +80,7 @@ class CoverageHandler {
     /** {@code POST /coverage/dump} body {@code {coverageId, reset}}
      *  — request a dump from the running JaCoCo agent. */
     String handleDump(String requestBody) {
-        JsonObject body = parseBody(requestBody);
+        JsonObject body = parseObjectBody(requestBody);
         if (body == null) {
             return error("coverage-not-found",
                     "Missing or invalid request body");
@@ -192,8 +195,8 @@ class CoverageHandler {
         String configId = config != null ? config.getName() : "";
         obj.addProperty("configId", configId);
 
-        Long timestamp = parseLong(launch.getAttribute(
-                DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
+        Long timestamp = CoverageJson.parseLaunchTimestamp(
+                launch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
         String coverageId = timestamp != null
                 ? configId + ":" + timestamp
                 : configId;
@@ -259,49 +262,4 @@ class CoverageHandler {
         return obj.toString();
     }
 
-    private static String error(String kind, String message) {
-        var obj = new JsonObject();
-        obj.addProperty("error", kind);
-        if (message != null && !message.isEmpty()) {
-            obj.addProperty("message", message);
-        }
-        return obj.toString();
-    }
-
-    private static JsonObject parseBody(String body) {
-        if (body == null || body.isBlank()) {
-            return null;
-        }
-        try {
-            JsonElement parsed = JsonParser.parseString(body);
-            if (parsed.isJsonObject()) {
-                return parsed.getAsJsonObject();
-            }
-        } catch (com.google.gson.JsonParseException e) {
-            return null;
-        }
-        return null;
-    }
-
-    private static String optString(JsonObject body, String key) {
-        JsonElement el = body.get(key);
-        return el != null && !el.isJsonNull()
-                ? el.getAsString() : null;
-    }
-
-    private static boolean optBool(JsonObject body, String key,
-            boolean defaultValue) {
-        JsonElement el = body.get(key);
-        return el != null && !el.isJsonNull()
-                ? el.getAsBoolean() : defaultValue;
-    }
-
-    private static Long parseLong(String raw) {
-        if (raw == null) return null;
-        try {
-            return Long.parseLong(raw);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageJson.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageJson.java
@@ -123,20 +123,6 @@ final class CoverageJson {
         }
     }
 
-    /** Eclipse stores {@code ATTR_LAUNCH_TIMESTAMP} as
-     *  {@code Long.toString(System.currentTimeMillis())}. Parses
-     *  back to {@link Long} or {@code null} on missing / malformed. */
-    static Long parseLaunchTimestamp(String raw) {
-        if (raw == null) {
-            return null;
-        }
-        try {
-            return Long.parseLong(raw);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
     /** {@link ICounter#getStatus()} bit-flag → constant name from
      *  {@link ICoverageNode}. */
     static String statusName(int status) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageJson.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageJson.java
@@ -1,0 +1,151 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode;
+import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+
+/**
+ * Shared wire-format helpers for {@code /coverage/*} responses.
+ * All shapes are documented in
+ * {@code docs/bridge-coverage-spec.md}.
+ */
+final class CoverageJson {
+
+    private CoverageJson() {
+    }
+
+    /** Standard {@code {"error": kind, "message": ...}} envelope. */
+    static String error(String kind, String message) {
+        var obj = new JsonObject();
+        obj.addProperty("error", kind);
+        if (message != null && !message.isEmpty()) {
+            obj.addProperty("message", message);
+        }
+        return obj.toString();
+    }
+
+    /** Parse a JSON object body, or {@code null} on missing /
+     *  malformed / non-object input. */
+    static JsonObject parseObjectBody(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(body);
+            if (parsed.isJsonObject()) {
+                return parsed.getAsJsonObject();
+            }
+        } catch (JsonParseException e) {
+            return null;
+        }
+        return null;
+    }
+
+    static String optString(JsonObject body, String key) {
+        JsonElement el = body.get(key);
+        return el != null && !el.isJsonNull()
+                ? el.getAsString() : null;
+    }
+
+    static boolean optBool(JsonObject body, String key,
+            boolean defaultValue) {
+        JsonElement el = body.get(key);
+        return el != null && !el.isJsonNull()
+                ? el.getAsBoolean() : defaultValue;
+    }
+
+    static void addNullableString(JsonObject obj, String key,
+            String value) {
+        if (value == null) {
+            obj.add(key, JsonNull.INSTANCE);
+        } else {
+            obj.addProperty(key, value);
+        }
+    }
+
+    static void addNullableLong(JsonObject obj, String key,
+            Long value) {
+        if (value == null) {
+            obj.add(key, JsonNull.INSTANCE);
+        } else {
+            obj.addProperty(key, value);
+        }
+    }
+
+    /** All six {@link ICounter}s wrapped in a single counters
+     *  object — wire shape per spec § Counter shape. */
+    static JsonObject countersOf(IJavaModelCoverage cov) {
+        var obj = new JsonObject();
+        if (cov == null) {
+            return obj;
+        }
+        obj.add("instruction",
+                counterJson(cov.getInstructionCounter()));
+        obj.add("branch", counterJson(cov.getBranchCounter()));
+        obj.add("line", counterJson(cov.getLineCounter()));
+        obj.add("complexity",
+                counterJson(cov.getComplexityCounter()));
+        obj.add("method", counterJson(cov.getMethodCounter()));
+        obj.add("class", counterJson(cov.getClassCounter()));
+        return obj;
+    }
+
+    /** Single-counter wire shape. {@code coveredRatio /
+     *  missedRatio} become JSON {@code null} when JaCoCo returns
+     *  {@code NaN} (i.e. {@code totalCount == 0}). */
+    static JsonObject counterJson(ICounter counter) {
+        var obj = new JsonObject();
+        if (counter == null) {
+            return obj;
+        }
+        obj.addProperty("coveredCount", counter.getCoveredCount());
+        obj.addProperty("missedCount", counter.getMissedCount());
+        obj.addProperty("totalCount", counter.getTotalCount());
+        addRatio(obj, "coveredRatio", counter.getCoveredRatio());
+        addRatio(obj, "missedRatio", counter.getMissedRatio());
+        obj.addProperty("coverageStatus",
+                statusName(counter.getStatus()));
+        return obj;
+    }
+
+    private static void addRatio(JsonObject obj, String key,
+            double value) {
+        if (Double.isNaN(value)) {
+            obj.add(key, JsonNull.INSTANCE);
+        } else {
+            obj.addProperty(key, value);
+        }
+    }
+
+    /** Eclipse stores {@code ATTR_LAUNCH_TIMESTAMP} as
+     *  {@code Long.toString(System.currentTimeMillis())}. Parses
+     *  back to {@link Long} or {@code null} on missing / malformed. */
+    static Long parseLaunchTimestamp(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** {@link ICounter#getStatus()} bit-flag → constant name from
+     *  {@link ICoverageNode}. */
+    static String statusName(int status) {
+        return switch (status) {
+            case ICounter.EMPTY -> "EMPTY";
+            case ICounter.NOT_COVERED -> "NOT_COVERED";
+            case ICounter.FULLY_COVERED -> "FULLY_COVERED";
+            case ICounter.PARTLY_COVERED -> "PARTLY_COVERED";
+            default -> "UNKNOWN";
+        };
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
@@ -86,7 +86,6 @@ public final class CoverageProgressStreamer {
                 safeWrite(out, analysisEvent(r,
                         "analysisReady", counters), closed, done);
                 if (isTerminal(r)) {
-                    safeWrite(out, terminatedEvent(r), closed, done);
                     done.countDown();
                 }
             }
@@ -94,7 +93,9 @@ public final class CoverageProgressStreamer {
             @Override
             public void onTerminated(CoverageRun r) {
                 safeWrite(out, terminatedEvent(r), closed, done);
-                done.countDown();
+                if (isTerminal(r)) {
+                    done.countDown();
+                }
             }
 
             @Override

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
@@ -6,6 +6,11 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.jacoco.core.analysis.ICounter;
 
 import com.google.gson.JsonObject;
 
@@ -40,7 +45,7 @@ public final class CoverageProgressStreamer {
      * client disconnects mid-stream.
      */
     public static void stream(OutputStream out, String coverageId,
-            CoverageTracker tracker) {
+            CoverageTracker tracker, CoverageAnalyzer analyzer) {
         if (coverageId == null || coverageId.isBlank()) {
             writeLine(out, errorEvent("missing-coverageId"));
             return;
@@ -60,47 +65,59 @@ public final class CoverageProgressStreamer {
         }
 
         CountDownLatch done = new CountDownLatch(1);
+        AtomicBoolean closed = new AtomicBoolean(false);
         CoverageTracker.CoverageEventListener listener =
                 new CoverageTracker.CoverageEventListener() {
             @Override
             public void onDumped(CoverageRun r, int dumpIndex,
                     long dumpTimestamp) {
-                writeLine(out, dumpedEvent(r, dumpIndex,
-                        dumpTimestamp));
+                safeWrite(out, dumpedEvent(r, dumpIndex,
+                        dumpTimestamp), closed, done);
             }
 
             @Override
             public void onAnalysisLoading(CoverageRun r) {
-                writeLine(out, analysisEvent(r,
-                        "analysisLoading"));
+                safeWrite(out, analysisEvent(r,
+                        "analysisLoading", null), closed, done);
             }
 
             @Override
             public void onAnalysisReady(CoverageRun r) {
-                writeLine(out, analysisEvent(r,
-                        "analysisReady"));
+                JsonObject counters = countersFor(r, analyzer);
+                safeWrite(out, analysisEvent(r,
+                        "analysisReady", counters), closed, done);
                 if (isTerminal(r)) {
-                    writeLine(out, terminatedEvent(r));
+                    safeWrite(out, terminatedEvent(r), closed, done);
                     done.countDown();
                 }
             }
 
             @Override
             public void onTerminated(CoverageRun r) {
-                writeLine(out, terminatedEvent(r));
+                safeWrite(out, terminatedEvent(r), closed, done);
+                done.countDown();
+            }
+
+            @Override
+            public void onFailed(CoverageRun r, String reason) {
+                safeWrite(out, failedEvent(r, reason),
+                        closed, done);
+                // Cancellation is terminal for the analysis phase
+                // even when the run itself isn't terminated yet —
+                // close the stream so the caller doesn't hang.
                 done.countDown();
             }
         };
 
         tracker.addCoverageListener(run.coverageId, listener);
         try {
-            // Re-check terminal state after subscription — covers
-            // the race where the run terminated between snapshot
-            // and listener registration.
-            CoverageRun snapshot = tracker.byCoverageId(
+            // Re-check after subscribe — covers the race where the
+            // run terminated between snapshot and listener
+            // registration.
+            CoverageRun postSubscribe = tracker.byCoverageId(
                     run.coverageId);
-            if (snapshot != null && isTerminal(snapshot)) {
-                writeLine(out, terminatedEvent(snapshot));
+            if (postSubscribe != null && isTerminal(postSubscribe)) {
+                writeLine(out, terminatedEvent(postSubscribe));
                 return;
             }
             done.await(1, TimeUnit.HOURS);
@@ -108,6 +125,48 @@ public final class CoverageProgressStreamer {
             Thread.currentThread().interrupt();
         } finally {
             tracker.removeCoverageListener(run.coverageId, listener);
+        }
+    }
+
+    /**
+     * Write one event from a listener callback, or no-op once the
+     * client has disconnected. The underlying {@link #writeLine}
+     * throws {@link StreamClosedException} on broken pipe — that
+     * propagates onto the listener-dispatch thread, where the
+     * tracker's {@code fire*} method catches it and ignores. To
+     * avoid quietly leaking the listener (the streamer thread
+     * would still be parked on {@code done.await}), we trip the
+     * latch on the first failure and skip subsequent writes.
+     */
+    private static void safeWrite(OutputStream out, String json,
+            AtomicBoolean closed, CountDownLatch done) {
+        if (closed.get()) {
+            return;
+        }
+        try {
+            writeLine(out, json);
+        } catch (StreamClosedException e) {
+            closed.set(true);
+            done.countDown();
+        }
+    }
+
+    /** Best-effort counter snapshot for the streamer's
+     *  {@code analysisReady} event. Returns {@code null} when
+     *  analysis isn't reproducible (e.g. stale workspace, no
+     *  classes resolvable) — the event still fires without
+     *  counters in that case. */
+    private static JsonObject countersFor(CoverageRun run,
+            CoverageAnalyzer analyzer) {
+        if (analyzer == null) return null;
+        ICoverageSession session = run.resolveSession(null);
+        if (session == null) return null;
+        try {
+            CoverageAnalyzer.CachedAnalysis ca =
+                    analyzer.ensureAnalyzed(session);
+            return countersJson(ca.modelCoverage);
+        } catch (CoreException e) {
+            return null;
         }
     }
 
@@ -139,11 +198,14 @@ public final class CoverageProgressStreamer {
     }
 
     private static String analysisEvent(CoverageRun run,
-            String eventName) {
+            String eventName, JsonObject counters) {
         var obj = new JsonObject();
         obj.addProperty("event", eventName);
         obj.addProperty("coverageId", run.coverageId);
         obj.addProperty("dumpIndex", run.dumpCount());
+        if (counters != null) {
+            obj.add("counters", counters);
+        }
         return obj.toString();
     }
 
@@ -158,11 +220,72 @@ public final class CoverageProgressStreamer {
         return obj.toString();
     }
 
+    private static String failedEvent(CoverageRun run,
+            String reason) {
+        var obj = new JsonObject();
+        obj.addProperty("event", "failed");
+        obj.addProperty("coverageId", run.coverageId);
+        obj.addProperty("reason", reason);
+        obj.addProperty("dumpIndex", run.dumpCount());
+        return obj.toString();
+    }
+
     private static String errorEvent(String reason) {
         var obj = new JsonObject();
         obj.addProperty("event", "failed");
         obj.addProperty("reason", reason);
         return obj.toString();
+    }
+
+    /** Same shape used by {@code CoverageSessionHandler.counterJson}
+     *  but locally inlined to avoid a public dep. */
+    private static JsonObject countersJson(
+            org.eclipse.eclemma.core.analysis.IJavaModelCoverage cov) {
+        var obj = new JsonObject();
+        if (cov == null) {
+            return obj;
+        }
+        obj.add("instruction",
+                counterJson(cov.getInstructionCounter()));
+        obj.add("branch", counterJson(cov.getBranchCounter()));
+        obj.add("line", counterJson(cov.getLineCounter()));
+        obj.add("complexity",
+                counterJson(cov.getComplexityCounter()));
+        obj.add("method", counterJson(cov.getMethodCounter()));
+        obj.add("class", counterJson(cov.getClassCounter()));
+        return obj;
+    }
+
+    private static JsonObject counterJson(ICounter counter) {
+        var obj = new JsonObject();
+        if (counter == null) return obj;
+        obj.addProperty("coveredCount", counter.getCoveredCount());
+        obj.addProperty("missedCount", counter.getMissedCount());
+        obj.addProperty("totalCount", counter.getTotalCount());
+        addRatio(obj, "coveredRatio", counter.getCoveredRatio());
+        addRatio(obj, "missedRatio", counter.getMissedRatio());
+        obj.addProperty("coverageStatus",
+                statusName(counter.getStatus()));
+        return obj;
+    }
+
+    private static void addRatio(JsonObject obj, String key,
+            double value) {
+        if (Double.isNaN(value)) {
+            obj.add(key, com.google.gson.JsonNull.INSTANCE);
+        } else {
+            obj.addProperty(key, value);
+        }
+    }
+
+    private static String statusName(int status) {
+        return switch (status) {
+            case ICounter.EMPTY -> "EMPTY";
+            case ICounter.NOT_COVERED -> "NOT_COVERED";
+            case ICounter.FULLY_COVERED -> "FULLY_COVERED";
+            case ICounter.PARTLY_COVERED -> "PARTLY_COVERED";
+            default -> "UNKNOWN";
+        };
     }
 
     private static void writeLine(OutputStream out, String json) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.eclemma.core.ICoverageSession;
-import org.jacoco.core.analysis.ICounter;
 
 import com.google.gson.JsonObject;
 
@@ -164,7 +163,7 @@ public final class CoverageProgressStreamer {
         try {
             CoverageAnalyzer.CachedAnalysis ca =
                     analyzer.ensureAnalyzed(session);
-            return countersJson(ca.modelCoverage);
+            return CoverageJson.countersOf(ca.modelCoverage);
         } catch (CoreException e) {
             return null;
         }
@@ -235,57 +234,6 @@ public final class CoverageProgressStreamer {
         obj.addProperty("event", "failed");
         obj.addProperty("reason", reason);
         return obj.toString();
-    }
-
-    /** Same shape used by {@code CoverageSessionHandler.counterJson}
-     *  but locally inlined to avoid a public dep. */
-    private static JsonObject countersJson(
-            org.eclipse.eclemma.core.analysis.IJavaModelCoverage cov) {
-        var obj = new JsonObject();
-        if (cov == null) {
-            return obj;
-        }
-        obj.add("instruction",
-                counterJson(cov.getInstructionCounter()));
-        obj.add("branch", counterJson(cov.getBranchCounter()));
-        obj.add("line", counterJson(cov.getLineCounter()));
-        obj.add("complexity",
-                counterJson(cov.getComplexityCounter()));
-        obj.add("method", counterJson(cov.getMethodCounter()));
-        obj.add("class", counterJson(cov.getClassCounter()));
-        return obj;
-    }
-
-    private static JsonObject counterJson(ICounter counter) {
-        var obj = new JsonObject();
-        if (counter == null) return obj;
-        obj.addProperty("coveredCount", counter.getCoveredCount());
-        obj.addProperty("missedCount", counter.getMissedCount());
-        obj.addProperty("totalCount", counter.getTotalCount());
-        addRatio(obj, "coveredRatio", counter.getCoveredRatio());
-        addRatio(obj, "missedRatio", counter.getMissedRatio());
-        obj.addProperty("coverageStatus",
-                statusName(counter.getStatus()));
-        return obj;
-    }
-
-    private static void addRatio(JsonObject obj, String key,
-            double value) {
-        if (Double.isNaN(value)) {
-            obj.add(key, com.google.gson.JsonNull.INSTANCE);
-        } else {
-            obj.addProperty(key, value);
-        }
-    }
-
-    private static String statusName(int status) {
-        return switch (status) {
-            case ICounter.EMPTY -> "EMPTY";
-            case ICounter.NOT_COVERED -> "NOT_COVERED";
-            case ICounter.FULLY_COVERED -> "FULLY_COVERED";
-            case ICounter.PARTLY_COVERED -> "PARTLY_COVERED";
-            default -> "UNKNOWN";
-        };
     }
 
     private static void writeLine(OutputStream out, String json) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
@@ -1,0 +1,181 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.google.gson.JsonObject;
+
+/**
+ * JSONL streaming for {@code GET /coverage/session/stream}.
+ * Emits the current snapshot, then forwards live transitions
+ * captured by {@link CoverageTracker.CoverageEventListener} until
+ * the run hits a terminal state ({@code terminated &&
+ * !analysisLoading}) or the client disconnects.
+ */
+public final class CoverageProgressStreamer {
+
+    /** Thrown when the underlying socket signals the client has
+     *  gone away. The HTTP server's stream-handling code maps this
+     *  back to a normal disconnect. Mirrors
+     *  {@code TestProgressStreamer.StreamClosedException}. */
+    public static final class StreamClosedException
+            extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        StreamClosedException(IOException cause) {
+            super(cause);
+        }
+    }
+
+    private CoverageProgressStreamer() {
+    }
+
+    /**
+     * Stream events for {@code coverageId} to {@code out} until the
+     * run reaches a terminal state. Returns normally when the
+     * stream ends; throws {@link StreamClosedException} when the
+     * client disconnects mid-stream.
+     */
+    public static void stream(OutputStream out, String coverageId,
+            CoverageTracker tracker) {
+        if (coverageId == null || coverageId.isBlank()) {
+            writeLine(out, errorEvent("missing-coverageId"));
+            return;
+        }
+        CoverageRun run = tracker.byCoverageId(coverageId);
+        if (run == null) {
+            writeLine(out, errorEvent("coverage-not-found"));
+            return;
+        }
+        // Always emit the snapshot first.
+        writeLine(out, snapshotEvent(run));
+
+        // Already-terminal: nothing more to wait for.
+        if (isTerminal(run)) {
+            writeLine(out, terminatedEvent(run));
+            return;
+        }
+
+        CountDownLatch done = new CountDownLatch(1);
+        CoverageTracker.CoverageEventListener listener =
+                new CoverageTracker.CoverageEventListener() {
+            @Override
+            public void onDumped(CoverageRun r, int dumpIndex,
+                    long dumpTimestamp) {
+                writeLine(out, dumpedEvent(r, dumpIndex,
+                        dumpTimestamp));
+            }
+
+            @Override
+            public void onAnalysisLoading(CoverageRun r) {
+                writeLine(out, analysisEvent(r,
+                        "analysisLoading"));
+            }
+
+            @Override
+            public void onAnalysisReady(CoverageRun r) {
+                writeLine(out, analysisEvent(r,
+                        "analysisReady"));
+                if (isTerminal(r)) {
+                    writeLine(out, terminatedEvent(r));
+                    done.countDown();
+                }
+            }
+
+            @Override
+            public void onTerminated(CoverageRun r) {
+                writeLine(out, terminatedEvent(r));
+                done.countDown();
+            }
+        };
+
+        tracker.addCoverageListener(run.coverageId, listener);
+        try {
+            // Re-check terminal state after subscription — covers
+            // the race where the run terminated between snapshot
+            // and listener registration.
+            CoverageRun snapshot = tracker.byCoverageId(
+                    run.coverageId);
+            if (snapshot != null && isTerminal(snapshot)) {
+                writeLine(out, terminatedEvent(snapshot));
+                return;
+            }
+            done.await(1, TimeUnit.HOURS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            tracker.removeCoverageListener(run.coverageId, listener);
+        }
+    }
+
+    private static boolean isTerminal(CoverageRun run) {
+        return run.terminated && !run.analysisLoading;
+    }
+
+    private static String snapshotEvent(CoverageRun run) {
+        var obj = new JsonObject();
+        obj.addProperty("event", "snapshot");
+        obj.addProperty("coverageId", run.coverageId);
+        obj.addProperty("coverageSessionKind", run.kind.wireName());
+        obj.addProperty("terminated", run.terminated);
+        obj.addProperty("dataReceived", run.dataReceived);
+        obj.addProperty("analysisLoading", run.analysisLoading);
+        obj.addProperty("analysisReady", run.analysisReady);
+        obj.addProperty("dumpCount", run.dumpCount());
+        return obj.toString();
+    }
+
+    private static String dumpedEvent(CoverageRun run,
+            int dumpIndex, long dumpTimestamp) {
+        var obj = new JsonObject();
+        obj.addProperty("event", "dumped");
+        obj.addProperty("coverageId", run.coverageId);
+        obj.addProperty("dumpIndex", dumpIndex);
+        obj.addProperty("dumpTimestamp", dumpTimestamp);
+        return obj.toString();
+    }
+
+    private static String analysisEvent(CoverageRun run,
+            String eventName) {
+        var obj = new JsonObject();
+        obj.addProperty("event", eventName);
+        obj.addProperty("coverageId", run.coverageId);
+        obj.addProperty("dumpIndex", run.dumpCount());
+        return obj.toString();
+    }
+
+    private static String terminatedEvent(CoverageRun run) {
+        var obj = new JsonObject();
+        obj.addProperty("event", "terminated");
+        obj.addProperty("coverageId", run.coverageId);
+        if (run.terminatedAt != null) {
+            obj.addProperty("terminatedAt", run.terminatedAt);
+        }
+        obj.addProperty("dataReceived", run.dataReceived);
+        return obj.toString();
+    }
+
+    private static String errorEvent(String reason) {
+        var obj = new JsonObject();
+        obj.addProperty("event", "failed");
+        obj.addProperty("reason", reason);
+        return obj.toString();
+    }
+
+    private static void writeLine(OutputStream out, String json) {
+        try {
+            out.write(json.getBytes(StandardCharsets.UTF_8));
+            out.write('\n');
+            out.flush();
+        } catch (IOException e) {
+            throw new StreamClosedException(e);
+        } catch (UncheckedIOException e) {
+            throw new StreamClosedException(
+                    e.getCause() instanceof IOException io
+                            ? io : new IOException(e));
+        }
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -18,6 +18,21 @@ import io.github.kaluchi.jdtbridge.ProjectScope;
  */
 class CoverageRouter {
 
+    private final CoverageTracker tracker = new CoverageTracker();
+
+    void start() {
+        tracker.start();
+    }
+
+    void stop() {
+        tracker.stop();
+    }
+
+    /** Test/inspection accessor. */
+    CoverageTracker tracker() {
+        return tracker;
+    }
+
     String dispatch(String path, Map<String, String> params,
             String body, ProjectScope scope) {
         return switch (path) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -11,10 +11,6 @@ import io.github.kaluchi.jdtbridge.ProjectScope;
  * {@link CoverageBridge#isAvailable()} is true. Owns the lazy
  * lifecycle of every coverage-side stateful component
  * (tracker, analyzer, handlers, streamer).
- * <p>
- * Phase 1 only knows the path list — every endpoint returns the
- * stub {@link #notImplemented(String)} JSON. Subsequent phases
- * replace each branch with a real handler call.
  */
 class CoverageRouter {
 
@@ -71,15 +67,6 @@ class CoverageRouter {
                     sessionHandler.handleRemove(body);
             default -> unknownPath(path);
         };
-    }
-
-    /** Stub response while the corresponding handler is not yet
-     *  wired in. Replaced phase by phase as handlers land. */
-    private static String notImplemented(String path) {
-        var obj = new JsonObject();
-        obj.addProperty("error", "coverage-not-implemented");
-        obj.addProperty("path", path);
-        return obj.toString();
     }
 
     private static String unknownPath(String path) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -1,0 +1,53 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+
+import io.github.kaluchi.jdtbridge.ProjectScope;
+
+/**
+ * Internal {@code /coverage/*} dispatcher. Loaded only when
+ * {@link CoverageBridge#isAvailable()} is true. Owns the lazy
+ * lifecycle of every coverage-side stateful component
+ * (tracker, analyzer, handlers, streamer).
+ * <p>
+ * Phase 1 only knows the path list — every endpoint returns the
+ * stub {@link #notImplemented(String)} JSON. Subsequent phases
+ * replace each branch with a real handler call.
+ */
+class CoverageRouter {
+
+    String dispatch(String path, Map<String, String> params,
+            String body, ProjectScope scope) {
+        return switch (path) {
+            case "/coverage/run" -> notImplemented(path);
+            case "/coverage/dump" -> notImplemented(path);
+            case "/coverage/refresh" -> notImplemented(path);
+            case "/coverage/relaunch" -> notImplemented(path);
+            case "/coverage/runs" -> notImplemented(path);
+            case "/coverage/session" -> notImplemented(path);
+            case "/coverage/active" -> notImplemented(path);
+            case "/coverage/activate" -> notImplemented(path);
+            case "/coverage/merge" -> notImplemented(path);
+            case "/coverage/remove" -> notImplemented(path);
+            default -> unknownPath(path);
+        };
+    }
+
+    /** Stub response while the corresponding handler is not yet
+     *  wired in. Replaced phase by phase as handlers land. */
+    private static String notImplemented(String path) {
+        var obj = new JsonObject();
+        obj.addProperty("error", "coverage-not-implemented");
+        obj.addProperty("path", path);
+        return obj.toString();
+    }
+
+    private static String unknownPath(String path) {
+        var obj = new JsonObject();
+        obj.addProperty("error", "coverage-unknown-path");
+        obj.addProperty("path", path);
+        return obj.toString();
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -19,6 +19,7 @@ import io.github.kaluchi.jdtbridge.ProjectScope;
 class CoverageRouter {
 
     private final CoverageTracker tracker = new CoverageTracker();
+    private final CoverageHandler handler = new CoverageHandler(tracker);
 
     void start() {
         tracker.start();
@@ -33,13 +34,18 @@ class CoverageRouter {
         return tracker;
     }
 
+    /** Test/inspection accessor. */
+    CoverageHandler handler() {
+        return handler;
+    }
+
     String dispatch(String path, Map<String, String> params,
             String body, ProjectScope scope) {
         return switch (path) {
-            case "/coverage/run" -> notImplemented(path);
-            case "/coverage/dump" -> notImplemented(path);
-            case "/coverage/refresh" -> notImplemented(path);
-            case "/coverage/relaunch" -> notImplemented(path);
+            case "/coverage/run" -> handler.handleRun(params);
+            case "/coverage/dump" -> handler.handleDump(body);
+            case "/coverage/refresh" -> handler.handleRefresh();
+            case "/coverage/relaunch" -> handler.handleRelaunch();
             case "/coverage/runs" -> notImplemented(path);
             case "/coverage/session" -> notImplemented(path);
             case "/coverage/active" -> notImplemented(path);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -18,7 +18,8 @@ import io.github.kaluchi.jdtbridge.ProjectScope;
  */
 class CoverageRouter {
 
-    private final CoverageTracker tracker = new CoverageTracker();
+    private final CoverageAnalyzer analyzer = new CoverageAnalyzer();
+    private final CoverageTracker tracker = new CoverageTracker(analyzer);
     private final CoverageHandler handler = new CoverageHandler(tracker);
 
     void start() {
@@ -27,6 +28,7 @@ class CoverageRouter {
 
     void stop() {
         tracker.stop();
+        analyzer.clear();
     }
 
     /** Test/inspection accessor. */
@@ -37,6 +39,11 @@ class CoverageRouter {
     /** Test/inspection accessor. */
     CoverageHandler handler() {
         return handler;
+    }
+
+    /** Test/inspection accessor. */
+    CoverageAnalyzer analyzer() {
+        return analyzer;
     }
 
     String dispatch(String path, Map<String, String> params,

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -21,6 +21,8 @@ class CoverageRouter {
     private final CoverageAnalyzer analyzer = new CoverageAnalyzer();
     private final CoverageTracker tracker = new CoverageTracker(analyzer);
     private final CoverageHandler handler = new CoverageHandler(tracker);
+    private final CoverageSessionHandler sessionHandler =
+            new CoverageSessionHandler(tracker, analyzer);
 
     void start() {
         tracker.start();
@@ -46,6 +48,11 @@ class CoverageRouter {
         return analyzer;
     }
 
+    /** Test/inspection accessor. */
+    CoverageSessionHandler sessionHandler() {
+        return sessionHandler;
+    }
+
     String dispatch(String path, Map<String, String> params,
             String body, ProjectScope scope) {
         return switch (path) {
@@ -53,12 +60,15 @@ class CoverageRouter {
             case "/coverage/dump" -> handler.handleDump(body);
             case "/coverage/refresh" -> handler.handleRefresh();
             case "/coverage/relaunch" -> handler.handleRelaunch();
-            case "/coverage/runs" -> notImplemented(path);
-            case "/coverage/session" -> notImplemented(path);
-            case "/coverage/active" -> notImplemented(path);
-            case "/coverage/activate" -> notImplemented(path);
-            case "/coverage/merge" -> notImplemented(path);
-            case "/coverage/remove" -> notImplemented(path);
+            case "/coverage/runs" -> sessionHandler.handleRuns(scope);
+            case "/coverage/session" ->
+                    sessionHandler.handleSession(params);
+            case "/coverage/active" -> sessionHandler.handleActive();
+            case "/coverage/activate" ->
+                    sessionHandler.handleActivate(body);
+            case "/coverage/merge" -> sessionHandler.handleMerge(body);
+            case "/coverage/remove" ->
+                    sessionHandler.handleRemove(body);
             default -> unknownPath(path);
         };
     }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRun.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRun.java
@@ -1,0 +1,163 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+/**
+ * Bridge-side view of one coverage run. Exactly one entry per
+ * {@code coverageId} in {@link CoverageTracker#runs}.
+ * <p>
+ * For {@link Kind#LIVE} a run is created at
+ * {@code launchesAdded(CoverageLaunch)}, accumulates one
+ * {@link ICoverageSession} per {@code requestDump}, and stays around
+ * until every session is explicitly removed.
+ * <p>
+ * For {@link Kind#MERGED} and {@link Kind#IMPORTED} a run holds
+ * exactly one session and is created at the {@code sessionAdded}
+ * that produced it.
+ */
+final class CoverageRun {
+
+    enum Kind {
+        LIVE("live"),
+        MERGED("merged"),
+        IMPORTED("imported");
+
+        private final String wireName;
+
+        Kind(String wireName) {
+            this.wireName = wireName;
+        }
+
+        String wireName() {
+            return wireName;
+        }
+    }
+
+    final String coverageId;
+    final Kind kind;
+    final String configId;
+    final String configType;
+    final String configTypeId;
+    /** Live launch handle — {@code null} for merged/imported. */
+    final ILaunch launch;
+    /** {@code ATTR_LAUNCH_TIMESTAMP} parsed to long for live;
+     *  {@code null} for merged/imported. */
+    final Long launchTimestamp;
+    /** Wall-clock millis at which this run was first seen by the
+     *  bridge. For live runs that's {@code launchesAdded}; for
+     *  merged/imported it's {@code sessionAdded}. */
+    final long createdAtMillis;
+
+    /** {@link IPackageFragmentRoot} set defining the run's scope.
+     *  Stable over the run's lifetime. */
+    volatile Set<IPackageFragmentRoot> coverageScope;
+
+    /** All sessions that belong to this run, latest last. Live runs
+     *  grow this list per dump; merged/imported runs hold exactly
+     *  one element. */
+    final List<ICoverageSession> sessions = new CopyOnWriteArrayList<>();
+    /** Wall-clock millis per session in {@link #sessions}, same
+     *  index. */
+    final List<Long> dumpedAt = new CopyOnWriteArrayList<>();
+
+    /** Coverage IDs of inputs consumed by a {@code merged} run.
+     *  Empty for live/imported. */
+    final List<String> consumedCoverageIds = new ArrayList<>();
+
+    /** Latest {@link ICoverageSession#getDescription()} — live runs
+     *  refresh on every dump, merged/imported keep the original. */
+    volatile String description;
+
+    volatile boolean terminated;
+    volatile boolean dataReceived;
+    volatile boolean analysisLoading;
+    volatile boolean analysisReady;
+    /** Wall-clock millis the run terminated; {@code null} while
+     *  still running. */
+    volatile Long terminatedAt;
+
+    private CoverageRun(String coverageId, Kind kind, String configId,
+            String configType, String configTypeId, ILaunch launch,
+            Long launchTimestamp, long createdAtMillis,
+            Set<IPackageFragmentRoot> coverageScope, String description) {
+        this.coverageId = coverageId;
+        this.kind = kind;
+        this.configId = configId;
+        this.configType = configType;
+        this.configTypeId = configTypeId;
+        this.launch = launch;
+        this.launchTimestamp = launchTimestamp;
+        this.createdAtMillis = createdAtMillis;
+        this.coverageScope = coverageScope;
+        this.description = description;
+    }
+
+    static CoverageRun live(String coverageId, String configId,
+            String configType, String configTypeId, ILaunch launch,
+            long launchTimestamp,
+            Set<IPackageFragmentRoot> coverageScope) {
+        long now = System.currentTimeMillis();
+        CoverageRun run = new CoverageRun(coverageId, Kind.LIVE, configId,
+                configType, configTypeId, launch, launchTimestamp, now,
+                coverageScope, null);
+        run.terminated = false;
+        run.dataReceived = false;
+        return run;
+    }
+
+    static CoverageRun merged(String coverageId, String configId,
+            String configType, String configTypeId,
+            Set<IPackageFragmentRoot> coverageScope, String description,
+            List<String> consumedCoverageIds) {
+        long now = System.currentTimeMillis();
+        CoverageRun run = new CoverageRun(coverageId, Kind.MERGED, configId,
+                configType, configTypeId, null, null, now,
+                coverageScope, description);
+        run.terminated = true;
+        run.dataReceived = true;
+        run.terminatedAt = now;
+        run.consumedCoverageIds.addAll(consumedCoverageIds);
+        return run;
+    }
+
+    static CoverageRun imported(String coverageId,
+            Set<IPackageFragmentRoot> coverageScope, String description) {
+        long now = System.currentTimeMillis();
+        CoverageRun run = new CoverageRun(coverageId, Kind.IMPORTED, null,
+                null, null, null, null, now,
+                coverageScope, description);
+        run.terminated = true;
+        run.dataReceived = true;
+        run.terminatedAt = now;
+        return run;
+    }
+
+    int dumpCount() {
+        return sessions.size();
+    }
+
+    /** Resolves the {@link ICoverageSession} for a {@code :N} dump
+     *  suffix on the coverage ID, where {@code N} is 1-based.
+     *  Without a suffix returns the latest dump (or the only
+     *  session for merged/imported). */
+    ICoverageSession resolveSession(Integer dumpIndex) {
+        if (sessions.isEmpty()) {
+            return null;
+        }
+        if (dumpIndex == null) {
+            return sessions.get(sessions.size() - 1);
+        }
+        int zero = dumpIndex - 1;
+        if (zero < 0 || zero >= sessions.size()) {
+            return null;
+        }
+        return sessions.get(zero);
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -62,11 +62,15 @@ class CoverageSessionHandler {
      *  filtered by {@link ProjectScope}. */
     String handleRuns(ProjectScope scope) {
         var arr = new JsonArray();
+        String activeCoverageId = tracker.activeCoverageId();
         for (CoverageRun run : tracker.snapshot().values()) {
             if (!inScope(run, scope)) {
                 continue;
             }
-            arr.add(runEntry(run));
+            JsonObject entry = runEntry(run);
+            entry.addProperty("active",
+                    run.coverageId.equals(activeCoverageId));
+            arr.add(entry);
         }
         return arr.toString();
     }
@@ -86,7 +90,10 @@ class CoverageSessionHandler {
         Integer dumpIndex = parseDumpIndex(coverageId);
         ICoverageSession session = run.resolveSession(dumpIndex);
         if (session == null) {
-            return error("coverage-dump-not-found", coverageId);
+            if (dumpIndex != null) {
+                return error("coverage-dump-not-found", coverageId);
+            }
+            return runEntry(run).toString();
         }
         JsonObject entry = runEntry(run);
         try {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -13,13 +13,19 @@ import org.eclipse.eclemma.core.ICoverageSession;
 import org.eclipse.eclemma.core.ISessionManager;
 import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.data.SessionInfo;
+
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.addNullableLong;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.addNullableString;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.countersOf;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.error;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.optBool;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.optString;
+import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.parseObjectBody;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import io.github.kaluchi.jdtbridge.ProjectScope;
 
@@ -87,7 +93,7 @@ class CoverageSessionHandler {
             CoverageAnalyzer.CachedAnalysis ca =
                     analyzer.ensureAnalyzed(session);
             entry.add("counters",
-                    countersJson(ca.modelCoverage));
+                    countersOf(ca.modelCoverage));
             entry.add("jacocoSessionInfos",
                     sessionInfosJson(ca.jacocoSessionInfos));
         } catch (CoreException e) {
@@ -101,19 +107,14 @@ class CoverageSessionHandler {
      *  or {@code null}. */
     String handleActive() {
         var obj = new JsonObject();
-        String activeId = tracker.activeCoverageId();
-        if (activeId != null) {
-            obj.addProperty("activeCoverageId", activeId);
-        } else {
-            obj.add("activeCoverageId",
-                    com.google.gson.JsonNull.INSTANCE);
-        }
+        addNullableString(obj, "activeCoverageId",
+                tracker.activeCoverageId());
         return obj.toString();
     }
 
     /** {@code POST /coverage/activate} body {@code {coverageId}}. */
     String handleActivate(String requestBody) {
-        JsonObject body = parseBody(requestBody);
+        JsonObject body = parseObjectBody(requestBody);
         if (body == null) {
             return error("coverage-not-found",
                     "Missing or invalid request body");
@@ -137,19 +138,14 @@ class CoverageSessionHandler {
         var obj = new JsonObject();
         obj.addProperty("ok", true);
         obj.addProperty("activeCoverageId", run.coverageId);
-        if (previous != null) {
-            obj.addProperty("previousActiveCoverageId", previous);
-        } else {
-            obj.add("previousActiveCoverageId",
-                    com.google.gson.JsonNull.INSTANCE);
-        }
+        addNullableString(obj, "previousActiveCoverageId", previous);
         return obj.toString();
     }
 
     /** {@code POST /coverage/merge} body
      *  {@code {coverageIds, description}}. */
     String handleMerge(String requestBody) {
-        JsonObject body = parseBody(requestBody);
+        JsonObject body = parseObjectBody(requestBody);
         if (body == null) {
             return error("coverage-not-found",
                     "Missing or invalid request body");
@@ -218,7 +214,7 @@ class CoverageSessionHandler {
     /** {@code POST /coverage/remove} — body {@code {}} removes
      *  the active session, body {@code {all: true}} removes all. */
     String handleRemove(String requestBody) {
-        JsonObject body = parseBody(requestBody);
+        JsonObject body = parseObjectBody(requestBody);
         boolean all = body != null && optBool(body, "all", false);
         ISessionManager sm = CoverageTools.getSessionManager();
         List<String> removed = new ArrayList<>();
@@ -266,12 +262,9 @@ class CoverageSessionHandler {
         addNullableString(obj, "configType", run.configType);
         addNullableString(obj, "configTypeId", run.configTypeId);
 
-        if (run.launch != null && run.kind == CoverageRun.Kind.LIVE) {
-            obj.addProperty("launchId", buildLaunchId(run));
-        } else {
-            obj.add("launchId",
-                    com.google.gson.JsonNull.INSTANCE);
-        }
+        addNullableString(obj, "launchId",
+                run.launch != null && run.kind == CoverageRun.Kind.LIVE
+                        ? buildLaunchId(run) : null);
 
         obj.addProperty("description", run.description != null
                 ? run.description : "");
@@ -295,18 +288,8 @@ class CoverageSessionHandler {
         obj.addProperty("analysisLoading", run.analysisLoading);
         obj.addProperty("analysisReady", run.analysisReady);
 
-        if (run.launchTimestamp != null) {
-            obj.addProperty("launchTimestamp", run.launchTimestamp);
-        } else {
-            obj.add("launchTimestamp",
-                    com.google.gson.JsonNull.INSTANCE);
-        }
-        if (run.terminatedAt != null) {
-            obj.addProperty("terminatedAt", run.terminatedAt);
-        } else {
-            obj.add("terminatedAt",
-                    com.google.gson.JsonNull.INSTANCE);
-        }
+        addNullableLong(obj, "launchTimestamp", run.launchTimestamp);
+        addNullableLong(obj, "terminatedAt", run.terminatedAt);
 
         if (run.kind == CoverageRun.Kind.MERGED
                 && !run.consumedCoverageIds.isEmpty()) {
@@ -331,56 +314,6 @@ class CoverageSessionHandler {
             }
         }
         return run.configId;
-    }
-
-    private static JsonObject countersJson(IJavaModelCoverage cov) {
-        var obj = new JsonObject();
-        if (cov == null) {
-            return obj;
-        }
-        obj.add("instruction",
-                counterJson(cov.getInstructionCounter()));
-        obj.add("branch", counterJson(cov.getBranchCounter()));
-        obj.add("line", counterJson(cov.getLineCounter()));
-        obj.add("complexity",
-                counterJson(cov.getComplexityCounter()));
-        obj.add("method", counterJson(cov.getMethodCounter()));
-        obj.add("class", counterJson(cov.getClassCounter()));
-        return obj;
-    }
-
-    private static JsonObject counterJson(ICounter counter) {
-        var obj = new JsonObject();
-        if (counter == null) {
-            return obj;
-        }
-        obj.addProperty("coveredCount", counter.getCoveredCount());
-        obj.addProperty("missedCount", counter.getMissedCount());
-        obj.addProperty("totalCount", counter.getTotalCount());
-        addRatio(obj, "coveredRatio", counter.getCoveredRatio());
-        addRatio(obj, "missedRatio", counter.getMissedRatio());
-        obj.addProperty("coverageStatus",
-                statusName(counter.getStatus()));
-        return obj;
-    }
-
-    private static void addRatio(JsonObject obj, String key,
-            double value) {
-        if (Double.isNaN(value)) {
-            obj.add(key, com.google.gson.JsonNull.INSTANCE);
-        } else {
-            obj.addProperty(key, value);
-        }
-    }
-
-    private static String statusName(int status) {
-        return switch (status) {
-            case ICounter.EMPTY -> "EMPTY";
-            case ICounter.NOT_COVERED -> "NOT_COVERED";
-            case ICounter.FULLY_COVERED -> "FULLY_COVERED";
-            case ICounter.PARTLY_COVERED -> "PARTLY_COVERED";
-            default -> "UNKNOWN_" + status;
-        };
     }
 
     private static JsonArray sessionInfosJson(
@@ -443,52 +376,6 @@ class CoverageSessionHandler {
             return null;
         }
         return (int) parsed;
-    }
-
-    private static void addNullableString(JsonObject obj,
-            String key, String value) {
-        if (value == null) {
-            obj.add(key, com.google.gson.JsonNull.INSTANCE);
-        } else {
-            obj.addProperty(key, value);
-        }
-    }
-
-    private static String error(String kind, String message) {
-        var obj = new JsonObject();
-        obj.addProperty("error", kind);
-        if (message != null && !message.isEmpty()) {
-            obj.addProperty("message", message);
-        }
-        return obj.toString();
-    }
-
-    private static JsonObject parseBody(String body) {
-        if (body == null || body.isBlank()) {
-            return null;
-        }
-        try {
-            JsonElement parsed = JsonParser.parseString(body);
-            if (parsed.isJsonObject()) {
-                return parsed.getAsJsonObject();
-            }
-        } catch (com.google.gson.JsonParseException e) {
-            return null;
-        }
-        return null;
-    }
-
-    private static String optString(JsonObject body, String key) {
-        JsonElement el = body.get(key);
-        return el != null && !el.isJsonNull()
-                ? el.getAsString() : null;
-    }
-
-    private static boolean optBool(JsonObject body, String key,
-            boolean defaultValue) {
-        JsonElement el = body.get(key);
-        return el != null && !el.isJsonNull()
-                ? el.getAsBoolean() : defaultValue;
     }
 
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -304,16 +304,8 @@ class CoverageSessionHandler {
     }
 
     private static String buildLaunchId(CoverageRun run) {
-        var procs = run.launch.getProcesses();
-        if (procs.length > 0) {
-            String pid = procs[0].getAttribute(
-                    org.eclipse.debug.core.model.IProcess
-                            .ATTR_PROCESS_ID);
-            if (pid != null) {
-                return run.configId + ":" + pid;
-            }
-        }
-        return run.configId;
+        return io.github.kaluchi.jdtbridge.LaunchAttrs
+                .launchIdOf(run.configId, run.launch);
     }
 
     private static JsonArray sessionInfosJson(

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -3,7 +3,6 @@ package io.github.kaluchi.jdtbridge.coverage;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.eclipse.eclemma.core.ISessionManager;
 import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.jacoco.core.analysis.ICounter;
-import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.data.SessionInfo;
 
 import com.google.gson.JsonArray;
@@ -189,32 +187,32 @@ class CoverageSessionHandler {
                     new Object[] { new Date() });
         }
         ISessionManager sm = CoverageTools.getSessionManager();
+        ICoverageSession merged;
         try {
-            ICoverageSession merged = sm.mergeSessions(inputs,
-                    description, new NullProgressMonitor());
-            // Wait for the deferred classification to settle so the
-            // tracker has the merged run indexed before responding.
-            org.eclipse.core.runtime.jobs.Job.getJobManager().join(
-                    CoverageTracker.CLASSIFY_FAMILY,
+            merged = sm.mergeSessions(inputs, description,
                     new NullProgressMonitor());
-            String mergedCoverageId = findCoverageIdFor(merged);
-            var obj = new JsonObject();
-            obj.addProperty("ok", true);
-            obj.addProperty("mergedCoverageId", mergedCoverageId);
-            JsonArray consumed = new JsonArray();
-            for (JsonElement el : inputArr) {
-                consumed.add(el.getAsString());
-            }
-            obj.add("consumedCoverageIds", consumed);
-            obj.addProperty("active", true);
-            return obj.toString();
-        } catch (CoreException | InterruptedException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (CoreException e) {
             return error("coverage-launch-failed",
                     "Merge failed: " + e.getMessage());
         }
+        try {
+            org.eclipse.core.runtime.jobs.Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY,
+                    new NullProgressMonitor());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        String mergedCoverageId = findCoverageIdFor(merged);
+        var obj = new JsonObject();
+        obj.addProperty("ok", true);
+        obj.addProperty("mergedCoverageId", mergedCoverageId);
+        JsonArray consumed = new JsonArray();
+        for (JsonElement el : inputArr) {
+            consumed.add(el.getAsString());
+        }
+        obj.add("consumedCoverageIds", consumed);
+        obj.addProperty("active", true);
+        return obj.toString();
     }
 
     /** {@code POST /coverage/remove} — body {@code {}} removes
@@ -474,8 +472,8 @@ class CoverageSessionHandler {
             if (parsed.isJsonObject()) {
                 return parsed.getAsJsonObject();
             }
-        } catch (Exception e) {
-            // fall through
+        } catch (com.google.gson.JsonParseException e) {
+            return null;
         }
         return null;
     }
@@ -493,25 +491,4 @@ class CoverageSessionHandler {
                 ? el.getAsBoolean() : defaultValue;
     }
 
-    /** Static accessor used by {@link CoverageRouter} so existing
-     *  helpers stay package-private. */
-    static String mergeDescriptionTemplate() {
-        return MERGE_DESC_TEMPLATE;
-    }
-
-    /** Test/inspection accessor — count the keys an entry would
-     *  emit. Used to keep wire-shape regression tests honest. */
-    static Map<String, Object> sampleEntryShape() {
-        // Reflects the keys runEntry emits — keep in sync.
-        return new LinkedHashMap<>(Map.of(
-                "coverageId", "",
-                "coverageSessionKind", "",
-                "configId", "",
-                "configType", "",
-                "configTypeId", "",
-                "launchId", "",
-                "description", "",
-                "coverageScope", new JsonArray(),
-                "dumpCount", 0));
-    }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -1,0 +1,498 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.ISessionManager;
+import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode;
+import org.jacoco.core.data.SessionInfo;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.github.kaluchi.jdtbridge.ProjectScope;
+
+/**
+ * HTTP handlers for the read / list / mutating-on-state
+ * {@code /coverage/*} endpoints: {@code /runs}, {@code /session},
+ * {@code /active}, {@code /activate}, {@code /merge},
+ * {@code /remove}.
+ * <p>
+ * Mutation against a running launch (run / dump / refresh /
+ * relaunch) lives in {@link CoverageHandler}; streaming lives in
+ * {@link CoverageProgressStreamer}.
+ */
+class CoverageSessionHandler {
+
+    /** Same template as EclEmma's
+     *  {@code MergeSessionsDialogDescriptionDefault_value}
+     *  ({@code uimessages.properties:59}). Mirrors what the GUI
+     *  injects when the user clicks Merge Sessions… without
+     *  editing the description field. */
+    private static final String MERGE_DESC_TEMPLATE =
+            "Merged ({0,date,medium} {0,time,medium})";
+
+    private final CoverageTracker tracker;
+    private final CoverageAnalyzer analyzer;
+
+    CoverageSessionHandler(CoverageTracker tracker,
+            CoverageAnalyzer analyzer) {
+        this.tracker = tracker;
+        this.analyzer = analyzer;
+    }
+
+    /** {@code GET /coverage/runs} — list every tracked run,
+     *  filtered by {@link ProjectScope}. */
+    String handleRuns(ProjectScope scope) {
+        var arr = new JsonArray();
+        for (CoverageRun run : tracker.snapshot().values()) {
+            if (!inScope(run, scope)) {
+                continue;
+            }
+            arr.add(runEntry(run));
+        }
+        return arr.toString();
+    }
+
+    /** {@code GET /coverage/session?coverageId=...} — full entry
+     *  including counters and JaCoCo session-info list. */
+    String handleSession(Map<String, String> params) {
+        String coverageId = params.get("coverageId");
+        if (coverageId == null || coverageId.isBlank()) {
+            return error("coverage-not-found",
+                    "Missing 'coverageId' parameter");
+        }
+        CoverageRun run = tracker.byCoverageId(coverageId);
+        if (run == null) {
+            return error("coverage-not-found", coverageId);
+        }
+        Integer dumpIndex = parseDumpIndex(coverageId);
+        ICoverageSession session = run.resolveSession(dumpIndex);
+        if (session == null) {
+            return error("coverage-dump-not-found", coverageId);
+        }
+        JsonObject entry = runEntry(run);
+        try {
+            CoverageAnalyzer.CachedAnalysis ca =
+                    analyzer.ensureAnalyzed(session);
+            entry.add("counters",
+                    countersJson(ca.modelCoverage));
+            entry.add("jacocoSessionInfos",
+                    sessionInfosJson(ca.jacocoSessionInfos));
+        } catch (CoreException e) {
+            return error("coverage-analysis-failed",
+                    e.getMessage());
+        }
+        return entry.toString();
+    }
+
+    /** {@code GET /coverage/active} — id of the active session,
+     *  or {@code null}. */
+    String handleActive() {
+        var obj = new JsonObject();
+        String activeId = tracker.activeCoverageId();
+        if (activeId != null) {
+            obj.addProperty("activeCoverageId", activeId);
+        } else {
+            obj.add("activeCoverageId",
+                    com.google.gson.JsonNull.INSTANCE);
+        }
+        return obj.toString();
+    }
+
+    /** {@code POST /coverage/activate} body {@code {coverageId}}. */
+    String handleActivate(String requestBody) {
+        JsonObject body = parseBody(requestBody);
+        if (body == null) {
+            return error("coverage-not-found",
+                    "Missing or invalid request body");
+        }
+        String coverageId = optString(body, "coverageId");
+        if (coverageId == null || coverageId.isBlank()) {
+            return error("coverage-not-found",
+                    "Missing 'coverageId' in body");
+        }
+        CoverageRun run = tracker.byCoverageId(coverageId);
+        if (run == null) {
+            return error("coverage-not-found", coverageId);
+        }
+        Integer dumpIndex = parseDumpIndex(coverageId);
+        ICoverageSession target = run.resolveSession(dumpIndex);
+        if (target == null) {
+            return error("coverage-dump-not-found", coverageId);
+        }
+        String previous = tracker.activeCoverageId();
+        CoverageTools.getSessionManager().activateSession(target);
+        var obj = new JsonObject();
+        obj.addProperty("ok", true);
+        obj.addProperty("activeCoverageId", run.coverageId);
+        if (previous != null) {
+            obj.addProperty("previousActiveCoverageId", previous);
+        } else {
+            obj.add("previousActiveCoverageId",
+                    com.google.gson.JsonNull.INSTANCE);
+        }
+        return obj.toString();
+    }
+
+    /** {@code POST /coverage/merge} body
+     *  {@code {coverageIds, description}}. */
+    String handleMerge(String requestBody) {
+        JsonObject body = parseBody(requestBody);
+        if (body == null) {
+            return error("coverage-not-found",
+                    "Missing or invalid request body");
+        }
+        JsonElement arrEl = body.get("coverageIds");
+        if (arrEl == null || !arrEl.isJsonArray()) {
+            return error("coverage-merge-too-few-inputs",
+                    "Missing 'coverageIds' array in body");
+        }
+        JsonArray inputArr = arrEl.getAsJsonArray();
+        if (inputArr.size() < 2) {
+            return error("coverage-merge-too-few-inputs",
+                    "Need at least 2 inputs, got " + inputArr.size());
+        }
+        List<ICoverageSession> inputs = new ArrayList<>();
+        for (JsonElement el : inputArr) {
+            String id = el.getAsString();
+            CoverageRun run = tracker.byCoverageId(id);
+            if (run == null) {
+                JsonObject err = new JsonObject();
+                err.addProperty("error", "coverage-not-found");
+                err.addProperty("message",
+                        "Unknown coverageId: " + id);
+                JsonObject ctx = new JsonObject();
+                ctx.addProperty("missing", id);
+                err.add("context", ctx);
+                return err.toString();
+            }
+            inputs.addAll(run.sessions);
+        }
+        String description = optString(body, "description");
+        if (description == null || description.isBlank()) {
+            description = MessageFormat.format(
+                    MERGE_DESC_TEMPLATE,
+                    new Object[] { new Date() });
+        }
+        ISessionManager sm = CoverageTools.getSessionManager();
+        try {
+            ICoverageSession merged = sm.mergeSessions(inputs,
+                    description, new NullProgressMonitor());
+            // Wait for the deferred classification to settle so the
+            // tracker has the merged run indexed before responding.
+            org.eclipse.core.runtime.jobs.Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY,
+                    new NullProgressMonitor());
+            String mergedCoverageId = findCoverageIdFor(merged);
+            var obj = new JsonObject();
+            obj.addProperty("ok", true);
+            obj.addProperty("mergedCoverageId", mergedCoverageId);
+            JsonArray consumed = new JsonArray();
+            for (JsonElement el : inputArr) {
+                consumed.add(el.getAsString());
+            }
+            obj.add("consumedCoverageIds", consumed);
+            obj.addProperty("active", true);
+            return obj.toString();
+        } catch (CoreException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return error("coverage-launch-failed",
+                    "Merge failed: " + e.getMessage());
+        }
+    }
+
+    /** {@code POST /coverage/remove} — body {@code {}} removes
+     *  the active session, body {@code {all: true}} removes all. */
+    String handleRemove(String requestBody) {
+        JsonObject body = parseBody(requestBody);
+        boolean all = body != null && optBool(body, "all", false);
+        ISessionManager sm = CoverageTools.getSessionManager();
+        List<String> removed = new ArrayList<>();
+        if (all) {
+            for (CoverageRun run : tracker.snapshot().values()) {
+                removed.add(run.coverageId);
+            }
+            sm.removeAllSessions();
+        } else {
+            ICoverageSession active = sm.getActiveSession();
+            if (active == null) {
+                return error("coverage-no-active-session",
+                        "No active coverage session");
+            }
+            String activeId = tracker.activeCoverageId();
+            if (activeId != null) {
+                removed.add(activeId);
+            }
+            sm.removeSession(active);
+        }
+        var obj = new JsonObject();
+        obj.addProperty("ok", true);
+        JsonArray arr = new JsonArray();
+        for (String id : removed) {
+            arr.add(id);
+        }
+        obj.add("removedCoverageIds", arr);
+        return obj.toString();
+    }
+
+    // -- helpers --
+
+    private boolean inScope(CoverageRun run, ProjectScope scope) {
+        if (run.kind == CoverageRun.Kind.LIVE && run.launch != null) {
+            return scope.containsLaunch(run.launch);
+        }
+        return scope.containsAnyOfRoots(run.coverageScope);
+    }
+
+    private static JsonObject runEntry(CoverageRun run) {
+        var obj = new JsonObject();
+        obj.addProperty("coverageId", run.coverageId);
+        obj.addProperty("coverageSessionKind", run.kind.wireName());
+        addNullableString(obj, "configId", run.configId);
+        addNullableString(obj, "configType", run.configType);
+        addNullableString(obj, "configTypeId", run.configTypeId);
+
+        if (run.launch != null && run.kind == CoverageRun.Kind.LIVE) {
+            obj.addProperty("launchId", buildLaunchId(run));
+        } else {
+            obj.add("launchId",
+                    com.google.gson.JsonNull.INSTANCE);
+        }
+
+        obj.addProperty("description", run.description != null
+                ? run.description : "");
+
+        JsonArray scopeArr = new JsonArray();
+        for (IPackageFragmentRoot root : run.coverageScope) {
+            scopeArr.add(root.getHandleIdentifier());
+        }
+        obj.add("coverageScope", scopeArr);
+
+        obj.addProperty("dumpCount", run.dumpCount());
+
+        if (run.kind == CoverageRun.Kind.LIVE) {
+            obj.addProperty("terminated",
+                    run.launch != null
+                            ? run.launch.isTerminated() : true);
+        } else {
+            obj.addProperty("terminated", true);
+        }
+        obj.addProperty("dataReceived", run.dataReceived);
+        obj.addProperty("analysisLoading", run.analysisLoading);
+        obj.addProperty("analysisReady", run.analysisReady);
+
+        if (run.launchTimestamp != null) {
+            obj.addProperty("launchTimestamp", run.launchTimestamp);
+        } else {
+            obj.add("launchTimestamp",
+                    com.google.gson.JsonNull.INSTANCE);
+        }
+        if (run.terminatedAt != null) {
+            obj.addProperty("terminatedAt", run.terminatedAt);
+        } else {
+            obj.add("terminatedAt",
+                    com.google.gson.JsonNull.INSTANCE);
+        }
+
+        if (run.kind == CoverageRun.Kind.MERGED
+                && !run.consumedCoverageIds.isEmpty()) {
+            JsonArray consumed = new JsonArray();
+            for (String id : run.consumedCoverageIds) {
+                consumed.add(id);
+            }
+            obj.add("consumedCoverageIds", consumed);
+        }
+
+        return obj;
+    }
+
+    private static String buildLaunchId(CoverageRun run) {
+        var procs = run.launch.getProcesses();
+        if (procs.length > 0) {
+            String pid = procs[0].getAttribute(
+                    org.eclipse.debug.core.model.IProcess
+                            .ATTR_PROCESS_ID);
+            if (pid != null) {
+                return run.configId + ":" + pid;
+            }
+        }
+        return run.configId;
+    }
+
+    private static JsonObject countersJson(IJavaModelCoverage cov) {
+        var obj = new JsonObject();
+        if (cov == null) {
+            return obj;
+        }
+        obj.add("instruction",
+                counterJson(cov.getInstructionCounter()));
+        obj.add("branch", counterJson(cov.getBranchCounter()));
+        obj.add("line", counterJson(cov.getLineCounter()));
+        obj.add("complexity",
+                counterJson(cov.getComplexityCounter()));
+        obj.add("method", counterJson(cov.getMethodCounter()));
+        obj.add("class", counterJson(cov.getClassCounter()));
+        return obj;
+    }
+
+    private static JsonObject counterJson(ICounter counter) {
+        var obj = new JsonObject();
+        if (counter == null) {
+            return obj;
+        }
+        obj.addProperty("coveredCount", counter.getCoveredCount());
+        obj.addProperty("missedCount", counter.getMissedCount());
+        obj.addProperty("totalCount", counter.getTotalCount());
+        addRatio(obj, "coveredRatio", counter.getCoveredRatio());
+        addRatio(obj, "missedRatio", counter.getMissedRatio());
+        obj.addProperty("coverageStatus",
+                statusName(counter.getStatus()));
+        return obj;
+    }
+
+    private static void addRatio(JsonObject obj, String key,
+            double value) {
+        if (Double.isNaN(value)) {
+            obj.add(key, com.google.gson.JsonNull.INSTANCE);
+        } else {
+            obj.addProperty(key, value);
+        }
+    }
+
+    private static String statusName(int status) {
+        return switch (status) {
+            case ICounter.EMPTY -> "EMPTY";
+            case ICounter.NOT_COVERED -> "NOT_COVERED";
+            case ICounter.FULLY_COVERED -> "FULLY_COVERED";
+            case ICounter.PARTLY_COVERED -> "PARTLY_COVERED";
+            default -> "UNKNOWN_" + status;
+        };
+    }
+
+    private static JsonArray sessionInfosJson(
+            List<SessionInfo> infos) {
+        var arr = new JsonArray();
+        for (SessionInfo info : infos) {
+            var obj = new JsonObject();
+            obj.addProperty("jacocoSessionId", info.getId());
+            obj.addProperty("agentStartTimestamp",
+                    info.getStartTimeStamp());
+            obj.addProperty("dumpTimestamp",
+                    info.getDumpTimeStamp());
+            arr.add(obj);
+        }
+        return arr;
+    }
+
+    /** Find the {@code coverageId} the tracker assigned to a
+     *  given session. Used after {@code mergeSessions} to surface
+     *  the bridge's id in the response. */
+    private String findCoverageIdFor(ICoverageSession session) {
+        for (CoverageRun run : tracker.snapshot().values()) {
+            if (run.sessions.contains(session)) {
+                return run.coverageId;
+            }
+        }
+        return null;
+    }
+
+    private static Integer parseDumpIndex(String coverageId) {
+        if (coverageId == null) return null;
+        int colon = coverageId.lastIndexOf(':');
+        if (colon < 0) return null;
+        String tail = coverageId.substring(colon + 1);
+        if (!tail.matches("\\d+")) return null;
+        // Bare configId:launchTimestamp also matches digits — only
+        // treat as dump index when the prefix already contains a
+        // colon (i.e. there are at least two colons in the id).
+        String prefix = coverageId.substring(0, colon);
+        if (prefix.indexOf(':') < 0) {
+            return null;
+        }
+        return Integer.parseInt(tail);
+    }
+
+    private static void addNullableString(JsonObject obj,
+            String key, String value) {
+        if (value == null) {
+            obj.add(key, com.google.gson.JsonNull.INSTANCE);
+        } else {
+            obj.addProperty(key, value);
+        }
+    }
+
+    private static String error(String kind, String message) {
+        var obj = new JsonObject();
+        obj.addProperty("error", kind);
+        if (message != null && !message.isEmpty()) {
+            obj.addProperty("message", message);
+        }
+        return obj.toString();
+    }
+
+    private static JsonObject parseBody(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(body);
+            if (parsed.isJsonObject()) {
+                return parsed.getAsJsonObject();
+            }
+        } catch (Exception e) {
+            // fall through
+        }
+        return null;
+    }
+
+    private static String optString(JsonObject body, String key) {
+        JsonElement el = body.get(key);
+        return el != null && !el.isJsonNull()
+                ? el.getAsString() : null;
+    }
+
+    private static boolean optBool(JsonObject body, String key,
+            boolean defaultValue) {
+        JsonElement el = body.get(key);
+        return el != null && !el.isJsonNull()
+                ? el.getAsBoolean() : defaultValue;
+    }
+
+    /** Static accessor used by {@link CoverageRouter} so existing
+     *  helpers stay package-private. */
+    static String mergeDescriptionTemplate() {
+        return MERGE_DESC_TEMPLATE;
+    }
+
+    /** Test/inspection accessor — count the keys an entry would
+     *  emit. Used to keep wire-shape regression tests honest. */
+    static Map<String, Object> sampleEntryShape() {
+        // Reflects the keys runEntry emits — keep in sync.
+        return new LinkedHashMap<>(Map.of(
+                "coverageId", "",
+                "coverageSessionKind", "",
+                "configId", "",
+                "configType", "",
+                "configTypeId", "",
+                "launchId", "",
+                "description", "",
+                "coverageScope", new JsonArray(),
+                "dumpCount", 0));
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -412,7 +412,9 @@ class CoverageSessionHandler {
         return null;
     }
 
-    private static Integer parseDumpIndex(String coverageId) {
+    /** Package-private for unit tests of the colon-in-configId
+     *  edge cases. */
+    static Integer parseDumpIndex(String coverageId) {
         if (coverageId == null) return null;
         int colon = coverageId.lastIndexOf(':');
         if (colon < 0) return null;
@@ -425,7 +427,24 @@ class CoverageSessionHandler {
         if (prefix.indexOf(':') < 0) {
             return null;
         }
-        return Integer.parseInt(tail);
+        // Configurations with ':' in the name produce three-or-more
+        // colon ids whose tail is the launchTimestamp (13-digit
+        // millis), not a dump index. Parse via Long with explicit
+        // range guard so a timestamp doesn't overflow Integer and
+        // throw NumberFormatException — and is rejected outright as
+        // not a real dump index. A real dump count is bounded by
+        // the number of requestDump calls in one launch (single /
+        // double digits in practice; cap at MAX_INT to be safe).
+        long parsed;
+        try {
+            parsed = Long.parseLong(tail);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        if (parsed < 1 || parsed > Integer.MAX_VALUE) {
+            return null;
+        }
+        return (int) parsed;
     }
 
     private static void addNullableString(JsonObject obj,

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -82,6 +82,12 @@ final class CoverageTracker
 
     private final CoverageEventBus events = new CoverageEventBus();
 
+    /** Test/inspection accessor — lets tests drive listener
+     *  callbacks without going through real EclEmma listeners. */
+    CoverageEventBus eventBus() {
+        return events;
+    }
+
     /** Streaming-side hook. {@code on*} methods are called
      *  synchronously from the listener thread. Implementations
      *  must be non-blocking and exception-safe. */

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -94,6 +94,7 @@ final class CoverageTracker
         void onAnalysisLoading(CoverageRun run);
         void onAnalysisReady(CoverageRun run);
         void onTerminated(CoverageRun run);
+        void onFailed(CoverageRun run, String reason);
     }
 
     /** Subscribe to events for one {@code coverageId}. Multiple
@@ -168,6 +169,19 @@ final class CoverageTracker
         for (CoverageEventListener l : list) {
             try {
                 l.onTerminated(run);
+            } catch (RuntimeException e) {
+                // ignore
+            }
+        }
+    }
+
+    private void fireFailed(CoverageRun run, String reason) {
+        java.util.List<CoverageEventListener> list =
+                listeners.get(run.coverageId);
+        if (list == null) return;
+        for (CoverageEventListener l : list) {
+            try {
+                l.onFailed(run, reason);
             } catch (RuntimeException e) {
                 // ignore
             }
@@ -455,18 +469,9 @@ final class CoverageTracker
         fireDumped(run);
     }
 
-    /** Classify a deferred session once any synchronous
-     *  {@code sessionRemoved} burst has had a chance to populate
-     *  {@link PendingClassification#removedCoverageIds}. Idempotent. */
     private IStatus finalizePending(ICoverageSession session) {
-        // Lock barrier: SessionManager.getSessions() synchronizes
-        // on the same lock that the merger thread holds across the
-        // sessionAdded(merged) → N×removeSession(input) dispatch.
-        // This call blocks until that lock is released, so by the
-        // time we read pending.removedCoverageIds below the
-        // listener callbacks have already populated it. Determinism
-        // via lock acquisition replaces the earlier 50ms delay.
-        // No-op when called from the merger thread (reentrant).
+        // Lock barrier — wait for the merger's synchronized
+        // dispatch to release before reading removedCoverageIds.
         CoverageTools.getSessionManager().getSessions();
 
         PendingClassification pc = pending.remove(session);
@@ -506,17 +511,12 @@ final class CoverageTracker
         run.dumpedAt.add(now);
         runs.put(coverageId, run);
         sessionToRunId.put(session, coverageId);
-        // For merged/imported runs the kind was just decided here,
-        // so the dump-add fires now (no live launch fired it).
         fireDumped(run);
-        // sessionActivated may have fired BEFORE this deferred
-        // classification ran (SessionImporter activates the new
-        // session synchronously inside the same dispatch). Adopt
-        // the SessionManager's current active session as our
-        // active here if it matches.
         if (session.equals(
                 CoverageTools.getSessionManager().getActiveSession())) {
             activeCoverageId = coverageId;
+            applyCoverageState(run,
+                    CoverageTools.getJavaModelCoverage());
         }
         return Status.OK_STATUS;
     }
@@ -550,15 +550,19 @@ final class CoverageTracker
 
     @Override
     public void coverageChanged() {
-        String activeId = activeCoverageId;
-        if (activeId == null) {
-            return;
-        }
-        CoverageRun run = runs.get(activeId);
-        if (run == null) {
-            return;
-        }
-        IJavaModelCoverage coverage = CoverageTools.getJavaModelCoverage();
+        ICoverageSession active =
+                CoverageTools.getSessionManager().getActiveSession();
+        if (active == null) return;
+        String coverageId = sessionToRunId.get(active);
+        if (coverageId == null) return;
+        CoverageRun run = runs.get(coverageId);
+        if (run == null) return;
+        applyCoverageState(run,
+                CoverageTools.getJavaModelCoverage());
+    }
+
+    private void applyCoverageState(CoverageRun run,
+            IJavaModelCoverage coverage) {
         if (coverage == IJavaModelCoverage.LOADING) {
             run.analysisLoading = true;
             run.analysisReady = false;
@@ -566,6 +570,9 @@ final class CoverageTracker
         } else if (coverage == null) {
             run.analysisLoading = false;
             run.analysisReady = false;
+            if (!run.terminated) {
+                fireFailed(run, "analysis-cancelled");
+            }
         } else {
             run.analysisLoading = false;
             run.analysisReady = true;

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -79,11 +79,7 @@ final class CoverageTracker
      *  {@code Job.getJobManager().join(CLASSIFY_FAMILY, ...)}. */
     static final Object CLASSIFY_FAMILY = new Object();
 
-    /** Per-{@code coverageId} subscriber list for streaming
-     *  endpoints. Keyed by coverage ID without dump suffix. */
-    private final ConcurrentHashMap<String,
-            java.util.List<CoverageEventListener>> listeners =
-            new ConcurrentHashMap<>();
+    private final CoverageEventBus events = new CoverageEventBus();
 
     /** Streaming-side hook. {@code on*} methods are called
      *  synchronously from the listener thread. Implementations
@@ -97,95 +93,39 @@ final class CoverageTracker
         void onFailed(CoverageRun run, String reason);
     }
 
-    /** Subscribe to events for one {@code coverageId}. Multiple
-     *  subscribers are allowed; remove via
-     *  {@link #removeCoverageListener}. */
     void addCoverageListener(String coverageId,
             CoverageEventListener listener) {
-        listeners.computeIfAbsent(coverageId,
-                k -> new java.util.concurrent.CopyOnWriteArrayList<>())
-                .add(listener);
+        events.subscribe(coverageId, listener);
     }
 
     void removeCoverageListener(String coverageId,
             CoverageEventListener listener) {
-        java.util.List<CoverageEventListener> list =
-                listeners.get(coverageId);
-        if (list != null) {
-            list.remove(listener);
-            if (list.isEmpty()) {
-                listeners.remove(coverageId, list);
-            }
-        }
+        events.unsubscribe(coverageId, listener);
     }
 
     private void fireDumped(CoverageRun run) {
-        java.util.List<CoverageEventListener> list =
-                listeners.get(run.coverageId);
-        if (list == null) return;
         int dumpIndex = run.sessions.size();
         long dumpTimestamp = run.dumpedAt.isEmpty()
                 ? System.currentTimeMillis()
                 : run.dumpedAt.get(run.dumpedAt.size() - 1);
-        for (CoverageEventListener l : list) {
-            try {
-                l.onDumped(run, dumpIndex, dumpTimestamp);
-            } catch (RuntimeException e) {
-                // Don't let one listener break the rest.
-            }
-        }
+        events.fire(run.coverageId,
+                l -> l.onDumped(run, dumpIndex, dumpTimestamp));
     }
 
     private void fireAnalysisLoading(CoverageRun run) {
-        java.util.List<CoverageEventListener> list =
-                listeners.get(run.coverageId);
-        if (list == null) return;
-        for (CoverageEventListener l : list) {
-            try {
-                l.onAnalysisLoading(run);
-            } catch (RuntimeException e) {
-                // ignore
-            }
-        }
+        events.fire(run.coverageId, l -> l.onAnalysisLoading(run));
     }
 
     private void fireAnalysisReady(CoverageRun run) {
-        java.util.List<CoverageEventListener> list =
-                listeners.get(run.coverageId);
-        if (list == null) return;
-        for (CoverageEventListener l : list) {
-            try {
-                l.onAnalysisReady(run);
-            } catch (RuntimeException e) {
-                // ignore
-            }
-        }
+        events.fire(run.coverageId, l -> l.onAnalysisReady(run));
     }
 
     private void fireTerminated(CoverageRun run) {
-        java.util.List<CoverageEventListener> list =
-                listeners.get(run.coverageId);
-        if (list == null) return;
-        for (CoverageEventListener l : list) {
-            try {
-                l.onTerminated(run);
-            } catch (RuntimeException e) {
-                // ignore
-            }
-        }
+        events.fire(run.coverageId, l -> l.onTerminated(run));
     }
 
     private void fireFailed(CoverageRun run, String reason) {
-        java.util.List<CoverageEventListener> list =
-                listeners.get(run.coverageId);
-        if (list == null) return;
-        for (CoverageEventListener l : list) {
-            try {
-                l.onFailed(run, reason);
-            } catch (RuntimeException e) {
-                // ignore
-            }
-        }
+        events.fire(run.coverageId, l -> l.onFailed(run, reason));
     }
 
     /** Per-millisecond collision counter for {@code merged:}/{@code
@@ -253,6 +193,7 @@ final class CoverageTracker
         runs.clear();
         sessionToRunId.clear();
         pending.clear();
+        events.clear();
         activeCoverageId = null;
     }
 
@@ -588,16 +529,8 @@ final class CoverageTracker
     }
 
     private static Long parseLaunchTimestamp(ILaunch launch) {
-        String raw = launch.getAttribute(
-                DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
-        if (raw == null) {
-            return null;
-        }
-        try {
-            return Long.parseLong(raw);
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return CoverageJson.parseLaunchTimestamp(
+                launch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
     }
 
     /** State held while a non-live {@code sessionAdded} waits for

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -214,6 +214,24 @@ final class CoverageTracker
         return activeCoverageId;
     }
 
+    /** Swap {@link #activeCoverageId} and clear analysis flags on
+     *  the previously-active run. The previous run is no longer the
+     *  analysis target, so its {@code analysisLoading}/
+     *  {@code analysisReady} bits would be stale once EclEmma starts
+     *  re-loading for the new session. */
+    private void setActiveCoverageId(String newId) {
+        String previous = activeCoverageId;
+        activeCoverageId = newId;
+        if (previous == null || previous.equals(newId)) {
+            return;
+        }
+        CoverageRun stale = runs.get(previous);
+        if (stale != null) {
+            stale.analysisLoading = false;
+            stale.analysisReady = false;
+        }
+    }
+
     CoverageRun byCoverageId(String coverageId) {
         if (coverageId == null) {
             return null;
@@ -349,13 +367,15 @@ final class CoverageTracker
     @Override
     public void sessionActivated(ICoverageSession session) {
         if (session == null) {
-            activeCoverageId = null;
+            setActiveCoverageId(null);
             return;
         }
         String coverageId = sessionToRunId.get(session);
         if (coverageId != null) {
-            activeCoverageId = coverageId;
+            setActiveCoverageId(coverageId);
         }
+        // If the session isn't classified yet, finalizePending will
+        // call setActiveCoverageId once it lands.
     }
 
     private void classifyImmediately(ICoverageSession session) {
@@ -462,7 +482,7 @@ final class CoverageTracker
         fireDumped(run);
         if (session.equals(
                 CoverageTools.getSessionManager().getActiveSession())) {
-            activeCoverageId = coverageId;
+            setActiveCoverageId(coverageId);
             applyCoverageState(run,
                     CoverageTools.getJavaModelCoverage());
         }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -1,0 +1,482 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.ILaunchesListener2;
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.ISessionListener;
+import org.eclipse.eclemma.core.ISessionManager;
+import org.eclipse.eclemma.core.analysis.IJavaCoverageListener;
+import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
+import org.eclipse.eclemma.core.launching.ICoverageLaunch;
+
+import io.github.kaluchi.jdtbridge.Log;
+
+/**
+ * Holds the bridge-side index from {@code coverageId} to
+ * {@link CoverageRun}, fed by Eclipse listeners.
+ * <p>
+ * Listens to:
+ * <ul>
+ *   <li>{@link ILaunchesListener2} — pre-creates a {@link CoverageRun}
+ *       at {@code launchesAdded} for each {@link ICoverageLaunch};
+ *       flips {@code terminated} on {@code launchesTerminated}.</li>
+ *   <li>{@link ISessionListener} — classifies new sessions as
+ *       {@code live} (when an existing live run matches) or defers
+ *       to {@link #classifyDeferred} for {@code merged}/{@code imported}
+ *       resolution.</li>
+ *   <li>{@link IJavaCoverageListener} — flips
+ *       {@link CoverageRun#analysisLoading} /
+ *       {@link CoverageRun#analysisReady} on the active run.</li>
+ * </ul>
+ * <p>
+ * The bundle that owns the EclEmma classes referenced here
+ * ({@link CoverageTools} et al.) is required at runtime — this
+ * class is loaded only after {@link CoverageBridge#isAvailable()}
+ * confirms the bundle is present.
+ */
+final class CoverageTracker
+        implements ISessionListener, ILaunchesListener2,
+                   IJavaCoverageListener {
+
+    private final ConcurrentHashMap<String, CoverageRun> runs =
+            new ConcurrentHashMap<>();
+
+    /** Reverse index from session identity → owning run's
+     *  {@code coverageId}. Identity-based ({@link ICoverageSession}
+     *  has no {@code equals} override, see spec). */
+    private final ConcurrentHashMap<ICoverageSession, String>
+            sessionToRunId = new ConcurrentHashMap<>();
+
+    /** Sessions awaiting merged/imported classification — entries
+     *  are added in {@link #sessionAdded} when the live-match fails
+     *  and removed in {@link #classifyDeferred}. The {@code burst}
+     *  list is appended in {@link #sessionRemoved} for tracked
+     *  sessions removed before classification settles. */
+    private final ConcurrentHashMap<ICoverageSession,
+            PendingClassification> pending = new ConcurrentHashMap<>();
+
+    /** {@link Job#belongsTo(Object)} family for the deferred
+     *  classification jobs — exposed so tests can
+     *  {@code Job.getJobManager().join(CLASSIFY_FAMILY, ...)}. */
+    static final Object CLASSIFY_FAMILY = new Object();
+
+    /** Per-millisecond collision counter for {@code merged:}/{@code
+     *  imported:} coverage IDs. Bumped when a generated ID was
+     *  already issued (i.e. two events landed in the same
+     *  millisecond). */
+    private final AtomicLong collisionSeq = new AtomicLong();
+
+    private volatile String activeCoverageId;
+    private volatile boolean started;
+
+    void start() {
+        if (started) {
+            return;
+        }
+        started = true;
+        ILaunchManager mgr = launchManager();
+        if (mgr != null) {
+            mgr.addLaunchListener(this);
+            // Retroactively pick up live coverage launches that
+            // started before the listener was attached.
+            for (ILaunch launch : mgr.getLaunches()) {
+                if (launch instanceof ICoverageLaunch
+                        && !launch.isTerminated()) {
+                    registerLiveLaunch(launch);
+                }
+            }
+        }
+        ISessionManager sm = CoverageTools.getSessionManager();
+        sm.addSessionListener(this);
+        // Retroactively classify sessions already in the manager.
+        for (ICoverageSession s : sm.getSessions()) {
+            classifyImmediately(s);
+        }
+        ICoverageSession active = sm.getActiveSession();
+        if (active != null) {
+            activeCoverageId = sessionToRunId.get(active);
+        }
+        CoverageTools.addJavaCoverageListener(this);
+    }
+
+    void stop() {
+        if (!started) {
+            return;
+        }
+        started = false;
+        ILaunchManager mgr = launchManager();
+        if (mgr != null) {
+            mgr.removeLaunchListener(this);
+        }
+        CoverageTools.getSessionManager().removeSessionListener(this);
+        CoverageTools.removeJavaCoverageListener(this);
+        runs.clear();
+        sessionToRunId.clear();
+        pending.clear();
+        activeCoverageId = null;
+    }
+
+    /** Test/inspection accessor — read-only snapshot keyed by
+     *  {@code coverageId}. */
+    java.util.Map<String, CoverageRun> snapshot() {
+        return java.util.Map.copyOf(runs);
+    }
+
+    String activeCoverageId() {
+        return activeCoverageId;
+    }
+
+    CoverageRun byCoverageId(String coverageId) {
+        if (coverageId == null) {
+            return null;
+        }
+        // Strip optional :N dump suffix when looking up the run —
+        // the suffix addresses a session within the run.
+        int colon = coverageId.lastIndexOf(':');
+        if (colon > 0) {
+            String tail = coverageId.substring(colon + 1);
+            if (tail.matches("\\d+")) {
+                CoverageRun viaSuffix = runs.get(coverageId);
+                if (viaSuffix != null) {
+                    return viaSuffix;
+                }
+                String head = coverageId.substring(0, colon);
+                CoverageRun viaHead = runs.get(head);
+                if (viaHead != null) {
+                    return viaHead;
+                }
+            }
+        }
+        return runs.get(coverageId);
+    }
+
+    // -- ILaunchesListener2 --
+
+    @Override
+    public void launchesAdded(ILaunch[] launches) {
+        for (ILaunch launch : launches) {
+            if (launch instanceof ICoverageLaunch) {
+                registerLiveLaunch(launch);
+            }
+        }
+    }
+
+    @Override
+    public void launchesChanged(ILaunch[] launches) {
+        // Refresh process metadata when it lands later — currently
+        // a no-op; CoverageRun reads launch state on demand.
+    }
+
+    @Override
+    public void launchesTerminated(ILaunch[] launches) {
+        long now = System.currentTimeMillis();
+        for (ILaunch launch : launches) {
+            for (CoverageRun run : runs.values()) {
+                if (run.launch == launch) {
+                    run.terminated = true;
+                    if (run.terminatedAt == null) {
+                        run.terminatedAt = now;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void launchesRemoved(ILaunch[] launches) {
+        // Intentionally keep tracker state — runs survive removal
+        // from the launch manager. Mirrors LaunchTracker.
+    }
+
+    private void registerLiveLaunch(ILaunch launch) {
+        ILaunchConfiguration cfg = launch.getLaunchConfiguration();
+        if (cfg == null) {
+            return;
+        }
+        String configId = cfg.getName();
+        Long timestamp = parseLaunchTimestamp(launch);
+        if (timestamp == null) {
+            // No timestamp attribute — bridge requires one to
+            // form a stable coverageId, so we skip silently.
+            return;
+        }
+        String coverageId = configId + ":" + timestamp;
+        if (runs.containsKey(coverageId)) {
+            return;
+        }
+        String configType = null;
+        String configTypeId = null;
+        try {
+            ILaunchConfigurationType type = cfg.getType();
+            if (type != null) {
+                configType = type.getName();
+                configTypeId = type.getIdentifier();
+            }
+        } catch (CoreException e) {
+            Log.warn("Failed reading launch type for " + configId, e);
+        }
+        Set<org.eclipse.jdt.core.IPackageFragmentRoot> scope =
+                ((ICoverageLaunch) launch).getScope();
+        CoverageRun run = CoverageRun.live(coverageId, configId,
+                configType, configTypeId, launch, timestamp, scope);
+        runs.put(coverageId, run);
+    }
+
+    // -- ISessionListener --
+
+    @Override
+    public void sessionAdded(ICoverageSession session) {
+        classifyImmediately(session);
+    }
+
+    @Override
+    public void sessionRemoved(ICoverageSession session) {
+        String coverageId = sessionToRunId.remove(session);
+        if (coverageId != null) {
+            CoverageRun run = runs.get(coverageId);
+            if (run != null) {
+                int idx = run.sessions.indexOf(session);
+                if (idx >= 0) {
+                    run.sessions.remove(idx);
+                    if (idx < run.dumpedAt.size()) {
+                        run.dumpedAt.remove(idx);
+                    }
+                }
+                if (run.sessions.isEmpty()) {
+                    runs.remove(coverageId);
+                }
+            }
+        }
+        // Append removed coverageId to any in-flight pending
+        // classification — distinguishes merged from imported.
+        if (coverageId != null) {
+            for (PendingClassification p : pending.values()) {
+                p.removedCoverageIds.add(coverageId);
+            }
+        }
+    }
+
+    @Override
+    public void sessionActivated(ICoverageSession session) {
+        if (session == null) {
+            activeCoverageId = null;
+            return;
+        }
+        String coverageId = sessionToRunId.get(session);
+        if (coverageId != null) {
+            activeCoverageId = coverageId;
+        }
+    }
+
+    private void classifyImmediately(ICoverageSession session) {
+        CoverageRun liveRun = matchLiveRun(session);
+        if (liveRun != null) {
+            appendLiveDump(liveRun, session);
+            return;
+        }
+        // Defer — sessionRemoved bursts that arrive synchronously
+        // after this call distinguish merged from imported.
+        PendingClassification pc = new PendingClassification(session);
+        pending.put(session, pc);
+        Job job = new Job("jdtbridge coverage classify") {
+            @Override
+            protected IStatus run(IProgressMonitor monitor) {
+                return finalizePending(session);
+            }
+
+            @Override
+            public boolean belongsTo(Object family) {
+                return family == CLASSIFY_FAMILY;
+            }
+        };
+        job.setSystem(true);
+        job.schedule();
+    }
+
+    /** Synchronously finalize every pending classification. Useful
+     *  in tests and on read paths that need a fully-settled view. */
+    void flushPending() {
+        for (ICoverageSession s : new ArrayList<>(pending.keySet())) {
+            finalizePending(s);
+        }
+    }
+
+    private CoverageRun matchLiveRun(ICoverageSession session) {
+        ILaunchConfiguration cfg = session.getLaunchConfiguration();
+        if (cfg == null) {
+            return null;
+        }
+        String configId = cfg.getName();
+        for (CoverageRun run : runs.values()) {
+            if (run.kind == CoverageRun.Kind.LIVE
+                    && configId.equals(run.configId)
+                    && !run.terminated) {
+                return run;
+            }
+        }
+        return null;
+    }
+
+    private void appendLiveDump(CoverageRun run,
+            ICoverageSession session) {
+        run.sessions.add(session);
+        run.dumpedAt.add(System.currentTimeMillis());
+        run.dataReceived = true;
+        run.description = session.getDescription();
+        sessionToRunId.put(session, run.coverageId);
+    }
+
+    /** Classify a deferred session once any synchronous
+     *  {@code sessionRemoved} burst has had a chance to populate
+     *  {@link PendingClassification#removedCoverageIds}. Idempotent. */
+    private IStatus finalizePending(ICoverageSession session) {
+        PendingClassification pc = pending.remove(session);
+        if (pc == null) {
+            return Status.OK_STATUS;
+        }
+        long now = System.currentTimeMillis();
+        boolean isMerged = pc.removedCoverageIds.size() >= 2;
+        String coverageId = uniqueId(isMerged ? "merged" : "imported",
+                now);
+        Set<org.eclipse.jdt.core.IPackageFragmentRoot> scope =
+                new HashSet<>(session.getScope());
+        String description = session.getDescription();
+        CoverageRun run;
+        if (isMerged) {
+            ILaunchConfiguration cfg = session.getLaunchConfiguration();
+            String configId = cfg != null ? cfg.getName() : null;
+            String configType = null;
+            String configTypeId = null;
+            if (cfg != null) {
+                try {
+                    if (cfg.getType() != null) {
+                        configType = cfg.getType().getName();
+                        configTypeId = cfg.getType().getIdentifier();
+                    }
+                } catch (CoreException e) {
+                    Log.warn("Failed reading merged config type", e);
+                }
+            }
+            run = CoverageRun.merged(coverageId, configId, configType,
+                    configTypeId, scope, description,
+                    new ArrayList<>(pc.removedCoverageIds));
+        } else {
+            run = CoverageRun.imported(coverageId, scope, description);
+        }
+        run.sessions.add(session);
+        run.dumpedAt.add(now);
+        runs.put(coverageId, run);
+        sessionToRunId.put(session, coverageId);
+        // sessionActivated may have fired BEFORE this deferred
+        // classification ran (SessionImporter activates the new
+        // session synchronously inside the same dispatch). Adopt
+        // the SessionManager's current active session as our
+        // active here if it matches.
+        if (session.equals(
+                CoverageTools.getSessionManager().getActiveSession())) {
+            activeCoverageId = coverageId;
+        }
+        return Status.OK_STATUS;
+    }
+
+    /** Generate {@code "<prefix>:<millis>"} or, on intra-millisecond
+     *  collision with a previously-issued ID, append {@code "#<seq>"}. */
+    private String uniqueId(String prefix, long millis) {
+        String base = prefix + ":" + millis;
+        if (!runs.containsKey(base) && !pendingHas(base)) {
+            return base;
+        }
+        long seq;
+        String candidate;
+        do {
+            seq = collisionSeq.incrementAndGet();
+            candidate = base + "#" + seq;
+        } while (runs.containsKey(candidate));
+        return candidate;
+    }
+
+    private boolean pendingHas(String coverageId) {
+        for (PendingClassification p : pending.values()) {
+            if (coverageId.equals(p.assignedCoverageId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // -- IJavaCoverageListener --
+
+    @Override
+    public void coverageChanged() {
+        String activeId = activeCoverageId;
+        if (activeId == null) {
+            return;
+        }
+        CoverageRun run = runs.get(activeId);
+        if (run == null) {
+            return;
+        }
+        IJavaModelCoverage coverage = CoverageTools.getJavaModelCoverage();
+        if (coverage == IJavaModelCoverage.LOADING) {
+            run.analysisLoading = true;
+            run.analysisReady = false;
+        } else if (coverage == null) {
+            run.analysisLoading = false;
+            run.analysisReady = false;
+        } else {
+            run.analysisLoading = false;
+            run.analysisReady = true;
+        }
+    }
+
+    // -- helpers --
+
+    private static ILaunchManager launchManager() {
+        DebugPlugin debug = DebugPlugin.getDefault();
+        return debug != null ? debug.getLaunchManager() : null;
+    }
+
+    private static Long parseLaunchTimestamp(ILaunch launch) {
+        String raw = launch.getAttribute(
+                DebugPlugin.ATTR_LAUNCH_TIMESTAMP);
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** State held while a non-live {@code sessionAdded} waits for
+     *  classification. Mutated only inside listener callbacks (single
+     *  thread per dispatch) — no lock needed for the lists. */
+    private static final class PendingClassification {
+        final ICoverageSession session;
+        final long createdAtMillis = System.currentTimeMillis();
+        final List<String> removedCoverageIds = new ArrayList<>();
+        volatile String assignedCoverageId;
+
+        PendingClassification(ICoverageSession session) {
+            this.session = session;
+        }
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -418,15 +418,7 @@ final class CoverageTracker
             }
         };
         job.setSystem(true);
-        // 50ms delay: SessionManager.mergeSessions fires
-        // sessionAdded(merged) FIRST, then loops removeSession on
-        // inputs — both inside the same synchronized(lock) block
-        // on the merger thread. The classify worker runs on a
-        // different thread, so a delayless schedule races and may
-        // observe an empty removal burst (→ misclassify as
-        // imported). The delay defers the worker until the
-        // lock-bound dispatch has finished.
-        job.schedule(50);
+        job.schedule();
     }
 
     /** Synchronously finalize every pending classification. Useful
@@ -467,6 +459,16 @@ final class CoverageTracker
      *  {@code sessionRemoved} burst has had a chance to populate
      *  {@link PendingClassification#removedCoverageIds}. Idempotent. */
     private IStatus finalizePending(ICoverageSession session) {
+        // Lock barrier: SessionManager.getSessions() synchronizes
+        // on the same lock that the merger thread holds across the
+        // sessionAdded(merged) → N×removeSession(input) dispatch.
+        // This call blocks until that lock is released, so by the
+        // time we read pending.removedCoverageIds below the
+        // listener callbacks have already populated it. Determinism
+        // via lock acquisition replaces the earlier 50ms delay.
+        // No-op when called from the merger thread (reentrant).
+        CoverageTools.getSessionManager().getSessions();
+
         PendingClassification pc = pending.remove(session);
         if (pc == null) {
             return Status.OK_STATUS;

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -79,6 +79,101 @@ final class CoverageTracker
      *  {@code Job.getJobManager().join(CLASSIFY_FAMILY, ...)}. */
     static final Object CLASSIFY_FAMILY = new Object();
 
+    /** Per-{@code coverageId} subscriber list for streaming
+     *  endpoints. Keyed by coverage ID without dump suffix. */
+    private final ConcurrentHashMap<String,
+            java.util.List<CoverageEventListener>> listeners =
+            new ConcurrentHashMap<>();
+
+    /** Streaming-side hook. {@code on*} methods are called
+     *  synchronously from the listener thread. Implementations
+     *  must be non-blocking and exception-safe. */
+    interface CoverageEventListener {
+        void onDumped(CoverageRun run, int dumpIndex,
+                long dumpTimestamp);
+        void onAnalysisLoading(CoverageRun run);
+        void onAnalysisReady(CoverageRun run);
+        void onTerminated(CoverageRun run);
+    }
+
+    /** Subscribe to events for one {@code coverageId}. Multiple
+     *  subscribers are allowed; remove via
+     *  {@link #removeCoverageListener}. */
+    void addCoverageListener(String coverageId,
+            CoverageEventListener listener) {
+        listeners.computeIfAbsent(coverageId,
+                k -> new java.util.concurrent.CopyOnWriteArrayList<>())
+                .add(listener);
+    }
+
+    void removeCoverageListener(String coverageId,
+            CoverageEventListener listener) {
+        java.util.List<CoverageEventListener> list =
+                listeners.get(coverageId);
+        if (list != null) {
+            list.remove(listener);
+            if (list.isEmpty()) {
+                listeners.remove(coverageId, list);
+            }
+        }
+    }
+
+    private void fireDumped(CoverageRun run) {
+        java.util.List<CoverageEventListener> list =
+                listeners.get(run.coverageId);
+        if (list == null) return;
+        int dumpIndex = run.sessions.size();
+        long dumpTimestamp = run.dumpedAt.isEmpty()
+                ? System.currentTimeMillis()
+                : run.dumpedAt.get(run.dumpedAt.size() - 1);
+        for (CoverageEventListener l : list) {
+            try {
+                l.onDumped(run, dumpIndex, dumpTimestamp);
+            } catch (RuntimeException e) {
+                // Don't let one listener break the rest.
+            }
+        }
+    }
+
+    private void fireAnalysisLoading(CoverageRun run) {
+        java.util.List<CoverageEventListener> list =
+                listeners.get(run.coverageId);
+        if (list == null) return;
+        for (CoverageEventListener l : list) {
+            try {
+                l.onAnalysisLoading(run);
+            } catch (RuntimeException e) {
+                // ignore
+            }
+        }
+    }
+
+    private void fireAnalysisReady(CoverageRun run) {
+        java.util.List<CoverageEventListener> list =
+                listeners.get(run.coverageId);
+        if (list == null) return;
+        for (CoverageEventListener l : list) {
+            try {
+                l.onAnalysisReady(run);
+            } catch (RuntimeException e) {
+                // ignore
+            }
+        }
+    }
+
+    private void fireTerminated(CoverageRun run) {
+        java.util.List<CoverageEventListener> list =
+                listeners.get(run.coverageId);
+        if (list == null) return;
+        for (CoverageEventListener l : list) {
+            try {
+                l.onTerminated(run);
+            } catch (RuntimeException e) {
+                // ignore
+            }
+        }
+    }
+
     /** Per-millisecond collision counter for {@code merged:}/{@code
      *  imported:} coverage IDs. Bumped when a generated ID was
      *  already issued (i.e. two events landed in the same
@@ -208,6 +303,7 @@ final class CoverageTracker
                     if (run.terminatedAt == null) {
                         run.terminatedAt = now;
                     }
+                    fireTerminated(run);
                 }
             }
         }
@@ -356,6 +452,7 @@ final class CoverageTracker
         run.dataReceived = true;
         run.description = session.getDescription();
         sessionToRunId.put(session, run.coverageId);
+        fireDumped(run);
     }
 
     /** Classify a deferred session once any synchronous
@@ -399,6 +496,9 @@ final class CoverageTracker
         run.dumpedAt.add(now);
         runs.put(coverageId, run);
         sessionToRunId.put(session, coverageId);
+        // For merged/imported runs the kind was just decided here,
+        // so the dump-add fires now (no live launch fired it).
+        fireDumped(run);
         // sessionActivated may have fired BEFORE this deferred
         // classification ran (SessionImporter activates the new
         // session synchronously inside the same dispatch). Adopt
@@ -452,12 +552,14 @@ final class CoverageTracker
         if (coverage == IJavaModelCoverage.LOADING) {
             run.analysisLoading = true;
             run.analysisReady = false;
+            fireAnalysisLoading(run);
         } else if (coverage == null) {
             run.analysisLoading = false;
             run.analysisReady = false;
         } else {
             run.analysisLoading = false;
             run.analysisReady = true;
+            fireAnalysisReady(run);
         }
     }
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -55,6 +55,8 @@ final class CoverageTracker
         implements ISessionListener, ILaunchesListener2,
                    IJavaCoverageListener {
 
+    private final CoverageAnalyzer analyzer;
+
     private final ConcurrentHashMap<String, CoverageRun> runs =
             new ConcurrentHashMap<>();
 
@@ -85,6 +87,18 @@ final class CoverageTracker
 
     private volatile String activeCoverageId;
     private volatile boolean started;
+
+    /** Production wiring — creates a fresh, dedicated
+     *  {@link CoverageAnalyzer} for cache invalidation. */
+    CoverageTracker() {
+        this(new CoverageAnalyzer());
+    }
+
+    /** Test/router wiring — pass an explicit analyzer so the
+     *  invalidation hook is observable. */
+    CoverageTracker(CoverageAnalyzer analyzer) {
+        this.analyzer = analyzer;
+    }
 
     void start() {
         if (started) {
@@ -248,6 +262,7 @@ final class CoverageTracker
 
     @Override
     public void sessionRemoved(ICoverageSession session) {
+        analyzer.invalidate(session);
         String coverageId = sessionToRunId.remove(session);
         if (coverageId != null) {
             CoverageRun run = runs.get(coverageId);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -418,7 +418,15 @@ final class CoverageTracker
             }
         };
         job.setSystem(true);
-        job.schedule();
+        // 50ms delay: SessionManager.mergeSessions fires
+        // sessionAdded(merged) FIRST, then loops removeSession on
+        // inputs — both inside the same synchronized(lock) block
+        // on the merger thread. The classify worker runs on a
+        // different thread, so a delayless schedule races and may
+        // observe an empty removal burst (→ misclassify as
+        // imported). The delay defers the worker until the
+        // lock-bound dispatch has finished.
+        job.schedule(50);
     }
 
     /** Synchronously finalize every pending classification. Useful

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -26,6 +26,7 @@ import org.eclipse.eclemma.core.analysis.IJavaCoverageListener;
 import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
 import org.eclipse.eclemma.core.launching.ICoverageLaunch;
 
+import io.github.kaluchi.jdtbridge.LaunchAttrs;
 import io.github.kaluchi.jdtbridge.Log;
 
 /**
@@ -524,13 +525,11 @@ final class CoverageTracker
     // -- helpers --
 
     private static ILaunchManager launchManager() {
-        DebugPlugin debug = DebugPlugin.getDefault();
-        return debug != null ? debug.getLaunchManager() : null;
+        return LaunchAttrs.launchManager();
     }
 
     private static Long parseLaunchTimestamp(ILaunch launch) {
-        return CoverageJson.parseLaunchTimestamp(
-                launch.getAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP));
+        return LaunchAttrs.launchTimestamp(launch);
     }
 
     /** State held while a non-live {@code sessionAdded} waits for

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTypes.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTypes.java
@@ -4,9 +4,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchManager;
+
+import io.github.kaluchi.jdtbridge.LaunchAttrs;
 
 /**
  * The set of launch configuration type IDs for which EclEmma
@@ -75,7 +76,7 @@ public final class CoverageTypes {
 
     private static Set<String> compute() {
         Set<String> modes = Set.of(LAUNCH_MODE);
-        ILaunchManager mgr = DebugPlugin.getDefault().getLaunchManager();
+        ILaunchManager mgr = LaunchAttrs.launchManager();
         Set<String> out = new LinkedHashSet<>();
         for (String typeId : CANDIDATE_TYPE_IDS) {
             ILaunchConfigurationType type =

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTypes.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTypes.java
@@ -1,0 +1,96 @@
+package io.github.kaluchi.jdtbridge.coverage;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchManager;
+
+/**
+ * The set of launch configuration type IDs for which EclEmma
+ * registers a {@code "coverage"} mode delegate. Mirrors the 9
+ * {@code launchDelegate} entries in EclEmma's
+ * {@code org.eclipse.eclemma.core/plugin.xml}.
+ * <p>
+ * The set is computed lazily on first access by querying the
+ * Eclipse debug framework — types whose
+ * {@link ILaunchConfigurationType#getDelegates(Set)} returns at
+ * least one delegate for {@code "coverage"} mode. The 9 IDs below
+ * are the candidates probed; the resolved set may be smaller in an
+ * Eclipse instance that lacks one of the optional host bundles
+ * (PDE, TestNG, RAP, SWTBot, Scala).
+ */
+public final class CoverageTypes {
+
+    /** Mode name used by EclEmma's launch delegates and by
+     *  {@code DebugPlugin.LAUNCH_MODE_COVERAGE}. */
+    public static final String LAUNCH_MODE = "coverage";
+
+    /** All launch type IDs probed for coverage support — same
+     *  9 entries listed in EclEmma's {@code plugin.xml}. */
+    public static final List<String> CANDIDATE_TYPE_IDS = List.of(
+            "org.eclipse.jdt.launching.localJavaApplication",
+            "org.eclipse.jdt.junit.launchconfig",
+            "org.eclipse.pde.ui.RuntimeWorkbench",
+            "org.eclipse.pde.ui.JunitLaunchConfig",
+            "org.eclipse.pde.ui.EquinoxLauncher",
+            "org.testng.eclipse.launchconfig",
+            "org.eclipse.rap.ui.launch.RAPJUnitTestLauncher",
+            "org.eclipse.swtbot.eclipse.ui.launcher.JunitLaunchConfig",
+            "scala.application");
+
+    private static volatile Set<String> resolved;
+
+    private CoverageTypes() {
+    }
+
+    /** Type IDs for which Eclipse currently has a coverage-mode
+     *  launch delegate registered. Result is cached after first
+     *  computation. */
+    public static Set<String> supported() {
+        Set<String> snapshot = resolved;
+        if (snapshot == null) {
+            synchronized (CoverageTypes.class) {
+                if (resolved == null) {
+                    resolved = compute();
+                }
+                snapshot = resolved;
+            }
+        }
+        return snapshot;
+    }
+
+    /** True when {@code typeId} has a registered coverage delegate. */
+    public static boolean isSupported(String typeId) {
+        return supported().contains(typeId);
+    }
+
+    /** Recompute and replace the cached set — for tests, or after
+     *  EclEmma install/uninstall via p2. */
+    public static synchronized void refresh() {
+        resolved = compute();
+    }
+
+    private static Set<String> compute() {
+        Set<String> modes = Set.of(LAUNCH_MODE);
+        ILaunchManager mgr = DebugPlugin.getDefault().getLaunchManager();
+        Set<String> out = new LinkedHashSet<>();
+        for (String typeId : CANDIDATE_TYPE_IDS) {
+            ILaunchConfigurationType type =
+                    mgr.getLaunchConfigurationType(typeId);
+            if (type == null) {
+                continue;
+            }
+            try {
+                if (type.getDelegates(modes).length > 0) {
+                    out.add(typeId);
+                }
+            } catch (Exception e) {
+                // type registered without delegates — skip
+            }
+        }
+        return Set.copyOf(out);
+    }
+}

--- a/ui/META-INF/MANIFEST.MF
+++ b/ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
- io.github.kaluchi.jdtbridge
+ io.github.kaluchi.jdtbridge,
+ org.eclipse.eclemma.core;resolution:=optional
 Import-Package: com.google.gson,
  org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy

--- a/ui/src/io/github/kaluchi/jdtbridge/ui/Activator.java
+++ b/ui/src/io/github/kaluchi/jdtbridge/ui/Activator.java
@@ -1,7 +1,10 @@
 package io.github.kaluchi.jdtbridge.ui;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+
+import io.github.kaluchi.jdtbridge.ui.coverage.CoverageToolbarRefresher;
 
 public class Activator extends AbstractUIPlugin {
 
@@ -9,14 +12,23 @@ public class Activator extends AbstractUIPlugin {
 
 	private static Activator instance;
 
+	private CoverageToolbarRefresher coverageRefresher;
+
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		instance = this;
+		if (Platform.getBundle("org.eclipse.eclemma.core") != null) {
+			coverageRefresher = CoverageToolbarRefresher.install();
+		}
 	}
 
 	@Override
 	public void stop(BundleContext context) throws Exception {
+		if (coverageRefresher != null) {
+			coverageRefresher.uninstall();
+			coverageRefresher = null;
+		}
 		instance = null;
 		super.stop(context);
 	}

--- a/ui/src/io/github/kaluchi/jdtbridge/ui/coverage/CoverageToolbarRefresher.java
+++ b/ui/src/io/github/kaluchi/jdtbridge/ui/coverage/CoverageToolbarRefresher.java
@@ -1,0 +1,83 @@
+package io.github.kaluchi.jdtbridge.ui.coverage;
+
+import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
+import org.eclipse.eclemma.core.ISessionListener;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Workaround for an EclEmma quirk: their toolbar handlers
+ * (subclasses of {@code AbstractSessionManagerHandler}) call
+ * {@code fireHandlerChanged} from {@code ISessionListener}
+ * callbacks, but the workbench does not pick that up for view
+ * toolbar items until the next focus event — so the user sees
+ * stale enabled/disabled state until they click somewhere.
+ *
+ * <p>This listener subscribes to the same session events and
+ * forces the EclEmma Coverage View's action bars to re-render
+ * via {@code IActionBars.updateActionBars()}, on the UI thread.
+ *
+ * <p>Activated by the UI plugin's Activator when EclEmma is on
+ * the classpath. No-op when the Coverage View is not open.
+ */
+public final class CoverageToolbarRefresher
+        implements ISessionListener {
+
+    private static final String COVERAGE_VIEW_ID =
+            "org.eclipse.eclemma.ui.CoverageView";
+
+    private CoverageToolbarRefresher() {
+    }
+
+    public static CoverageToolbarRefresher install() {
+        CoverageToolbarRefresher r = new CoverageToolbarRefresher();
+        CoverageTools.getSessionManager().addSessionListener(r);
+        return r;
+    }
+
+    public void uninstall() {
+        CoverageTools.getSessionManager().removeSessionListener(this);
+    }
+
+    @Override
+    public void sessionAdded(ICoverageSession s) {
+        scheduleRefresh();
+    }
+
+    @Override
+    public void sessionRemoved(ICoverageSession s) {
+        scheduleRefresh();
+    }
+
+    @Override
+    public void sessionActivated(ICoverageSession s) {
+        scheduleRefresh();
+    }
+
+    private void scheduleRefresh() {
+        Display.getDefault().asyncExec(this::refreshCoverageViewBars);
+    }
+
+    private void refreshCoverageViewBars() {
+        IWorkbench wb = PlatformUI.getWorkbench();
+        if (wb == null) {
+            return;
+        }
+        for (IWorkbenchWindow win : wb.getWorkbenchWindows()) {
+            IWorkbenchPage page = win.getActivePage();
+            if (page == null) {
+                continue;
+            }
+            IViewPart view = page.findView(COVERAGE_VIEW_ID);
+            if (view != null) {
+                view.getViewSite().getActionBars()
+                        .updateActionBars();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Plugin
- `CoverageBridge` — single guarded entry for `/coverage/*` routes;
  loaded eagerly but defers `CoverageRouter` (which imports EclEmma)
  until both `Platform.getBundle(\"org.eclipse.eclemma.core\") != null`
  AND a request arrives. Eclipse without EclEmma returns
  `coverage-not-installed` JSON without a NoClassDefFoundError.
- `CoverageTracker` — `Map<coverageId, CoverageRun>` fed by
  `ILaunchesListener2` / `ISessionListener` / `IJavaCoverageListener`.
  Three session kinds: `live` / `merged` / `imported`. Merged vs
  imported decided by counting the synchronous `sessionRemoved`
  burst that follows `sessionAdded` on the merger thread; deferred
  to a `Job` keyed by `CLASSIFY_FAMILY`, which acquires
  `SessionManager.lock` via `getSessions()` as a deterministic
  barrier (no timing delay). `#<seq>` suffix on intra-millisecond
  collisions.
- `CoverageHandler` — `/coverage/run`, `/dump`, `/refresh`,
  `/relaunch`. `CoverageSessionHandler` — `/runs`, `/session`,
  `/active`, `/activate`, `/merge`, `/remove`.
  `CoverageProgressStreamer` — `/coverage/session/stream` JSONL
  with `snapshot` / `dumped` / `analysisLoading` /
  `analysisReady` (carries counters) / `terminated` /
  `failed` (`analysis-cancelled`) events; subscribers cleaned up
  on broken pipe.
- `CoverageAnalyzer` — identity-keyed cache around
  `SessionAnalyzer.processSession`; invalidated on
  `sessionRemoved`.
- `CoverageTypes` — 9 launch types EclEmma registers a coverage
  delegate for, runtime-resolved.
- `TestHandler` learns `coverage=true`; response carries
  `coverageId` (== `testRunId` byte-for-byte) and
  `launchMode: \"coverage\"`.

## Cross-cutting refactor
- `LaunchAttrs` (root package) — `launchManager()`,
  `firstPid()`, `launchTimestamp()`, `launchIdOf()`. Replaces 6
  copies of `configId:pid` composition, 4 of
  `getLaunchManager()`, 4 of `Long.parseLong(ATTR_LAUNCH_TIMESTAMP)`
  including one in `TestSessionHandler` that lacked try/catch
  and would have thrown on a malformed value.
- `CoverageJson` (coverage subpackage) — `error` envelope,
  `parseObjectBody`, `optString` / `optBool`,
  `addNullableString` / `addNullableLong`, counter shape
  (`countersOf` / `counterJson` / `statusName`). Single source
  for what was inlined in three handlers.
- `CoverageEventBus` — extracted from tracker; the five fire*
  methods collapse to one-liners on `Consumer<CoverageEventListener>`.

## CLI
- `jdt coverage *` subcommands: `run`, `runs`, `status`, `dump`,
  `refresh`, `relaunch`, `active`, `activate`, `merge`, `remove`,
  `stop`. `--coverage` flag on `jdt test run`.
- Format helpers under `cli/src/format/` — STATUS line composer
  per spec (Group A/B/C), runs table, snapshot block, stream
  events, run header + onboarding guide.
- `cli/src/format/stream.mjs#followJsonlStream` extracted from
  the duplicated SIGINT + getStreamLines + try/catch in
  `followTestStream` / `followCoverageStream`.
- `cli/src/format/relative-time.mjs#ago` — was duplicated in
  `coverage-state.mjs` and `commands/test-sessions.mjs`.

## Specs
- `docs/jdt-coverage-spec.md` — CLI surface, identity vocabulary,
  STATUS composition, header + onboarding, `--coverage` on test
  run.
- `docs/bridge-coverage-spec.md` — HTTP contract, per-field SSOT
  mapping for live/merged/imported, lifetime, error categories,
  counter shape.

## Tests
- Plugin: 619 total, 151 in the coverage package across 11
  suites (bridge, types, run/handler/session-handler/analyzer,
  tracker, streamer + event-bus, test-run-coverage-flag,
  coverage-run data class).
- CLI: 779 total, 55 added for the coverage commands +
  formatters.
- CI: green.

## Test plan
- [x] Plugin suite (`jdt test run --project io.github.kaluchi.jdtbridge.tests`)
- [x] CLI suite (`cd cli && npm test`)
- [x] CI build
- [ ] Manual end-to-end smoke against a live coverage launch in
  the reviewer's Eclipse (`jdt coverage run <configId>`,
  `jdt coverage status <id> -f`, `jdt coverage merge <a> <b>`)

Closes #101.