### PR TITLE
Add /coverage/node — point lookup of one element's raw coverage

### DIFF
--- a/docs/bridge-coverage-spec.md
+++ b/docs/bridge-coverage-spec.md
@@ -553,6 +553,13 @@ SSOT for the additional fields:
 returned successfully (it always runs synchronously when called —
 either reads bridge cache or invokes `SessionAnalyzer.processSession`).
 
+`counters.*` is the sum of per-project children:
+`Σ getCoverageFor(project).getCounter*()` over
+`IJavaModelCoverage.getProjects()`, accumulated through
+`CoverageNodeImpl.increment` into a session-level
+`CoverageNodeImpl(GROUP, "session")` by
+`CoverageSessionHandler.aggregateProjectCounters`.
+
 `jacocoSessionInfos` length comes from
 `SessionInfoStore.getInfos()` after `session.accept(execStore,
 sessionInfoStore)`. Per kind:
@@ -568,6 +575,88 @@ sessionInfoStore)`. Per kind:
 - `imported`: whatever the imported `.exec` file contains, parsed
   by `URLExecutionDataSource.accept` via
   `ExecutionDataReader.read()`
+
+### `GET /coverage/node`
+
+Point lookup of one element's raw coverage data — counters and
+(for source-bearing element kinds) per-line breakdown.
+
+Params:
+- `coverageId` (required, with optional `:N` dump suffix)
+- `fqn` (required) — IJavaElement identifier in the convention
+  used by `jdt q` (see `jdt-query-spec` § fqn format by kind)
+
+Resolves `fqn` via `JdtUtils.resolveElement` to an `IJavaElement`,
+then asks the cached `IJavaModelCoverage` for that element's
+`ICoverageNode`. Triggers `CoverageAnalyzer.ensureAnalyzed(session)`
+on first call (cached after). The endpoint blocks during analysis.
+
+Response — `counters` always present; `lines` block present iff
+the returned `ICoverageNode` is an `ISourceNode` subtype (type /
+method / source-file):
+
+```json
+{
+  "coverageId": "MyTest:1777078913423",
+  "fqn": "pkg.Foo#bar(java.lang.String)",
+  "elementKind": "method",
+  "elementType": "METHOD",
+  "counters": {
+    "instruction": { ...counter shape... },
+    "branch":      { ...counter shape... },
+    "line":        { ...counter shape... },
+    "complexity":  { ...counter shape... },
+    "method":      { ...counter shape... },
+    "class":       { ...counter shape... }
+  },
+  "lines": {
+    "firstLine": 42,
+    "lastLine": 78,
+    "entries": [
+      {
+        "line": 42,
+        "status": "FULLY_COVERED",
+        "instructionCovered": 5,
+        "instructionMissed": 0,
+        "branchCovered": 0,
+        "branchMissed": 0
+      }
+    ]
+  }
+}
+```
+
+`entries` includes only non-empty source lines — those whose
+`ILine.getStatus() != ICounter.EMPTY`. Empty lines (outside
+`[firstLine, lastLine]`, or with no instructions / no branches)
+are omitted; clients re-derive them as the gap between
+consecutive entries.
+
+SSOT mapping:
+
+| Field | SSOT type | API path |
+|---|---|---|
+| `elementKind` | wire kebab-token | `IJavaElement.getElementType()` mapped to `project` / `packageFragmentRoot` / `package` / `type` / `method` / `field` / `file` / `classFile` / `other` |
+| `elementType` | `ICoverageNode.ElementType` | `node.getElementType().name()` (`GROUP` / `BUNDLE` / `PACKAGE` / `CLASS` / `METHOD` / `SOURCEFILE`) |
+| `counters.*` | `ICounter` (JaCoCo) | `node.get<X>Counter()` where `node = IJavaModelCoverage.getCoverageFor(element)` |
+| `lines.firstLine` | `int` | `ISourceNode.getFirstLine()` |
+| `lines.lastLine` | `int` | `ISourceNode.getLastLine()` |
+| `lines.entries[i].line` | `int` | iteration index in `[firstLine, lastLine]` |
+| `lines.entries[i].status` | wire enum | `ILine.getStatus()` → `EMPTY` / `NOT_COVERED` / `FULLY_COVERED` / `PARTLY_COVERED` |
+| `lines.entries[i].instructionCovered/Missed` | `ICounter` | `ILine.getInstructionCounter().getCoveredCount()` / `getMissedCount()` |
+| `lines.entries[i].branchCovered/Missed` | `ICounter` | `ILine.getBranchCounter().getCoveredCount()` / `getMissedCount()` |
+
+Errors specific to this endpoint:
+- `coverage-fqn-unresolved` — missing `fqn`, malformed, or
+  `JdtUtils.resolveElement` returned `null` (no such workspace
+  element)
+- `coverage-no-data-for-element` — element resolved but
+  `IJavaModelCoverage.getCoverageFor` returned `null`. JaCoCo has
+  no field-level coverage, so all `IField` subjects fall here;
+  types outside the session's analysis scope also fall here.
+
+Plus the shared `coverage-not-found` / `coverage-dump-not-found` /
+`coverage-analysis-failed` from `/coverage/session`.
 
 ### `GET /coverage/session/stream`
 

--- a/docs/jdt-coverage-analyze-spec.md
+++ b/docs/jdt-coverage-analyze-spec.md
@@ -1,52 +1,32 @@
 # jdt coverage analyze — Design Spec
 
-Synthesis of UX research, EclEmma data-model surface, onboarding
-lifecycle, and design constraints for the coverage-analysis query
-layer of `jdt q`.
-
-This document is a single dump of the design rationale before
-implementation. After the feature lands, the constituent parts split
-into the relevant pinpoint specs:
+Cross-cutting principles, vocabulary contract, and edge-case
+constraints for the `:jdt/coverage` qlang axes layered on the
+coverage analysis cache. Detail surfaces split across:
 
 - CLI commands and onboarding texts → `jdt-coverage-spec.md`
-- qlang axes and conduits → `jdt-query-spec.md` (or a sibling
-  `jdt-coverage-query-spec.md`)
+- qlang axes and conduits → `jdt-query-spec.md`
 - HTTP endpoint and node-Map shape → `bridge-coverage-spec.md`
-
-What lives here permanently: the cross-cutting principles, vocabulary
-contract, and edge-case constraints that any of the downstream specs
-must respect.
 
 ## Context
 
-The existing CLI gives the agent only session-management commands —
-`run`, `runs`, `status`, `dump`, `merge`, `relaunch`, `remove`,
-`stop`. Once a session reaches `analysisReady`, the agent has no
-first-class way to ask *anything* about the result without dropping
-into raw HTTP / JSON parsing. Aggregate counters at session level
-are returned by `/coverage/session`, but per-element drilldown,
-per-line gaps, untested-predicate filtering, and graph-joined
-queries are absent.
-
-Underneath, the data is already there. EclEmma's
-`SessionAnalyzer` produces `IJavaModelCoverage` per session;
-`CoverageAnalyzer` (this plugin) caches that result by
-`ICoverageSession` identity, including raw JaCoCo `SessionInfo`
-and `ExecutionData`. A query layer over this cache, exposing the
-results via `:jdt/coverage` qlang axes, closes the analysis gap
-without touching session lifecycle.
+`CoverageAnalyzer` (this plugin) caches `IJavaModelCoverage` per
+`ICoverageSession`, including raw JaCoCo `SessionInfo` and
+`ExecutionData`. The `:jdt/coverage` axes expose this cache as a
+qlang queryable surface — point lookups, per-line breakdowns,
+predicate composition with `:jdt/graph`, no rebuild of session
+lifecycle.
 
 ## Design principles
 
-### 1. Not a replacement for the Coverage View
+### 1. Mirror EclEmma idioms
 
 The user works in Eclipse with full GUI — Coverage View tree,
 gutter coloring, session dropdown, every menu including those the
-CLI doesn't expose. The CLI surface is for the agent. Wherever a
-choice exists between mirroring an existing EclEmma idiom and
-inventing a new one, mirror EclEmma. The user's mental model is
-already shaped by years of EclEmma use; the CLI extends, never
-replaces.
+CLI doesn't expose. The CLI surface is for the agent. Where a
+choice exists between mirroring an EclEmma idiom and introducing
+a new one, the CLI mirrors EclEmma; the user's mental model
+carries over from the GUI verbatim.
 
 ### 2. Scope inherits from the launch config
 
@@ -71,14 +51,13 @@ their radar at all.
 
 ### 4. Contextual onboarding by lifecycle moment
 
-Discovery of analysis commands happens at the moment the agent is
-already in the relevant context, never via up-front help dumps.
-Six lifecycle moments carry onboarding (§ Lifecycle onboarding).
-On `jdt help`, only the canonical happy-path commands surface; on
-`jdt coverage run`, the existing 4-section guide gains a 5th
-"Analyze results" section; on `analysisReady` events in `-f`
-streams, a 3-line tail offers the next step; full reference lives
-in `jdt help coverage analyze`.
+Analysis-command discovery surfaces at the moment the agent is
+in the relevant context. Six lifecycle moments carry onboarding
+(§ Lifecycle onboarding): `jdt help` shows only the canonical
+happy-path commands; `jdt coverage run` carries an "Analyze
+results" section in its guide; `analysisReady` events in `-f`
+streams emit a 3-line tail; the full reference lives in
+`jdt help coverage analyze`.
 
 ### 5. Top-5 user questions resolve in 1-2 commands
 
@@ -88,15 +67,13 @@ a method) each map to a single qlang pipeline that the onboarding
 text shows verbatim. The agent does not assemble these from
 primitives — it copies a template, substitutes the fqn, and runs.
 
-### 6. Composition with graph axes is the unique advantage
+### 6. Composition with `:jdt/graph` axes
 
-JaCoCo CLI, IntelliJ Run-with-Coverage, SonarQube, Codecov — none
-of them compose coverage with the Eclipse semantic graph (callers,
-hierarchy, annotations, complexity). The CLI does, and that is
-the differentiator. Queries like
-`@methods | filter(@untested) | filter(@callers | empty | not)`
-("hot uncovered methods") are one-liners with no equivalent in
-mature coverage tooling.
+`:jdt/coverage` axes share `pipeValue` semantics with `:jdt/graph`,
+so coverage and graph predicates compose in a single pipeline.
+Example: `@methods | filter(@untested) | filter(@callers | empty | not)`
+selects methods with zero instruction coverage and at least one
+caller — the "hot uncovered" set — in one expression.
 
 ## Top-20 user questions
 
@@ -387,10 +364,10 @@ Run with coverage instrumentation:
   jdt test run <fqn> --coverage          adds CoverageId/CoverageScope to header
 ```
 
