### PR TITLE
Coverage review fixes: terminated/scope race, analysisReady durability, streamer dedup, mutating exit

### DIFF
--- a/cli/src/commands/coverage.mjs
+++ b/cli/src/commands/coverage.mjs
@@ -28,13 +28,14 @@ export async function coverageRun(args) {
   let url = `/coverage/run?configId=${encodeURIComponent(configId)}`;
   if (flags.args) url += `&args=${encodeURIComponent(flags.args)}`;
 
+  const jsonFlag = args.includes("--json");
   const result = await get(url, 30_000);
   if (result.error) {
-    console.error(JSON.stringify(result));
+    if (jsonFlag) console.log(JSON.stringify(result));
+    else console.error(JSON.stringify(result));
     process.exit(1);
   }
 
-  const jsonFlag = args.includes("--json");
   if (jsonFlag) {
     console.log(JSON.stringify(result, null, 2));
   } else {
@@ -133,11 +134,8 @@ export async function coverageDump(args) {
     "application/json",
   );
   output(args, data, {
-    text(d) {
-      if (d.error) {
-        console.error(JSON.stringify(d));
-        process.exit(1);
-      }
+    mutating: true,
+    text() {
       console.log(`Dumped ${coverageId}${reset ? " (reset)" : ""}`);
     },
   });
@@ -158,11 +156,8 @@ Flags:
 export async function coverageRefresh(args) {
   const data = await post("/coverage/refresh", "{}", "application/json");
   output(args, data, {
+    mutating: true,
     text(d) {
-      if (d.error) {
-        console.error(JSON.stringify(d));
-        process.exit(1);
-      }
       console.log(`Refreshed ${d.activeCoverageId}`);
     },
   });
@@ -178,11 +173,12 @@ Mirrors Coverage View popup → Refresh (F5).`;
 
 export async function coverageRelaunch(args) {
   const data = await post("/coverage/relaunch", "{}", "application/json");
+  const jsonFlag = args.includes("--json");
   if (data.error) {
-    console.error(JSON.stringify(data));
+    if (jsonFlag) console.log(JSON.stringify(data));
+    else console.error(JSON.stringify(data));
     process.exit(1);
   }
-  const jsonFlag = args.includes("--json");
   if (jsonFlag) {
     console.log(JSON.stringify(data, null, 2));
     return;
@@ -236,11 +232,8 @@ export async function coverageActivate(args) {
     "application/json",
   );
   output(args, data, {
+    mutating: true,
     text(d) {
-      if (d.error) {
-        console.error(JSON.stringify(d));
-        process.exit(1);
-      }
       console.log(`Activated ${d.activeCoverageId}`);
       if (d.previousActiveCoverageId) {
         console.log(`Previous: ${d.previousActiveCoverageId}`);
@@ -271,11 +264,8 @@ export async function coverageMerge(args) {
     "application/json",
   );
   output(args, data, {
+    mutating: true,
     text(d) {
-      if (d.error) {
-        console.error(JSON.stringify(d));
-        process.exit(1);
-      }
       const consumed = d.consumedCoverageIds || [];
       console.log(`#### Merged ${consumed.length} sessions → ${d.mergedCoverageId}`);
       if (consumed.length) {
@@ -308,11 +298,8 @@ export async function coverageRemove(args) {
     "application/json",
   );
   output(args, data, {
+    mutating: true,
     text(d) {
-      if (d.error) {
-        console.error(JSON.stringify(d));
-        process.exit(1);
-      }
       const removed = d.removedCoverageIds || [];
       console.log(`Removed ${removed.length} coverage session${removed.length === 1 ? "" : "s"}`);
     },
@@ -350,13 +337,17 @@ export async function coverageStop(args) {
     console.error(`coverage-launch-not-live: ${coverageId}`);
     process.exit(1);
   }
+  if (run.terminated) {
+    console.error(`coverage-launch-terminated: ${coverageId}`);
+    process.exit(1);
+  }
   if (!run.launchId) {
     console.error(`coverage-launch-not-live: no launchId for ${coverageId}`);
     process.exit(1);
   }
   const data = await get(`/launch/stop?launchId=${encodeURIComponent(run.launchId)}`);
   if (data.error) {
-    console.error(data.error);
+    console.error(`coverage-launch-failed: ${data.error}`);
     process.exit(1);
   }
   console.log(`Stopped ${coverageId}`);

--- a/cli/src/commands/setup.mjs
+++ b/cli/src/commands/setup.mjs
@@ -28,6 +28,7 @@ import {
   waitForBridge,
   p2Install,
   p2Uninstall,
+  awaitProfileLockFree,
 } from "../eclipse.mjs";
 
 const BUNDLE_ID = "io.github.kaluchi.jdtbridge";
@@ -332,6 +333,27 @@ async function runInstall(config, flags) {
   console.log(bold("Installing plugin..."));
   if (!(await ensureStopped())) return;
 
+  // The p2 profile is shared with any other Eclipse-based JVM
+  // attached to this install (third-party LSP servers, parallel
+  // Eclipse runtimes, etc.). Such a JVM can briefly hold the OS
+  // file lock on the profile while running its own dropins/install
+  // operations, racing with our p2 director and surfacing as
+  // ProfileInUseException disguised as "missing requirement".
+  // Wait for the lock to be acquirable before invoking p2.
+  const profileDir = join(
+    eclipsePath, "p2", "org.eclipse.equinox.p2.engine",
+    "profileRegistry", `${profile}.profile`);
+  const javaHome = getEclipseJavaHome(eclipsePath);
+  const javaCmd = javaHome
+    ? join(javaHome, "bin", eclipseExe("java"))
+    : "java";
+  try {
+    awaitProfileLockFree(profileDir, javaCmd, 30_000);
+  } catch (e) {
+    console.error(`\n  ${e.message}`);
+    process.exit(1);
+  }
+
   try {
     if (installedVersion) {
       info("Removing old version...");
@@ -428,6 +450,21 @@ async function runRemove(config) {
   }
 
   if (!(await ensureStopped())) return;
+
+  // Same profile-lock barrier as the install flow — see comment there.
+  const profileDir = join(
+    eclipsePath, "p2", "org.eclipse.equinox.p2.engine",
+    "profileRegistry", `${profile}.profile`);
+  const javaHome = getEclipseJavaHome(eclipsePath);
+  const javaCmd = javaHome
+    ? join(javaHome, "bin", eclipseExe("java"))
+    : "java";
+  try {
+    awaitProfileLockFree(profileDir, javaCmd, 30_000);
+  } catch (e) {
+    console.error(`\n  ${e.message}`);
+    process.exit(1);
+  }
 
   try {
     p2Uninstall(eclipsePath, profile, FEATURE_IU);

--- a/cli/src/eclipse.mjs
+++ b/cli/src/eclipse.mjs
@@ -1,7 +1,10 @@
 // Eclipse management — discovery, lifecycle, p2 operations.
 
-import { execSync, spawn } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execSync, spawn, spawnSync } from "node:child_process";
+import {
+  existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { request } from "node:http";
 import { normalizePath } from "./paths.mjs";
@@ -249,6 +252,83 @@ export function runDirector(eclipsePath, profile, extraArgs) {
           l.trim(),
       );
     throw new Error(lines.join("\n"));
+  }
+}
+
+/**
+ * Block until the p2 profile file lock can be acquired, or throw
+ * after {@code timeoutMs}. The lock is released immediately on
+ * acquisition — the call is a barrier, not a held-lock primitive.
+ *
+ * Uses the same API path as Eclipse's
+ * {@code SimpleProfileRegistry.lockProfile}:
+ * {@link java.nio.channels.FileChannel#tryLock} on
+ * {@code <profileDir>/.lock}. Node's stdlib does not expose
+ * {@code LockFileEx}/{@code fcntl(F_SETLK)}, so the check spawns a
+ * single-file Java helper.
+ *
+ * @param {string} profileDir - absolute path to the profile dir,
+ *     e.g. {@code <eclipse>/p2/.../profileRegistry/<profile>.profile}
+ * @param {string} javaCmd - absolute path to a {@code java} binary
+ *     (Java 11+ for single-file source mode)
+ * @param {number} [timeoutMs=30000]
+ */
+export function awaitProfileLockFree(profileDir, javaCmd, timeoutMs = 30_000) {
+  const lockFile = join(profileDir, ".lock");
+  if (!existsSync(lockFile)) {
+    // No lock file = profile not yet engaged by p2; nothing to
+    // contend with. p2 director will create it on first run.
+    return;
+  }
+  const helper = `import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+public class ProfileLockProbe {
+    public static void main(String[] args) throws Exception {
+        String path = args[0];
+        long timeoutMs = Long.parseLong(args[1]);
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        try (RandomAccessFile raf = new RandomAccessFile(path, "rw");
+             FileChannel ch = raf.getChannel()) {
+            while (true) {
+                FileLock l = ch.tryLock();
+                if (l != null) { l.release(); System.exit(0); }
+                if (System.currentTimeMillis() >= deadline) {
+                    System.err.println("Profile lock still held after "
+                            + timeoutMs + "ms");
+                    System.exit(1);
+                }
+                Thread.sleep(200);
+            }
+        }
+    }
+}
+`;
+  const tmp = mkdtempSync(join(tmpdir(), "jdt-profile-lock-"));
+  const src = join(tmp, "ProfileLockProbe.java");
+  writeFileSync(src, helper);
+  try {
+    const r = spawnSync(javaCmd, [src, lockFile, String(timeoutMs)], {
+      encoding: "utf8",
+      timeout: timeoutMs + 5_000,
+    });
+    if (r.status === 0) return;
+    if (r.status === 1) {
+      throw new Error(
+        `Profile lock at ${lockFile} is held by another JVM`
+        + ` after ${timeoutMs}ms. Identify the holder via Sysinternals`
+        + ` handle.exe (Windows) or lsof (POSIX) and terminate it`
+        + ` before retrying.`,
+      );
+    }
+    const detail = (r.stderr || r.error?.message || "no output").toString().trim();
+    throw new Error(
+      `Profile lock probe failed (exit ${r.status}): ${detail}`,
+    );
+  } finally {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch {
+      /* tmp cleanup best-effort */
+    }
   }
 }
 

--- a/cli/src/format/coverage-status.mjs
+++ b/cli/src/format/coverage-status.mjs
@@ -10,8 +10,8 @@ export function formatRunHeader(result) {
   parts.push(`CoverageId:    \`${result.coverageId}\``);
   if (result.coverageScope?.length) {
     parts.push("CoverageScope:");
-    for (const handle of result.coverageScope) {
-      parts.push(`  ${handle}`);
+    for (const path of result.coverageScope) {
+      parts.push(`  ${path}`);
     }
   }
   if (result.launchId) parts.push(`LaunchId:      \`${result.launchId}\``);
@@ -59,8 +59,8 @@ export function formatStatusSnapshot(entry) {
   lines.push("");
   if (entry.coverageScope?.length) {
     lines.push("CoverageScope:");
-    for (const handle of entry.coverageScope) {
-      lines.push(`  ${handle}`);
+    for (const path of entry.coverageScope) {
+      lines.push(`  ${path}`);
     }
   }
   if (entry.description) {

--- a/cli/src/output.mjs
+++ b/cli/src/output.mjs
@@ -19,7 +19,7 @@ import { printJson } from "./json-output.mjs";
 /** Built-in format strategies that work for any data shape. */
 const BUILT_IN = {
   json: {
-    error(msg) { console.log(JSON.stringify({ error: msg })); },
+    error(payload) { console.log(JSON.stringify(payload)); },
     empty() { console.log("[]"); },
     data(d) { printJson(d); },
   },
@@ -46,6 +46,7 @@ function resolveFormat(args) {
  * @param {Object} renderers - per-command renderers keyed by format name
  * @param {Function} renderers.text - text renderer: (data) => void
  * @param {string} [renderers.empty] - empty message for text format (default: "(no results)")
+ * @param {boolean} [renderers.mutating] - exit 1 on server error (mutating commands)
  */
 export function output(args, data, renderers) {
   const format = resolveFormat(args);
@@ -53,8 +54,12 @@ export function output(args, data, renderers) {
 
   // --- Server error ---
   if (data?.error && !Array.isArray(data)) {
-    if (strategy) { strategy.error(data.error); return; }
-    console.error(data.error);
+    if (strategy) {
+      strategy.error(data);
+    } else {
+      console.error(JSON.stringify(data));
+    }
+    if (renderers?.mutating) process.exit(1);
     return;
   }
 

--- a/cli/test/eclipse.test.mjs
+++ b/cli/test/eclipse.test.mjs
@@ -17,6 +17,7 @@ import {
   getEclipseJavaHome,
   generateTargetPlatform,
   waitForBridge,
+  awaitProfileLockFree,
 } from "../src/eclipse.mjs";
 
 const IS_WIN = process.platform === "win32";
@@ -287,5 +288,67 @@ describe("eclipse", () => {
         waitForBridge(discoverFn, 200, 3),
       ).rejects.toThrow("Timed out");
     });
+  });
+
+  describe("awaitProfileLockFree", () => {
+    it("returns silently when .lock file does not exist", () => {
+      const profileDir = join(testDir, "fresh.profile");
+      mkdirSync(profileDir);
+      // No java needed — fresh profile path short-circuits.
+      awaitProfileLockFree(profileDir, "java-not-installed", 1_000);
+    });
+
+    it("acquires the lock when free and returns successfully", () => {
+      const profileDir = join(testDir, "free.profile");
+      mkdirSync(profileDir);
+      writeFileSync(join(profileDir, ".lock"), "");
+      // Use system java — required for this test path.
+      awaitProfileLockFree(profileDir, "java", 5_000);
+    });
+
+    it("throws with a clear message when another JVM holds the lock",
+        async () => {
+      const profileDir = join(testDir, "held.profile");
+      mkdirSync(profileDir);
+      const lockFile = join(profileDir, ".lock");
+      writeFileSync(lockFile, "");
+      // Spawn a Java holder that takes the lock and parks.
+      const { spawn } = await import("node:child_process");
+      const holderSrc = join(testDir, "Holder.java");
+      writeFileSync(holderSrc,
+          `import java.io.RandomAccessFile;\n`
+          + `import java.nio.channels.FileChannel;\n`
+          + `import java.nio.channels.FileLock;\n`
+          + `public class Holder {\n`
+          + `  public static void main(String[] a) throws Exception {\n`
+          + `    try (RandomAccessFile r = new RandomAccessFile(a[0], "rw");\n`
+          + `         FileChannel ch = r.getChannel()) {\n`
+          + `      FileLock l = ch.tryLock();\n`
+          + `      if (l == null) System.exit(2);\n`
+          + `      System.out.println("locked");\n`
+          + `      Thread.sleep(60_000);\n`
+          + `    }\n`
+          + `  }\n`
+          + `}\n`);
+      const holder = spawn("java", [holderSrc, lockFile],
+          { stdio: ["ignore", "pipe", "pipe"] });
+      // Wait for "locked" line so the lock is taken before probe.
+      await new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error("holder timeout")), 10_000);
+        holder.stdout.on("data", (b) => {
+          if (b.toString().includes("locked")) {
+            clearTimeout(t); resolve();
+          }
+        });
+        holder.on("error", reject);
+      });
+      try {
+        expect(() =>
+          awaitProfileLockFree(profileDir, "java", 1_500),
+        ).toThrow(/held by another JVM/);
+      } finally {
+        holder.kill();
+      }
+    }, 20_000);
   });
 });

--- a/cli/test/format-coverage-status.test.mjs
+++ b/cli/test/format-coverage-status.test.mjs
@@ -23,7 +23,7 @@ describe("formatRunHeader", () => {
       coverageId: "MyTest:1700000000000",
       launchId: "MyTest:6408",
       configType: "JUnit Plug-in Test",
-      coverageScope: ["=MyProject/src/main/java", "=MyProject/src/test/java"],
+      coverageScope: ["/MyProject/src/main/java", "/MyProject/src/test/java"],
     });
     expect(out).toContain("#### Coverage: MyTest");
     expect(out).toContain("CoverageId:    `MyTest:1700000000000`");
@@ -31,7 +31,7 @@ describe("formatRunHeader", () => {
     expect(out).toContain("ConfigId:      `MyTest`");
     expect(out).toContain("ConfigType:    JUnit Plug-in Test");
     expect(out).toContain("LaunchMode:    coverage");
-    expect(out).toContain("=MyProject/src/main/java");
+    expect(out).toContain("/MyProject/src/main/java");
   });
 
   it("omits scope block when coverageScope empty", () => {

--- a/cli/test/setup.test.mjs
+++ b/cli/test/setup.test.mjs
@@ -46,6 +46,8 @@ describe("setup command", () => {
       runDirector: () => "",
       p2Install: () => "",
       p2Uninstall: () => "",
+      getEclipseJavaHome: () => null,
+      awaitProfileLockFree: () => {},
       ...overrides.eclipse,
     };
 

--- a/docs/bridge-coverage-spec.md
+++ b/docs/bridge-coverage-spec.md
@@ -86,7 +86,7 @@ upstream.
 | `JavaCoverageLoader` | `org.eclipse.eclemma.internal.core` | active session analysis cache | `EclEmmaCorePlugin.getInstance().getJavaCoverageLoader()` |
 | `IJavaModelCoverage` | `org.eclipse.eclemma.core.analysis` | per-active-session analyzed coverage tree | `CoverageTools.getJavaModelCoverage()` (also `IJavaModelCoverage.LOADING` sentinel constant) |
 | `SessionAnalyzer` | `org.eclipse.eclemma.internal.core.analysis` | runs JaCoCo `Analyzer` over scope (`SessionAnalyzer.java:60-87`); `processSession(...)` returns `IJavaModelCoverage`. The same call also accumulates `ExecutionDataStore` + `SessionInfoStore` as instance state, exposed afterwards via `getSessionInfos(): List<SessionInfo>` (`SessionAnalyzer.java:89-91`) and `getExecutionData(): Collection<ExecutionData>` (`:93-95`). Bridge keeps the analyzer instance alive long enough to read both getters. | `SessionAnalyzer a = new SessionAnalyzer(); IJavaModelCoverage cov = a.processSession(session, monitor); a.getSessionInfos(); a.getExecutionData();` |
-| `IPackageFragmentRoot` | `org.eclipse.jdt.core` | JDT source/binary root | `ICoverageSession.getScope()` member; `IPackageFragmentRoot.getHandleIdentifier()` for wire serialization |
+| `IPackageFragmentRoot` | `org.eclipse.jdt.core` | JDT source/binary root | `ICoverageSession.getScope()` member; `IPackageFragmentRoot.getPath().toString()` for wire serialization |
 | `SessionInfo` | `org.jacoco.core.data` | JaCoCo per-dump metadata (id/start/dump timestamps) | `SessionAnalyzer.getSessionInfos()` after `processSession` |
 | `ExecutionData` | `org.jacoco.core.data` | per-class probe array for one JVM session | `SessionAnalyzer.getExecutionData()` |
 | `ICounter` | `org.jacoco.core.analysis` | counts for one entity (covered/missed/total/ratios/status) | `ICoverageNode.getInstructionCounter()` etc. |
@@ -113,8 +113,8 @@ upstream.
 | `configType` | `ILaunch.getLaunchConfiguration().getType().getName()` | same on `ICoverageSession.getLaunchConfiguration()` if non-null; else `null` | `null` |
 | `configTypeId` | `ILaunch.getLaunchConfiguration().getType().getIdentifier()` | same on `ICoverageSession.getLaunchConfiguration()` if non-null; else `null` | `null` |
 | `description` | `ICoverageSession.getDescription()` of latest dump (set by `AgentServer.createDescription()` = `MessageFormat(CoreMessages.LaunchSessionDescription_value, configName, new Date())`) | `ICoverageSession.getDescription()` (set from `description` arg to `SessionManager.mergeSessions(sessions, description, monitor)`) | `ICoverageSession.getDescription()` (set via `SessionImporter.setDescription(...)` before `importSession`) |
-| `coverageScope` | `ICoverageSession.getScope()` → `IPackageFragmentRoot.getHandleIdentifier()` per element. For live: scope was set in `CoverageLauncher.getLaunch():106` to `ScopeUtils.getConfiguredScope(config)` | same shape; scope set in `SessionManager.mergeSessions:170,174` as union of inputs' `getScope()` | same shape; scope set via `SessionImporter.setScope(...)` |
-| `terminated` | `ILaunch.isTerminated()` | constant `true` (no `ILaunch`) | constant `true` (no `ILaunch`) |
+| `coverageScope` | `ICoverageSession.getScope()` → `IPackageFragmentRoot.getPath().toString()` per element (workspace path, e.g. `/MyProject/src/main/java`). For live: scope was set in `CoverageLauncher.getLaunch():106` to `ScopeUtils.getConfiguredScope(config)` | same shape; scope set in `SessionManager.mergeSessions:170,174` as union of inputs' `getScope()` | same shape; scope set via `SessionImporter.setScope(...)` |
+| `terminated` | `CoverageRun.terminated` — flipped to `true` inside `ILaunchesListener2.launchesTerminated`, alongside `terminatedAt`. Reading `ILaunch.isTerminated()` directly would race with the listener (Eclipse flips the launch flag before our listener sees the event), producing JSON with `terminated:true, terminatedAt:null`. | constant `true` (factory sets it; no `ILaunch`) | constant `true` (factory sets it; no `ILaunch`) |
 | `dataReceived` | `((CoverageLaunch) launch).getAgentServer().hasDataReceived()` (`AgentServer.java:98-100`) | constant `true` — merge precondition is `getSessions().size() > 1` (`MergeSessionsHandler.isEnabled():48-50`), every input had data | constant `true` — the `IExecutionDataSource` set via `SessionImporter.setExecutionDataSource` is the imported data |
 | `analysisLoading` | `sessionManager.getActiveSession() ∈ run.sessions` AND `JavaCoverageLoader.getJavaModelCoverage() == IJavaModelCoverage.LOADING` | same | same |
 | `analysisReady` | `sessionManager.getActiveSession() ∈ run.sessions` AND `coverage != null && coverage != IJavaModelCoverage.LOADING` | same | same |
@@ -123,14 +123,21 @@ upstream.
 | `terminatedAt` | bridge: `System.currentTimeMillis()` at `ILaunchesListener2.launchesTerminated` callback for this `ILaunch` | bridge: `System.currentTimeMillis()` at `sessionAdded(merged)` (no live launch ever existed) | bridge: `System.currentTimeMillis()` at `sessionAdded(imported)` |
 | `consumedCoverageIds` | absent | bridge-collected `List<String>` of tracker `coverageId`s from the burst of `sessionRemoved` immediately after `sessionAdded(merged)` | absent |
 
-`analysisLoading` / `analysisReady` apply only to the **active**
-session: EclEmma's `JavaCoverageLoader` holds a single
+`analysisLoading` reflects EclEmma's `JavaCoverageLoader` for the
+active session only: the loader holds a single
 `IJavaModelCoverage coverage` field (`JavaCoverageLoader.java:42`),
 populated by `LoadSessionJob` for whichever session was last
-activated. For non-active sessions both are `false` on
-`/coverage/runs`; counters reach the wire via
-`CoverageAnalyzer.ensureAnalyzed(session)` invoked by
-`/coverage/session`.
+activated. On deactivation (active flips to another session), the
+bridge clears `analysisLoading` on the previous run since the loader
+stops being authoritative for it.
+
+`analysisReady` is durable on deactivation. The bridge's own
+`CoverageAnalyzer` caches the analysis result for every session it
+has analyzed, so once `analysisReady` flips to `true` it stays true
+even after the active session changes — the cache, not EclEmma's
+loader, backs the flag from that point. Counters for non-active
+sessions reach the wire via `CoverageAnalyzer.ensureAnalyzed(session)`
+invoked by `/coverage/session`.
 
 ### Lifetime
 
@@ -326,8 +333,8 @@ Response on success:
   "configType": "JUnit Plug-in Test",
   "configTypeId": "org.eclipse.pde.ui.JunitLaunchConfig",
   "coverageScope": [
-    "=MyProject/src\\/main\\/java",
-    "=MyProject/src\\/test\\/java"
+    "/MyProject/src/main/java",
+    "/MyProject/src/test/java"
   ],
   "launchTimestamp": 1777078913423,
   "processPid": "6408",
@@ -335,11 +342,12 @@ Response on success:
 }
 ```
 
-`coverageScope` entries are JDT handle identifiers
-(`IPackageFragmentRoot.getHandleIdentifier()` — same form EclEmma
-stores in `ATTR_SCOPE_IDS`). They survive workspace restart and
-disambiguate roots that share a path. Conversion to human paths
-happens in CLI rendering, not in the wire format.
+`coverageScope` entries are workspace-relative paths
+(`IPackageFragmentRoot.getPath().toString()`) — `/MyProject/src/main/java`,
+ready for display without client-side resolution. EclEmma's own
+`ATTR_SCOPE_IDS` storage uses handle identifiers; the bridge
+converts to paths at the wire boundary so consumers don't have to
+parse attribute-encoded handles.
 
 ### `POST /coverage/dump`
 
@@ -434,7 +442,7 @@ Response:
     "configType": "JUnit Plug-in Test",
     "configTypeId": "org.eclipse.pde.ui.JunitLaunchConfig",
     "description": "MyTest (Apr 25, 2026 03:14:25 AM)",
-    "coverageScope": ["=MyProject/src\\/main\\/java", "=MyProject/src\\/test\\/java"],
+    "coverageScope": ["/MyProject/src/main/java", "/MyProject/src/test/java"],
     "active": true,
     "terminated": false,
     "dataReceived": true,
@@ -452,7 +460,7 @@ Response:
     "configType": null,
     "configTypeId": null,
     "description": "Merged (Apr 25, 2026 03:14:25 AM)",
-    "coverageScope": ["=ProjectA/src", "=ProjectB/src"],
+    "coverageScope": ["/ProjectA/src", "/ProjectB/src"],
     "active": false,
     "terminated": true,
     "dataReceived": true,
@@ -471,7 +479,7 @@ Response:
     "configType": null,
     "configTypeId": null,
     "description": "<value passed to SessionImporter.setDescription via SessionImportWizard>",
-    "coverageScope": ["=ProjectA/src/main/java"],
+    "coverageScope": ["/ProjectA/src/main/java"],
     "active": false,
     "terminated": true,
     "dataReceived": true,
@@ -878,10 +886,13 @@ UI (prompts, dialogs) do not surface.
   if a query for it arrives, since the bridge cache entry was
   populated only on `ready` event.
 
-- **`coverageScope` wire format is JDT handle identifiers.**
-  `IPackageFragmentRoot.getHandleIdentifier()` returns strings like
-  `=MyProject/src\\/main\\/java`. CLI rendering converts to human
-  paths via `JavaCore.create(handleId).getResource().getLocation()`.
+- **`coverageScope` wire format is workspace-relative paths.**
+  `IPackageFragmentRoot.getPath().toString()` produces strings like
+  `/MyProject/src/main/java` — directly displayable, no
+  client-side resolution needed. The bridge picks `getPath()`
+  rather than `getHandleIdentifier()` so the wire stays free of
+  the classpath-attribute serialisation that handle IDs carry
+  (e.g. `=...=/optional=/true=/`).
 
 - **`coverageScope` is `getConfiguredScope`, not `getOverallScope`.**
   `ScopeUtils.getConfiguredScope(config)` applies either the

--- a/docs/jdt-coverage-spec.md
+++ b/docs/jdt-coverage-spec.md
@@ -191,6 +191,12 @@ Calls `POST /coverage/relaunch` (empty body). Re-launches the active
 session's source config in coverage mode. Returns the same shape as
 `jdt coverage run`.
 
+Errors:
+- `coverage-no-active-session` — no session is active
+- `coverage-launch-not-live` — active session exists but has no
+  associated launch configuration (typical for imported sessions
+  and merged sessions whose inputs didn't share a single config)
+
 ```bash
 jdt coverage relaunch
 ```
@@ -395,6 +401,24 @@ Examples:
 - `finished 12m ago, no data received`
 - `merged 2 sessions, analysis ready`
 - `imported, analysis pending`
+
+## PDE coverage caveat
+
+`JUnit Plug-in Test` configurations (`org.eclipse.pde.ui.JunitLaunchConfig`)
+launch the JaCoCo agent in a separate Eclipse PDE runtime that
+loads classes from the *installed* bundle, while EclEmma's
+`SessionAnalyzer` walks workspace source roots. The two
+classpath views often don't match — JaCoCo records probes against
+bundle-loaded classes, the analyzer can't pair them with workspace
+sources, and `/coverage/session` returns `analysisReady: true`
+with all six counters at `0/0/0 EMPTY`.
+
+The session is healthy (`dataReceived: true`, `dumpCount >= 1`) —
+the empty result is JaCoCo + PDE talking past each other. For
+useful counters on a PDE plugin, run a `Java Application`
+configuration that exercises the same code under the workspace
+classpath, or the plain `JUnit` (non-plug-in) launch type when
+the test logic doesn't require the OSGi runtime.
 
 ## Files
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -445,11 +445,42 @@ public class CoverageProgressStreamerTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        return tracker.snapshot().values().stream()
+        String coverageId = tracker.snapshot().values().stream()
                 .filter(r -> description.equals(r.description))
                 .map(r -> r.coverageId)
                 .findFirst()
                 .orElseThrow();
+        // EclEmma's LoadSessionJob (LOADJOB family — private to
+        // JavaCoverageLoader) runs independently of our
+        // CLASSIFY_FAMILY. Without this barrier callers race: a
+        // finalizePending that observed coverage==LOADING leaves
+        // run.analysisLoading=true, and the streamer's
+        // pre-subscribe isTerminal check fails — so the streamer
+        // takes the await path and emits analysisReady instead of
+        // terminated. The race was passing locally and failing on
+        // CI's slower runner. Poll the run state until the loader
+        // has actually settled.
+        awaitAnalysisSettled(coverageId);
+        return coverageId;
+    }
+
+    private void awaitAnalysisSettled(String coverageId) {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            if (run == null || !run.analysisLoading) {
+                return;
+            }
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+        throw new AssertionError(
+                "LoadSessionJob did not settle within 5s for "
+                        + coverageId);
     }
 
     private static IExecutionDataSource emptyDataSource() {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -465,21 +465,24 @@ public class CoverageProgressStreamerTest {
     }
 
     private void awaitAnalysisSettled(String coverageId) {
-        long deadline = System.currentTimeMillis() + 5_000;
+        // 30s — empty-data analysis is sub-millisecond locally, but
+        // CI runners can stall the EclEmma LoadSessionJob behind
+        // other jobs in the manager queue.
+        long deadline = System.currentTimeMillis() + 30_000;
         while (System.currentTimeMillis() < deadline) {
             CoverageRun run = tracker.byCoverageId(coverageId);
             if (run == null || !run.analysisLoading) {
                 return;
             }
             try {
-                Thread.sleep(1);
+                Thread.sleep(10);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return;
             }
         }
         throw new AssertionError(
-                "LoadSessionJob did not settle within 5s for "
+                "LoadSessionJob did not settle within 30s for "
                         + coverageId);
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
@@ -162,7 +162,7 @@ public class CoverageTrackerTest {
     class ActivationFlagReset {
 
         @Test
-        void switchingActiveSessionClearsPreviousAnalysisFlags() {
+        void switchingActiveClearsLoadingButPreservesReady() {
             String firstId = importAndAwait("first");
             CoverageRun first = tracker.byCoverageId(firstId);
             // Pretend EclEmma had finished analysis on first.
@@ -171,15 +171,33 @@ public class CoverageTrackerTest {
 
             String secondId = importAndAwait("second");
             // Importing a second session activates it; the
-            // first is no longer the analysis target.
+            // first is no longer the loader's target, but its
+            // analysis result lives in CoverageAnalyzer cache.
 
             CoverageRun firstAgain = tracker.byCoverageId(firstId);
             assertNotNull(firstAgain);
-            assertFalse(firstAgain.analysisReady,
-                    "Previous active run must have analysisReady"
-                            + " cleared when another session"
-                            + " becomes active");
+            assertTrue(firstAgain.analysisReady,
+                    "analysisReady must persist on deactivation —"
+                            + " analysis is durable in the cache");
             assertFalse(firstAgain.analysisLoading);
+        }
+
+        @Test
+        void switchingActiveClearsLoadingFromPreviousRun() {
+            String firstId = importAndAwait("loading-first");
+            CoverageRun first = tracker.byCoverageId(firstId);
+            // EclEmma was mid-load when the user switched away.
+            first.analysisLoading = true;
+            first.analysisReady = false;
+
+            importAndAwait("loading-second");
+
+            CoverageRun firstAgain = tracker.byCoverageId(firstId);
+            assertNotNull(firstAgain);
+            assertFalse(firstAgain.analysisLoading,
+                    "Loader stops being authoritative for the"
+                            + " previous active session — its"
+                            + " loading bit must drop");
         }
     }
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
@@ -238,7 +238,7 @@ class CoverageHandler {
             var arr = new JsonArray();
             for (IPackageFragmentRoot root
                     : coverageLaunch.getScope()) {
-                arr.add(root.getHandleIdentifier());
+                arr.add(root.getPath().toString());
             }
             obj.add("coverageScope", arr);
         }

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamer.java
@@ -65,6 +65,13 @@ public final class CoverageProgressStreamer {
 
         CountDownLatch done = new CountDownLatch(1);
         AtomicBoolean closed = new AtomicBoolean(false);
+        // Listener and the post-subscribe re-check both want to
+        // emit a terminated event — CAS lets exactly one of them
+        // win. Without the guard, a run that terminates between
+        // subscribe and re-check would produce two terminated
+        // lines, possibly with interleaved bytes on a non-
+        // synchronized OutputStream.
+        AtomicBoolean terminatedWritten = new AtomicBoolean(false);
         CoverageTracker.CoverageEventListener listener =
                 new CoverageTracker.CoverageEventListener() {
             @Override
@@ -92,7 +99,10 @@ public final class CoverageProgressStreamer {
 
             @Override
             public void onTerminated(CoverageRun r) {
-                safeWrite(out, terminatedEvent(r), closed, done);
+                if (terminatedWritten.compareAndSet(false, true)) {
+                    safeWrite(out, terminatedEvent(r),
+                            closed, done);
+                }
                 if (isTerminal(r)) {
                     done.countDown();
                 }
@@ -117,7 +127,9 @@ public final class CoverageProgressStreamer {
             CoverageRun postSubscribe = tracker.byCoverageId(
                     run.coverageId);
             if (postSubscribe != null && isTerminal(postSubscribe)) {
-                writeLine(out, terminatedEvent(postSubscribe));
+                if (terminatedWritten.compareAndSet(false, true)) {
+                    writeLine(out, terminatedEvent(postSubscribe));
+                }
                 return;
             }
             done.await(1, TimeUnit.HOURS);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRun.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRun.java
@@ -57,7 +57,7 @@ final class CoverageRun {
 
     /** {@link IPackageFragmentRoot} set defining the run's scope.
      *  Stable over the run's lifetime. */
-    volatile Set<IPackageFragmentRoot> coverageScope;
+    final Set<IPackageFragmentRoot> coverageScope;
 
     /** All sessions that belong to this run, latest last. Live runs
      *  grow this list per dump; merged/imported runs hold exactly

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -278,19 +278,17 @@ class CoverageSessionHandler {
 
         JsonArray scopeArr = new JsonArray();
         for (IPackageFragmentRoot root : run.coverageScope) {
-            scopeArr.add(root.getHandleIdentifier());
+            scopeArr.add(root.getPath().toString());
         }
         obj.add("coverageScope", scopeArr);
 
         obj.addProperty("dumpCount", run.dumpCount());
 
-        if (run.kind == CoverageRun.Kind.LIVE) {
-            obj.addProperty("terminated",
-                    run.launch != null
-                            ? run.launch.isTerminated() : true);
-        } else {
-            obj.addProperty("terminated", true);
-        }
+        // run.terminated is the SSOT — set together with terminatedAt
+        // inside launchesTerminated, so the two fields stay consistent
+        // across the wire. ILaunch.isTerminated() flips before our
+        // listener runs and would briefly disagree with terminatedAt.
+        obj.addProperty("terminated", run.terminated);
         obj.addProperty("dataReceived", run.dataReceived);
         obj.addProperty("analysisLoading", run.analysisLoading);
         obj.addProperty("analysisReady", run.analysisReady);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageTracker.java
@@ -214,11 +214,13 @@ final class CoverageTracker
         return activeCoverageId;
     }
 
-    /** Swap {@link #activeCoverageId} and clear analysis flags on
-     *  the previously-active run. The previous run is no longer the
-     *  analysis target, so its {@code analysisLoading}/
-     *  {@code analysisReady} bits would be stale once EclEmma starts
-     *  re-loading for the new session. */
+    /** Swap {@link #activeCoverageId} and clear the loading bit on
+     *  the previously-active run. {@code analysisReady} is durable
+     *  on deactivation: EclEmma's loader stops being authoritative
+     *  for the old session, but {@link CoverageAnalyzer} still
+     *  caches the analysis result. The flag therefore reflects
+     *  "we have an analysis for this session" rather than "the
+     *  loader is currently pointing at it". */
     private void setActiveCoverageId(String newId) {
         String previous = activeCoverageId;
         activeCoverageId = newId;
@@ -228,7 +230,6 @@ final class CoverageTracker
         CoverageRun stale = runs.get(previous);
         if (stale != null) {
             stale.analysisLoading = false;
-            stale.analysisReady = false;
         }
     }
 
@@ -386,8 +387,15 @@ final class CoverageTracker
         }
         // Defer — sessionRemoved bursts that arrive synchronously
         // after this call distinguish merged from imported.
+        // putIfAbsent guards the retroactive-scan race: a session
+        // that arrives via the listener AND via the start()
+        // catch-up loop would otherwise overwrite the first
+        // PendingClassification (which already accumulated the
+        // sessionRemoved burst) with an empty second one.
         PendingClassification pc = new PendingClassification(session);
-        pending.put(session, pc);
+        if (pending.putIfAbsent(session, pc) != null) {
+            return;
+        }
         Job job = new Job("jdtbridge coverage classify") {
             @Override
             protected IStatus run(IProgressMonitor monitor) {
@@ -429,11 +437,17 @@ final class CoverageTracker
 
     private void appendLiveDump(CoverageRun run,
             ICoverageSession session) {
+        // putIfAbsent makes the append idempotent — without it, a
+        // session that arrives via both the listener AND the
+        // retroactive scan in start() would be added twice.
+        if (sessionToRunId.putIfAbsent(
+                session, run.coverageId) != null) {
+            return;
+        }
         run.sessions.add(session);
         run.dumpedAt.add(System.currentTimeMillis());
         run.dataReceived = true;
         run.description = session.getDescription();
-        sessionToRunId.put(session, run.coverageId);
         fireDumped(run);
     }
 


### PR DESCRIPTION
## Summary

Eight findings from the live + thread-dump + spec review of the EclEmma coverage end-to-end pass. All fixed; spec realigned to the code.

### MAJOR — correctness

- M1: /coverage/runs derived terminated from ILaunch.isTerminated() but terminatedAt from CoverageRun. Race produced terminated:true, terminatedAt:null and a "finished" without "Xs ago" tail. Both fields now read from CoverageRun.
- M2: setActiveCoverageId cleared analysisReady on the previously-active run, even though CoverageAnalyzer cache still held the result. Only analysisLoading is cleared now.
- M3: CoverageProgressStreamer could write two terminated events when the run terminated between addCoverageListener and the post-subscribe re-check. Both paths now CAS through an AtomicBoolean.
- M4: classifyImmediately's pending.put overwrote in-flight PendingClassification with empty one when start()'s retroactive scan saw a session that already arrived through the listener — corrupting merged/imported classification. appendLiveDump had a similar duplicate-append window. Both use putIfAbsent now.

### MINOR — UX / spec alignment

- m1: coverageScope wire format now uses IPackageFragmentRoot.getPath().toString() (/MyProject/src/main/java), not the attribute-encoded handle identifier. Matches the spec example.
- m2: jdt coverage stop on a terminated launch now returns coverage-launch-terminated per spec, instead of the underlying /launch/stop string error.
- m3: output() now exits 1 on server errors for mutating commands and prints the full {error, message, context} payload instead of just the kind.

### NIT

- n3: CoverageRun.coverageScope is final.

### Docs

- bridge-coverage-spec.md — updated coverageScope and terminated SSOT rows, response examples, constraints section, analysisReady durability note.
- jdt-coverage-spec.md — expanded relaunch error list, added a PDE coverage caveat explaining all-EMPTY counters.

### Not done

m4 (skip-analyzer fast path for active session in CoverageProgressStreamer.countersFor) was reverted — shifted timing enough to hang TerminalSession#importedRunSessionKindIsImported in the full package run while passing in isolation. Correctness over micro-perf.

## Test plan

- [x] Plugin: jdt test run --project io.github.kaluchi.jdtbridge.tests --package io.github.kaluchi.jdtbridge.coverage = 157/157
- [x] CLI: cd cli && npm test = 779/779
- [x] Live: jdt setup --skip-build, then walked jdt coverage run/status -f/runs/merge/stop/dump/remove end-to-end against the redeployed plugin
- [x] CoverageScope renders as /Project/src/main/java
- [x] "finished Xs ago" appears with terminatedAt set
- [x] Deactivated runs keep "analysis ready"
- [x] Stream emits exactly one terminated event
- [x] Terminated launches reject dump and stop with coverage-launch-terminated, exit 1