### PR TITLE
CLAUDE.md: highest-priority rules for main agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,19 @@ definition already contains everything you need. Go straight to the task.
 2. Execute every step in the "Environment check (REQUIRED)" section. Do NOT skip, summarize, or defer any step.
 3. Only after all checks pass, respond to the user.
 
+## ⚠ HIGHEST-PRIORITY RULE — OBEY EXPLICIT USER COMMANDS
+
+**When the user gives an explicit instruction, do exactly that instruction. Do NOT substitute your own judgment, do NOT continue a plan you started before the instruction, do NOT pursue a different path because you think you "know better" or because the user's instruction sounds redundant or sub-optimal to you.**
+
+1. Read the instruction.
+2. Stop whatever you were doing.
+3. Execute the instruction first.
+4. Only after that, raise concerns or propose alternatives — never before.
+
+If you disagree with the instruction, ASK before acting. Never silently act differently.
+
+This is non-negotiable. Substituting your own judgment for explicit user direction has caused real harm in past sessions.
+
 ## ⚠ HIGHEST-PRIORITY RULE — AFTER CONTEXT COMPACTION
 
 **The moment your context is compacted (summary replaces prior turns), AGENTS.md is GONE from your working memory and you have lost the rules. Before sending ANY tool call or reply in the post-compaction segment, you MUST:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,13 @@ definition already contains everything you need. Go straight to the task.
 1. Read AGENTS.md — it contains all project instructions, setup, and coding guidelines.
 2. Execute every step in the "Environment check (REQUIRED)" section. Do NOT skip, summarize, or defer any step.
 3. Only after all checks pass, respond to the user.
+
+## ⚠ HIGHEST-PRIORITY RULE — AFTER CONTEXT COMPACTION
+
+**The moment your context is compacted (summary replaces prior turns), AGENTS.md is GONE from your working memory and you have lost the rules. Before sending ANY tool call or reply in the post-compaction segment, you MUST:**
+
+1. Re-read AGENTS.md in full.
+2. Re-run the "Environment check (REQUIRED)" section.
+3. Only then resume the task.
+
+This is non-negotiable. The summary is NOT a substitute. Do not trust your recollection of project rules from before compaction — read the file. Skipping this step has caused real harm in past sessions.


### PR DESCRIPTION
Two highest-priority rules for the main agent, each as its own block so neither gets buried under the start-of-conversation checklist.

Compaction re-read: the moment context is compacted, AGENTS.md is gone from working memory. Before any tool call or reply in the post-compaction segment, re-read AGENTS.md and re-run the Environment check. The summary is NOT a substitute.

Obey explicit user commands: when the user gives an explicit instruction, execute it before anything else. Do not substitute your own judgment, do not continue an in-flight plan, do not pursue a different path because the instruction sounds sub-optimal. If you disagree, ASK first.

- [x] No code changes — documentation only