-### M3 — `jdt coverage run <id>` guide (5th section)
+### M3 — `jdt coverage run <id>` guide
 
-The existing run-guide has four sections (status / logs /
-manage / sessions). Add a fifth:
+The run-guide carries five sections: status / logs / manage /
+sessions / analyze. The analyze block:
 
 ```
 **Analyze results** (after analysisReady):
@@ -403,12 +380,11 @@ manage / sessions). Add a fifth:
   jdt help coverage analyze                         full reference
 ```
 
-Analysis runs against the active session by default; pinning to
-a specific coverageId is the optional advanced step from M6.
+Analysis targets the active session unless pinned via `M6`.
 
 ### M4 — Stream tail after `analysisReady`
 
-Three-line tail appended in `formatStreamEvent`:
+Three-line tail in `formatStreamEvent`:
 
 ```
 [hh:mm:ss] ready #1 — instructions 94.8%, branches 80.7%, ...
@@ -418,15 +394,11 @@ Next: jdt q '"<class>" | @uncoveredLines'   line gaps
       jdt help coverage analyze             full reference
 ```
 
-The agent in `-f` follow-mode does not have to scroll back to M3
-to find the next-step menu.
-
 ### M5 — `jdt coverage status` snapshot tail
 
-Same 3-line tail appended to `formatStatusSnapshot` when
-`analysisReady=true`. This is the second entry path: the user
-ran coverage in Eclipse, the agent comes in fresh and lands on
-`status` directly, never seeing M3.
+Same 3-line tail in `formatStatusSnapshot` when
+`analysisReady=true`. Covers the entry path where the agent
+joins a session created in Eclipse without going through M3.
 
 ### M6 — `jdt help coverage analyze`
 
