### PR TITLE
jdt build --clean: workspace-wide clean + full rebuild

### DIFF
--- a/cli/src/commands/build.mjs
+++ b/cli/src/commands/build.mjs
@@ -6,8 +6,11 @@ export async function build(args) {
   const params = [];
   if (flags.project) params.push(`project=${encodeURIComponent(flags.project)}`);
 
-  // Default is clean when project specified; --incremental to skip
-  if (flags.project && !flags.incremental) params.push("clean");
+  // Default for --project is clean (use --incremental to skip);
+  // workspace-wide clean is opt-in via explicit --clean.
+  const clean = flags.clean
+      || (flags.project && !flags.incremental);
+  if (clean) params.push("clean");
 
   let url = "/build";
   if (params.length > 0) url += "?" + params.join("&");
@@ -27,18 +30,23 @@ export async function build(args) {
 
 export const help = `Build a project via Eclipse clean or incremental builder.
 
-Usage:  jdt build [--project <name>] [--incremental]
+Usage:  jdt build [--project <name>] [--clean | --incremental]
 
 Options:
-  --project <name>   project to build (omit for workspace-wide incremental)
-  --incremental      incremental build only (default is clean + full rebuild)
+  --project <name>   project to build (omit for workspace-wide build)
+  --clean            clean + full rebuild (Project > Clean equivalent)
+  --incremental      incremental build (skip clean for --project)
 
-Default is clean build when --project is specified.
-Without --project, triggers workspace-wide incremental build.
+Default with --project is clean + full rebuild.
+Default without --project is workspace-wide incremental.
+--clean without --project runs workspace-wide CLEAN_BUILD + FULL_BUILD,
+the same operation as Project > Clean > Clean all projects in Eclipse;
+this is the cure for stale cached errors after Eclipse restarts.
 Always refreshes from disk before building.
 Exit code: 0 if no compilation errors, 1 if errors found.
 
 Examples:
   jdt build --project my-app                clean build (default)
   jdt build --project my-app --incremental  incremental only
-  jdt build                                 workspace incremental`;
+  jdt build                                 workspace incremental
+  jdt build --clean                         workspace clean + full`;

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsIntegrationTest.java
@@ -3,6 +3,7 @@ package io.github.kaluchi.jdtbridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -118,13 +119,19 @@ public class DiagnosticsIntegrationTest {
     }
 
     @Test
-    public void buildCleanWithoutProject() throws Exception {
+    public void buildCleanWithoutProjectRunsWorkspaceWide()
+            throws Exception {
+        // clean without project = Project > Clean > Clean all
+        // projects: workspace-wide CLEAN_BUILD + FULL_BUILD.
+        // Verifies the call returns an errors count and no error.
         Map<String, String> params = new HashMap<>();
         params.put("clean", "");
         String json = handler.handleBuild(params);
         JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
-        assertNotNull(obj.get("error"),
-                "Should have error about missing project");
+        assertNull(obj.get("error"),
+                "Workspace clean should not return an error");
+        assertNotNull(obj.get("errors"),
+                "Should report errors count");
     }
 
     @Test

--- a/plugin/src/io/github/kaluchi/jdtbridge/DiagnosticsHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/DiagnosticsHandler.java
@@ -97,20 +97,25 @@ class DiagnosticsHandler {
             scope = root;
         }
 
-        if (clean && buildProject == null) {
-            return HttpServer.jsonError(
-                    "clean requires a specific project"
-                    + " (use 'project' param)");
-        }
-
         scope.refreshLocal(IResource.DEPTH_INFINITE, null);
         JdtUtils.joinAutoBuild();
 
-        if (clean) {
+        // Project > Clean dialog default = "Build immediately after
+        // the clean": CLEAN_BUILD discards state, then FULL_BUILD
+        // recompiles. CLEAN_BUILD on its own only deletes derived
+        // resources and leaves the workspace uncompiled.
+        if (clean && buildProject != null) {
             buildProject.build(
                     IncrementalProjectBuilder.CLEAN_BUILD,
                     null);
             buildProject.build(
+                    IncrementalProjectBuilder.FULL_BUILD,
+                    null);
+        } else if (clean) {
+            ResourcesPlugin.getWorkspace().build(
+                    IncrementalProjectBuilder.CLEAN_BUILD,
+                    null);
+            ResourcesPlugin.getWorkspace().build(
                     IncrementalProjectBuilder.FULL_BUILD,
                     null);
         } else if (buildProject != null) {


### PR DESCRIPTION
Adds workspace-scoped clean rebuild as the CLI equivalent of Eclipse's Project > Clean > Clean all projects.

After Eclipse restarts the Java builder occasionally surfaces stale "missing type" markers that the incremental builder will not flush; Project > Clean clears them and so does this. Until now jdt build only had project-level clean and rejected --clean without --project.

Changes:
- CLI: --clean flag accepted independently of --project (workspace-wide when no project, project-scoped when both)
- Server: handleBuild runs ResourcesPlugin.getWorkspace().build(CLEAN_BUILD) + FULL_BUILD when clean has no project, mirroring the project-level pair

- [x] Verified jdt build --clean clears stale markers after Eclipse restart
- [x] Tests pass — change is additive