@@ -436,71 +408,57 @@ conduits, subject polymorphism rules, composition examples with
 This is the depth surface — agent reaches it only when M3/M4/M5
 pointed there.
 
-## CLI ergonomics — idioms borrowed from mature tooling
-
-Cross-tool patterns observed across `coverage.py`, `pytest-cov`,
-`nyc`/`c8`, `lcov`, `gcov`, `llvm-cov`, `go tool cover`,
-`jacoco-cli`. The ones we adopt:
+## CLI ergonomics
 
 ### Collapsed line ranges
 
 Per-line gap output collapses consecutive line numbers into
 ranges: `33-35, 39, 41-50` instead of
-`33, 34, 35, 39, 41, 42, 43, ..., 50`. Source: coverage.py
-`--show-missing`, nyc `Uncovered Line #s` column. Implemented in
-`mdCoverage` renderer, not in the wire format — the server emits
-raw `Vec<int>` and the CLI collapses on render.
+`33, 34, 35, 39, 41, 42, 43, ..., 50`. Collapse happens in the
+`mdCoverage` renderer; the server emits raw `Vec<int>`.
 
 ### Text-summary micro-format
 
 A 4-line block of `Metric : XX% (n/m)` per counter, no per-file
-detail, designed for CI logs. Source: nyc `text-summary`, c8
-`text-summary`. Available as a render mode of `@coverageSummary`
-when the agent wants a compact CI-log fragment.
+detail. Available as a render mode of `@coverageSummary`.
 
 ### Color-coded ratios
 
 Ratio percentages render colored: red <50, yellow 50-80, green
->80. Already in the existing `composeStatus` — extend to ratio
-columns in tables. Source: nyc / c8 / istanbul text reporters.
+>80. The same `composeStatus` palette used elsewhere applies to
+ratio columns in tables.
 
 ### TOTAL row pinned at bottom of tables
 
-Tables of per-package or per-class coverage include a synthetic
-TOTAL row for the aggregate. Source: coverage.py `report`,
-llvm-cov `report`, nyc `text`, lcov `--list`.
+Per-package and per-class coverage tables carry a synthetic
+TOTAL row for the aggregate.
 
-### `--skip-covered` style filter
+### `@onlyGaps` filter
 
-Conduit `@onlyGaps` filters elements at 100% coverage out of the
-result, surfacing only files needing attention. Source:
-coverage.py `--skip-covered`, nyc `--per-file`. Implemented as
-a qlang filter, not a server flag — `filter(/counters/instruction/coveredRatio | lt(1.0))`.
+Conduit `@onlyGaps` keeps elements below 100% coverage,
+expressed as `filter(/counters/instruction/coveredRatio | lt(1.0))`.
 
-### What we don't borrow
+### Boundaries
 
-- `--fail-under=N` threshold-gate flag at the command level.
-  Threshold gates are agent-side decisions; expressed as
-  ordinary qlang predicates plus exit-code mapping if needed.
-  Adding a flag adds another configuration knob the agent must
-  learn.
-- `--show-contexts` / per-test labeling. Per-test forward
-  mapping is not natively supported by JaCoCo agent's session
-  model; achievable only by running each test as its own launch
-  (test-FQN configId). The CLI does not pretend to deliver
-  testwise coverage from a single session.
-- Diff-coverage as a primitive flag. Diff is a qlang join over
-  two sessions (`@coverageOf(:idA)` vs `@coverageOf(:idB)`)
-  composed with git axes, not a dedicated server endpoint.
+- Threshold gates are agent-side qlang predicates plus exit-code
+  mapping; no `--fail-under=N` flag.
+- Per-test (testwise) attribution comes from running each test
+  as its own launch (test-FQN configId) so the session's data
+  IS the testwise mapping. No `--show-contexts`-style labeling
+  inside a multi-test session — JaCoCo's session model does not
+  carry it.
+- Diff coverage is a qlang join over `@coverageOf(:idA)` vs
+  `@coverageOf(:idB)` composed with git axes. No dedicated
+  server endpoint.
 
 ## Architectural constraints
 
 ### Field coverage = null
 
 `IJavaModelCoverage.getCoverageFor(IField)` returns `null`
-unconditionally — JaCoCo does not model field coverage at the
-data layer. The `@coverage` axis on a `:field` subject returns
-a typed error value:
+unconditionally — JaCoCo's data layer carries no field-level
+coverage. The `@coverage` axis on a `:field` subject returns a
+typed error value:
 
 ```
 !{:kind :coverage-no-data-for-element
@@ -509,10 +467,9 @@ a typed error value:
   :fqn "..."}
 ```
 
-This surfaces explicitly on the fail-track; the agent never
-silently sees zero coverage on a field. Filter idiom for a
-mixed-member iteration: `... | filter(/kind | eq("field") | not)`
-before applying coverage axes.
+The error rides the fail-track. Filter idiom for a mixed-member
+iteration: `... | filter(/kind | eq("field") | not)` before
+applying coverage axes.
 
 ### Per-line breakdown only for `ISourceNode`
 
@@ -539,11 +496,8 @@ anonymous class as a separate `IClassCoverage` with a
 `$N`-suffixed VM name; EclEmma maps these back to their IType
 through the binary-name traversal.
 
-The `@coverage` axis on a synthetic-type fqn returns counters
-for that synthetic class. Cross-validation against running
-sessions is needed before the surface is declared stable for
-synthetic types — the synthetic-name → IClassCoverage mapping
-is the most failure-prone path in the EclEmma adapter.
+`@coverage` on a synthetic-type fqn returns counters for that
+synthetic class.
 
 ## Glossary
 
@@ -564,32 +518,26 @@ example, and reshape literal in the codebase uses these terms.
 | **diff coverage** | Comparison of two coverage sessions, surfacing lines covered in one but not the other. Implemented as a qlang join over `@coverageOf(:idA)` and `@coverageOf(:idB)`, never as a server primitive. |
 | **testwise** | Per-test attribution of covered lines. Achievable only when a test runs as its own launch (test-FQN configId, `--coverage`); then the session's data IS the testwise mapping. Multi-test sessions aggregate and lose per-test attribution. |
 
-## What is out of scope
+## Boundaries of the analyze surface
 
-Items deliberately not part of the analyze surface:
-
-- **Trend over time.** No history storage. Each `coverageId` is
-  point-in-time; trends require external time-series storage
-  (CI artifacts, SonarQube). Out of scope for the CLI.
-- **Threshold-gate flag.** No `--fail-under=N`. Gates are qlang
-  predicates the agent composes. Mapping a predicate result to
-  the process exit code is an agent-side decision.
-- **Custom exclude patterns at query time.** EclEmma's
-  `Coverage Runtime` preferences (`Includes:`, `Excludes:`,
-  `Exclude classloaders:`) live in the Eclipse preferences UI.
-  Filtering at query time uses qlang `filter(...)` — generated /
-  Lombok / DTO exclusion is composed per-query, not configured.
-- **Diff-coverage as a server primitive.** Composed in qlang
-  from two `@coverageOf` calls.
-- **HTML report rendering.** EclEmma already exports JaCoCo HTML
-  via Coverage View → Export. The CLI does not duplicate that.
-  Markdown cards (`@coverageCard`) are the CLI's rendering
-  surface, optimized for PR comments and agent context.
-- **Live source-annotated view.** `gcov`-style inline-annotated
-  source is not a CLI primary output. The bridge offers
-  `@source` (raw) and `@coveredLines`/`@uncoveredLines` (line
-  numbers) — composing them into an annotated view is a render
-  conduit if a user demands it, not a default surface.
+- **Trend over time** — each `coverageId` is point-in-time;
+  trend storage lives in CI artifacts or SonarQube, not in the
+  bridge.
+- **Threshold gating** — qlang predicates plus agent-side
+  exit-code mapping; no `--fail-under=N` CLI flag.
+- **Exclude patterns** — EclEmma's `Coverage Runtime`
+  preferences (`Includes:`, `Excludes:`, `Exclude classloaders:`)
+  shape what the JaCoCo agent instruments. Per-query filtering
+  of generated / Lombok / DTO classes goes through qlang
+  `filter(...)`.
+- **Diff coverage** — qlang join of two `@coverageOf` calls; no
+  dedicated server endpoint.
+- **HTML report rendering** — Coverage View → Export Session
+  emits JaCoCo HTML. The analyze surface emits markdown cards
+  (`@coverageCard`) suited to PR comments and agent context.
+- **Inline source-annotated view** — `gcov`-style overlay is a
+  composition of `@source` plus `@coveredLines` /
+  `@uncoveredLines`, expressed as a render conduit when needed.
 
 ## References
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -36,6 +36,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import io.github.kaluchi.jdtbridge.ProjectScope;
+import io.github.kaluchi.jdtbridge.TestFixture;
 
 /**
  * Tests for {@link CoverageSessionHandler}. Drives state through
@@ -258,6 +259,78 @@ public class CoverageSessionHandlerTest {
                     .get("coverageStatus").getAsString();
             // Empty execution data → EMPTY status from JaCoCo.
             assertEquals("EMPTY", status);
+        }
+    }
+
+    @Nested
+    class HandleNode {
+
+        @BeforeEach
+        void seedFixture() throws Exception {
+            // Need a real workspace type to test the
+            // resolvable-fqn → no-data-for-element path; the
+            // imported empty session has no scope, so even with
+            // the type present getCoverageFor returns null.
+            TestFixture.create();
+        }
+
+        @Test
+        void missingCoverageIdReturnsNotFound() {
+            JsonObject obj = parseObj(
+                    handler.handleNode(Map.of()));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void missingFqnReturnsFqnUnresolved() {
+            String coverageId = importAndAwait("node-no-fqn");
+            JsonObject obj = parseObj(handler.handleNode(
+                    Map.of("coverageId", coverageId)));
+            assertEquals("coverage-fqn-unresolved",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownCoverageIdReturnsNotFound() {
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", "Bogus:9999",
+                    "fqn", "anything")));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unresolvableFqnReturnsFqnUnresolved() {
+            String coverageId = importAndAwait("node-bad-fqn");
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", coverageId,
+                    "fqn", "no.such.Type")));
+            assertEquals("coverage-fqn-unresolved",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void resolvableFqnOutsideScopeReturnsNoDataForElement() {
+            // The imported empty-scope session has no projects in
+            // modelCoverage; the fixture type resolves but
+            // getCoverageFor returns null.
+            String coverageId = importAndAwait("node-no-data");
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", coverageId,
+                    "fqn", "test.model.Animal")));
+            assertEquals("coverage-no-data-for-element",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void unknownDumpSuffixReturnsDumpNotFound() {
+            String coverageId = importAndAwait("node-dump");
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", coverageId + ":99",
+                    "fqn", "test.model.Animal")));
+            assertEquals("coverage-dump-not-found",
+                    obj.get("error").getAsString());
         }
     }
 

--- a/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
@@ -30,7 +30,7 @@ import org.eclipse.jdt.core.dom.LambdaExpression;
 /**
  * Shared JDT utilities used by multiple handlers.
  */
-class JdtUtils {
+public class JdtUtils {
 
     /** Lambda-suffix marker in a composite synthetic FQN. */
     private static final String LAMBDA_SUFFIX_HEAD = ".() -> {...}";
@@ -72,7 +72,7 @@ class JdtUtils {
      * the parsed one; first match wins when multiple identical
      * synthetics share the enclosing method.
      */
-    static IJavaElement resolveElement(String fqn)
+    public static IJavaElement resolveElement(String fqn)
             throws JavaModelException {
         int syntheticIdx = syntheticSuffixStart(fqn);
         if (syntheticIdx < 0) return resolveRegular(fqn);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageJson.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageJson.java
@@ -78,13 +78,7 @@ final class CoverageJson {
     }
 
     /** All six {@link ICounter}s wrapped in a single counters
-     *  object — wire shape per spec § Counter shape. Accepts any
-     *  {@link ICoverageNode}; for session-level aggregation pass
-     *  the result of
-     *  {@link CoverageSessionHandler#aggregateProjectCounters} since
-     *  the root {@link
-     *  org.eclipse.eclemma.core.analysis.IJavaModelCoverage} itself
-     *  is never incremented by EclEmma. */
+     *  object — wire shape per spec § Counter shape. */
     static JsonObject countersOf(ICoverageNode cov) {
         var obj = new JsonObject();
         if (cov == null) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageRouter.java
@@ -59,6 +59,8 @@ class CoverageRouter {
             case "/coverage/runs" -> sessionHandler.handleRuns(scope);
             case "/coverage/session" ->
                     sessionHandler.handleSession(params);
+            case "/coverage/node" ->
+                    sessionHandler.handleNode(params);
             case "/coverage/active" -> sessionHandler.handleActive();
             case "/coverage/activate" ->
                     sessionHandler.handleActivate(body);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandler.java
@@ -12,11 +12,18 @@ import org.eclipse.eclemma.core.CoverageTools;
 import org.eclipse.eclemma.core.ICoverageSession;
 import org.eclipse.eclemma.core.ISessionManager;
 import org.eclipse.eclemma.core.analysis.IJavaModelCoverage;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaModelException;
 import org.jacoco.core.analysis.CoverageNodeImpl;
+import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.analysis.ICoverageNode;
+import org.jacoco.core.analysis.ILine;
+import org.jacoco.core.analysis.ISourceNode;
 import org.jacoco.core.data.SessionInfo;
+
+import io.github.kaluchi.jdtbridge.JdtUtils;
 
 import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.addNullableLong;
 import static io.github.kaluchi.jdtbridge.coverage.CoverageJson.addNullableString;
@@ -114,16 +121,10 @@ class CoverageSessionHandler {
     }
 
     /**
-     * Aggregate per-project counters into a single session-level
-     * coverage node. EclEmma's
-     * {@link org.eclipse.eclemma.internal.core.analysis.JavaModelCoverage#putFragmentRoot}
-     * increments only the child project node
-     * ({@code getProjectCoverage(...).increment(coverage)}); the
-     * root {@link IJavaModelCoverage} itself is never incremented
-     * and its counters stay at zero. Eclipse's Coverage View
-     * sidesteps this by rendering project / fragment-root / package
-     * children directly, never the root. The wire format must
-     * aggregate to give the client session totals.
+     * Sum per-project child counters into a session-level
+     * {@link CoverageNodeImpl}. Iterates {@code model.getProjects()},
+     * folds {@code getCoverageFor(project)} into the result via
+     * {@link CoverageNodeImpl#increment(ICoverageNode)}.
      */
     static ICoverageNode aggregateProjectCounters(
             IJavaModelCoverage model) {
@@ -139,6 +140,133 @@ class CoverageSessionHandler {
             }
         }
         return agg;
+    }
+
+    /**
+     * {@code GET /coverage/node?coverageId=...&fqn=...} — point
+     * lookup of one element's raw coverage. Resolves {@code fqn}
+     * via {@link JdtUtils#resolveElement} → {@link IJavaElement},
+     * then asks the cached {@link IJavaModelCoverage} for that
+     * element's {@link ICoverageNode}. The response is the raw
+     * counters plus, for {@link ISourceNode} subtypes (type /
+     * method / source-file), the per-line breakdown — no
+     * aggregation, no derived flags, no synthesis.
+     */
+    String handleNode(Map<String, String> params) {
+        String coverageId = params.get("coverageId");
+        if (coverageId == null || coverageId.isBlank()) {
+            return error("coverage-not-found",
+                    "Missing 'coverageId' parameter");
+        }
+        String fqn = params.get("fqn");
+        if (fqn == null || fqn.isBlank()) {
+            return error("coverage-fqn-unresolved",
+                    "Missing 'fqn' parameter");
+        }
+        CoverageRun run = tracker.byCoverageId(coverageId);
+        if (run == null) {
+            return error("coverage-not-found", coverageId);
+        }
+        Integer dumpIndex = parseDumpIndex(coverageId);
+        ICoverageSession session = run.resolveSession(dumpIndex);
+        if (session == null) {
+            return error(dumpIndex != null
+                    ? "coverage-dump-not-found"
+                    : "coverage-not-found", coverageId);
+        }
+        IJavaElement element;
+        try {
+            element = JdtUtils.resolveElement(fqn);
+        } catch (JavaModelException e) {
+            return error("coverage-fqn-unresolved",
+                    fqn + ": " + e.getMessage());
+        }
+        if (element == null) {
+            return error("coverage-fqn-unresolved", fqn);
+        }
+        CoverageAnalyzer.CachedAnalysis ca;
+        try {
+            ca = analyzer.ensureAnalyzed(session);
+        } catch (CoreException e) {
+            return error("coverage-analysis-failed",
+                    e.getMessage());
+        }
+        ICoverageNode node = ca.modelCoverage.getCoverageFor(element);
+        if (node == null) {
+            return error("coverage-no-data-for-element",
+                    fqn + " (kind=" + elementKind(element) + ")");
+        }
+        var obj = new JsonObject();
+        obj.addProperty("coverageId", coverageId);
+        obj.addProperty("fqn", fqn);
+        obj.addProperty("elementKind", elementKind(element));
+        obj.addProperty("elementType",
+                node.getElementType().name());
+        obj.add("counters", countersOf(node));
+        if (node instanceof ISourceNode src) {
+            obj.add("lines", linesJson(src));
+        }
+        return obj.toString();
+    }
+
+    /** Per-line breakdown for an {@link ISourceNode}. Iterates
+     *  {@code [firstLine, lastLine]}, skips lines with status
+     *  {@link ICounter#EMPTY}, and emits one entry per non-empty
+     *  line carrying the line's status plus its instruction and
+     *  branch counter values. No collapsing into ranges, no
+     *  classification into covered/missed buckets — that is the
+     *  client's job. */
+    private static JsonObject linesJson(ISourceNode src) {
+        var obj = new JsonObject();
+        int first = src.getFirstLine();
+        int last = src.getLastLine();
+        obj.addProperty("firstLine", first);
+        obj.addProperty("lastLine", last);
+        var entries = new JsonArray();
+        if (first != ISourceNode.UNKNOWN_LINE) {
+            for (int i = first; i <= last; i++) {
+                ILine line = src.getLine(i);
+                if (line.getStatus() == ICounter.EMPTY) {
+                    continue;
+                }
+                var entry = new JsonObject();
+                entry.addProperty("line", i);
+                entry.addProperty("status",
+                        CoverageJson.statusName(line.getStatus()));
+                ICounter ic = line.getInstructionCounter();
+                entry.addProperty("instructionCovered",
+                        ic.getCoveredCount());
+                entry.addProperty("instructionMissed",
+                        ic.getMissedCount());
+                ICounter bc = line.getBranchCounter();
+                entry.addProperty("branchCovered",
+                        bc.getCoveredCount());
+                entry.addProperty("branchMissed",
+                        bc.getMissedCount());
+                entries.add(entry);
+            }
+        }
+        obj.add("entries", entries);
+        return obj;
+    }
+
+    /** {@link IJavaElement#getElementType()} → wire kebab token.
+     *  Mirrors the {@code :kind} keyword the {@code :jdt/graph}
+     *  axes already use, so a graph-side {@code /kind} projection
+     *  joins cleanly with the coverage-side {@code /elementKind}. */
+    private static String elementKind(IJavaElement element) {
+        return switch (element.getElementType()) {
+            case IJavaElement.JAVA_PROJECT -> "project";
+            case IJavaElement.PACKAGE_FRAGMENT_ROOT ->
+                    "packageFragmentRoot";
+            case IJavaElement.PACKAGE_FRAGMENT -> "package";
+            case IJavaElement.TYPE -> "type";
+            case IJavaElement.METHOD -> "method";
+            case IJavaElement.FIELD -> "field";
+            case IJavaElement.COMPILATION_UNIT -> "file";
+            case IJavaElement.CLASS_FILE -> "classFile";
+            default -> "other";
+        };
     }
 
     /** {@code GET /coverage/active} — id of the active session,


### PR DESCRIPTION
GET /coverage/node?coverageId=X&fqn=Y returns the raw ICoverageNode
that EclEmma's IJavaModelCoverage holds for the given workspace
element. Counters always; per-line breakdown when the node is
ISourceNode (type / method / source-file). No aggregation, no
derived flags, no rendering — pure data passthrough.

Resolves fqn via JdtUtils.resolveElement (handles types, methods,
fields, lambdas, anonymous classes — the full :jdt/graph fqn
convention). Errors:
- coverage-not-found (missing/unknown coverageId)
- coverage-dump-not-found (out-of-range :N suffix)
- coverage-fqn-unresolved (no such workspace element)
- coverage-no-data-for-element (resolved but out-of-scope, or
  IField — JaCoCo has no field-level coverage)
- coverage-analysis-failed (CoreException during processSession)

JdtUtils class + resolveElement opened public so coverage/ package
can use them.

bridge-coverage-spec.md gets the endpoint section plus a clarifying
note on /coverage/session counters aggregation (per-project sum,
not root) introduced in PR #108.

Test plan
- [x] jdt build --project io.github.kaluchi.jdtbridge
- [x] jdt build --project io.github.kaluchi.jdtbridge.tests
- [x] jdt test run io.github.kaluchi.jdtbridge.coverage.CoverageSessionHandlerTest — 51/51 pass (45 existing + 6 new HandleNode)
- [ ] Live verification post-deploy: jdt setup --skip-build, then curl /coverage/node?coverageId=<live>&fqn=io.github.kaluchi.jdtbridge.coverage.CoverageRouter — expect 81.1% / 99 covered / 23 missed matching Coverage View