### PR TITLE
Add :jdt/coverage qlang module + mdCoverage renderer

### DIFF
--- a/cli/lib/jdt/coverage.impl.mjs
+++ b/cli/lib/jdt/coverage.impl.mjs
@@ -1,0 +1,210 @@
+// JS-side implementations for the :jdt/coverage qlang module.
+//
+// Two primitives, both thin HTTP wrappers:
+//
+//   @coverage           subject(node-Map | fqn) → /coverage/node Map
+//   @activeCoverageId   () → String | null
+//
+// The 0-arity form of @coverage resolves the active coverageId via
+// @activeCoverageId (per-process cached) and routes to
+// /coverage/node?coverageId=<active>&fqn=<extracted>. The 1-arity
+// overload pins the captured-arg coverageId — `@coverage("MyTest:1234")`
+// or any sub-pipeline evaluating to a String — and bypasses the
+// active lookup.
+//
+// Aggregations, predicates, line classification, card shaping —
+// none live here. They are qlang conduits in coverage.qlang. The
+// plugin is a thin adapter; this layer is a thin transport.
+
+import { nullaryOp, overloadedOp } from '@kaluchi/qlang-core/dispatch';
+import { keyword, makeErrorValue, isErrorValue }
+    from '@kaluchi/qlang-core';
+import { get } from '../../src/client.mjs';
+
+const FQN_KEY = keyword('fqn');
+const ACTIVE_COVERAGE_ID_KEY = keyword('activeCoverageId');
+
+const enc = encodeURIComponent;
+
+function envInt(name, fallback) {
+    const override = Number.parseInt(process.env[name] ?? '', 10);
+    return Number.isFinite(override) && override > 0
+            ? override
+            : fallback;
+}
+
+// HTTP timeout per coverage call. Override: JDT_COVERAGE_TIMEOUT_MS.
+const COVERAGE_TIMEOUT_MS =
+        envInt('JDT_COVERAGE_TIMEOUT_MS', 300_000);
+
+// Per-process active-coverageId cache. One `/coverage/active` call
+// per `jdt q` invocation regardless of how many coverage axes fire.
+// Disable: JDT_COVERAGE_CACHE=0 (used in tests).
+const COVERAGE_CACHE_ENABLED =
+        process.env.JDT_COVERAGE_CACHE !== '0';
+
+let activeCoverageIdPromise = null;
+
+// Per-process /coverage/node cache keyed by `coverageId|fqn`.
+// Coverage data is immutable for a given (session, fqn) pair, so a
+// fan-out like `@typesInProject * @coverage` can dedupe repeats and
+// concurrent identical in-flight requests.
+const nodeCache = new Map();
+
+function jsonToQlang(jsonVal) {
+    if (Array.isArray(jsonVal)) return jsonVal.map(jsonToQlang);
+    if (jsonVal !== null && typeof jsonVal === 'object') {
+        const m = new Map();
+        for (const [k, v] of Object.entries(jsonVal)) {
+            m.set(keyword(k), jsonToQlang(v));
+        }
+        return m;
+    }
+    return jsonVal;
+}
+
+function liftServerResponse(jsonVal) {
+    if (jsonVal !== null
+            && typeof jsonVal === 'object'
+            && !Array.isArray(jsonVal)
+            && jsonVal._error !== undefined) {
+        return makeErrorValue(jsonToQlang(jsonVal._error));
+    }
+    return jsonToQlang(jsonVal);
+}
+
+function fqnOf(subject) {
+    if (typeof subject === 'string') return subject;
+    if (subject instanceof Map) {
+        const fqn = subject.get(FQN_KEY);
+        if (typeof fqn === 'string') return fqn;
+    }
+    return null;
+}
+
+function missingSubjectError(operandName, subject) {
+    const ctx = new Map();
+    ctx.set(keyword('operand'), operandName);
+    ctx.set(keyword('subjectType'),
+            subject === null || subject === undefined ? 'null'
+            : Array.isArray(subject) ? 'vec'
+            : subject instanceof Map ? 'map-without-fqn'
+            : typeof subject);
+    const descriptor = new Map();
+    descriptor.set(keyword('kind'),
+            keyword('missing-subject-fqn'));
+    descriptor.set(keyword('thrown'), keyword('MissingSubjectFqn'));
+    descriptor.set(keyword('origin'), keyword('jdt/coverage'));
+    descriptor.set(keyword('message'),
+            `${operandName}: pipeValue must be a node-Map with `
+            + `:fqn or a fqn-String`);
+    descriptor.set(keyword('context'), ctx);
+    return makeErrorValue(descriptor);
+}
+
+function noActiveCoverageError() {
+    const descriptor = new Map();
+    descriptor.set(keyword('kind'),
+            keyword('coverage-no-active-session'));
+    descriptor.set(keyword('thrown'),
+            keyword('CoverageNoActiveSession'));
+    descriptor.set(keyword('origin'), keyword('jdt/coverage'));
+    descriptor.set(keyword('message'),
+            'No active coverage session — pin a coverageId via '
+            + '`@coverage("<coverageId>")` or activate one via '
+            + '`jdt coverage activate <id>`');
+    return makeErrorValue(descriptor);
+}
+
+function coverageIdNotStringError(actualValue) {
+    const descriptor = new Map();
+    descriptor.set(keyword('kind'),
+            keyword('coverage-id-not-string'));
+    descriptor.set(keyword('thrown'),
+            keyword('CoverageIdNotString'));
+    descriptor.set(keyword('origin'), keyword('jdt/coverage'));
+    descriptor.set(keyword('message'),
+            `@coverage modifier must evaluate to a non-empty `
+            + `String coverageId, got `
+            + (actualValue === null ? 'null' : typeof actualValue));
+    return makeErrorValue(descriptor);
+}
+
+async function fetchActiveCoverageId() {
+    const raw = await get(
+            '/coverage/active', COVERAGE_TIMEOUT_MS);
+    const lifted = liftServerResponse(raw);
+    if (isErrorValue(lifted)) return lifted;
+    if (lifted instanceof Map) {
+        const id = lifted.get(ACTIVE_COVERAGE_ID_KEY);
+        return typeof id === 'string' ? id : null;
+    }
+    return null;
+}
+
+function getActiveCoverageId() {
+    if (!COVERAGE_CACHE_ENABLED) return fetchActiveCoverageId();
+    if (activeCoverageIdPromise) return activeCoverageIdPromise;
+    activeCoverageIdPromise = fetchActiveCoverageId();
+    activeCoverageIdPromise.catch(() => {
+        activeCoverageIdPromise = null;
+    });
+    return activeCoverageIdPromise;
+}
+
+async function fetchNodeUncached(coverageId, fqn) {
+    return liftServerResponse(await get(
+            `/coverage/node?coverageId=${enc(coverageId)}`
+            + `&fqn=${enc(fqn)}`,
+            COVERAGE_TIMEOUT_MS));
+}
+
+function fetchNode(coverageId, fqn) {
+    if (!COVERAGE_CACHE_ENABLED) {
+        return fetchNodeUncached(coverageId, fqn);
+    }
+    const key = coverageId + '|' + fqn;
+    const cached = nodeCache.get(key);
+    if (cached) return cached;
+    const promise = fetchNodeUncached(coverageId, fqn);
+    promise.catch(() => nodeCache.delete(key));
+    nodeCache.set(key, promise);
+    return promise;
+}
+
+const activeCoverageIdImpl = nullaryOp('@activeCoverageId',
+        async () => getActiveCoverageId());
+
+const coverageImpl = overloadedOp('@coverage', 2, {
+    0: async (subject) => {
+        const fqn = fqnOf(subject);
+        if (fqn === null) {
+            return missingSubjectError('@coverage', subject);
+        }
+        const id = await getActiveCoverageId();
+        if (isErrorValue(id)) return id;
+        if (id === null || id === undefined) {
+            return noActiveCoverageError();
+        }
+        return fetchNode(id, fqn);
+    },
+    1: async (subject, coverageIdLambda) => {
+        const fqn = fqnOf(subject);
+        if (fqn === null) {
+            return missingSubjectError('@coverage', subject);
+        }
+        const id = await coverageIdLambda(subject);
+        if (isErrorValue(id)) return id;
+        if (typeof id !== 'string' || id.length === 0) {
+            return coverageIdNotStringError(id);
+        }
+        return fetchNode(id, fqn);
+    },
+});
+
+export function createImpls() {
+    return {
+        '@coverage':         coverageImpl,
+        '@activeCoverageId': activeCoverageIdImpl,
+    };
+}

--- a/cli/lib/jdt/coverage.qlang
+++ b/cli/lib/jdt/coverage.qlang
@@ -1,0 +1,126 @@
+|~ ───────────────────────────────────────────────────────────────────
+   :jdt/coverage — query surface over EclEmma's IJavaModelCoverage
+   cache, layered on the GET /coverage/node endpoint.
+
+   Subject = a node-Map (skeleton/detail) or a fqn String. Each
+   axis routes to /coverage/node?coverageId=<id>&fqn=<fqn> with
+   the active session as default; the optional captured-arg
+   modifier on @coverage pins to a specific coverageId.
+
+   Per-line breakdown (covered/uncovered/partial) is available on
+   ISourceNode subjects only — type, method, source-file. Project
+   / package / fragment-root subjects carry counters but no
+   :lines block; line-axis conduits return an error value on those
+   shapes.
+   ───────────────────────────────────────────────────────────── ~|
+
+|~ ── Primitives — bound by coverage.impl.mjs ─────────────────── ~|
+
+{:@coverage {:qlang/kind :builtin
+             :qlang/impl null
+             :category :jdt/coverage
+             :subject [:map :string]
+             :modifiers [:string]
+             :returns :map
+             :docs ["Raw /coverage/node response: counters Map plus :lines block when subject is an ISourceNode."
+                    "0-arity form binds to the active session via @activeCoverageId."
+                    "1-arity form pins a specific coverageId — `@coverage(\"MyTest:1234\")` or any String expression evaluating to one."]
+             :examples [{:doc "Type counters against the active session"
+                         :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @coverage | /counters/instruction"}
+                        {:doc "Method counters with explicit coverageId pin"
+                         :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start()\" | @coverage(\"CoverageBridgeTest:1777239787278\")"}
+                        {:doc "Line-level entries on a method"
+                         :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start()\" | @coverage | /lines/entries"}]
+             :throws [:CoverageNotFound :CoverageDumpNotFound :CoverageFqnUnresolved :CoverageNoDataForElement :CoverageAnalysisFailed :CoverageNotInstalled]}
+
+ :@activeCoverageId {:qlang/kind :builtin
+                     :qlang/impl null
+                     :category :jdt/coverage
+                     :subject :any
+                     :modifiers []
+                     :returns :string
+                     :docs ["Active coverageId from /coverage/active, or null when no session is active."
+                            "Cached per-process for the life of one `jdt q` invocation; @coverage uses it implicitly when no captured-arg pin is given."]
+                     :examples [{:doc "Read the active coverageId"
+                                 :snippet "@activeCoverageId"}
+                                {:doc "Pin every coverage call in a pipeline to a snapshot of active"
+                                 :snippet "@activeCoverageId | as(:cov) | \"io.github.kaluchi.jdtbridge.HttpServer\" | @coverage(cov)"}]
+                     :throws [:CoverageNotInstalled]}}
+| use
+
+|~ ── Counter-status predicates — subject-level booleans ──────── ~|
+
+|~~ Subject-level predicate — true iff `coveredCount` of the
+    `instruction` counter equals zero. Composes via filter / any /
+    every over a Vec of skeletons, or applies to a single node for
+    a boolean check.
+
+    Distinct from `:jdt/graph`'s @untested, which infers absence
+    from the lack of test-scope callers (a structural proxy).
+    @uncovered reads the actual JaCoCo probe data — the test ran
+    but never hit this element.
+
+      "pkg.Foo" | @methods | filter(@uncovered) * /fqn
+      "pkg.Foo#bar()" | @uncovered                     |~| true / false ~~|
+let(:@uncovered,
+    @coverage | /counters/instruction/coveredCount | eq(0))
+
+|~~ True iff the element's `instruction` counter is
+    `PARTLY_COVERED` — some instructions ran, some didn't.
+    Marker for branch-incomplete code:
+
+      "pkg.Foo" | @methods | filter(@partial) * /fqn   |~| dig in here ~~|
+let(:@partial,
+    @coverage | /counters/instruction/coverageStatus | eq("PARTLY_COVERED"))
+
+|~~ True iff every instruction of the element ran. Composes the
+    same way as @uncovered. ~~|
+let(:@fullyCovered,
+    @coverage | /counters/instruction/coverageStatus | eq("FULLY_COVERED"))
+
+|~ ── Line-level axes — ISourceNode subjects only ─────────────── ~|
+
+|~~ Vec of line numbers whose status is FULLY_COVERED. Subject
+    must be a type, method, or source-file (ISourceNode) — on
+    project / package / fragment-root the underlying /coverage/node
+    response carries no :lines block and the pipeline fails with a
+    type error against the missing key.
+
+      "pkg.Foo#bar()" | @coveredLines      → [42 43 45 47 48 49] ~~|
+let(:@coveredLines,
+    @coverage | /lines/entries
+    | filter(/status | eq("FULLY_COVERED")) * /line)
+
+|~~ Vec of line numbers whose status is NOT_COVERED. Same
+    subject requirement as @coveredLines.
+
+      "pkg.Foo#bar()" | @uncoveredLines    → [52 53 54 60 61 62] ~~|
+let(:@uncoveredLines,
+    @coverage | /lines/entries
+    | filter(/status | eq("NOT_COVERED")) * /line)
+
+|~~ Vec of partial-line entries — each carries `:line` plus the
+    branch counter values (`:branchCovered`, `:branchMissed`).
+    Same subject requirement as @coveredLines. Use this when the
+    branch-coverage breakdown matters; for plain line numbers
+    project to /line.
+
+      "pkg.Foo#bar()" | @partialLines * /line
+                                          → [50 51] ~~|
+let(:@partialLines,
+    @coverage | /lines/entries
+    | filter(/status | eq("PARTLY_COVERED")))
+
+|~ ── Markdown coverage card ──────────────────────────────────── ~|
+
+|~~ Bundle the subject's @detail node and its @coverage Map for
+    the host-bound `mdCoverage` renderer. Subject can be a type
+    or method fqn / node-Map; the card lays out the six counters
+    plus the per-line breakdown when present.
+
+      "io.github.kaluchi.jdtbridge.HttpServer" | @coverageCard ~~|
+let(:@coverageCard,
+    @asNode | as(:self)
+    | {:node     self | @detail
+       :coverage self | @coverage}
+    | mdCoverage)

--- a/cli/lib/jdt/render.impl.mjs
+++ b/cli/lib/jdt/render.impl.mjs
@@ -26,6 +26,26 @@ const K_INCOMING   = keyword('incoming');
 const K_SUPERS     = keyword('supers');
 const K_SUBTYPES   = keyword('subtypes');
 const K_MEMBERS    = keyword('members');
+const K_COVERAGE   = keyword('coverage');
+
+// Coverage-bundle and node-Map keys
+const K_COUNTERS         = keyword('counters');
+const K_LINES_BUNDLE     = keyword('lines');
+const K_ENTRIES          = keyword('entries');
+const K_STATUS           = keyword('status');
+const K_LINE_NUMBER      = keyword('line');
+const K_COVERED_COUNT    = keyword('coveredCount');
+const K_MISSED_COUNT     = keyword('missedCount');
+const K_TOTAL_COUNT      = keyword('totalCount');
+const K_COVERED_RATIO    = keyword('coveredRatio');
+const K_BRANCH_COVERED   = keyword('branchCovered');
+const K_BRANCH_MISSED    = keyword('branchMissed');
+const K_C_INSTRUCTION    = keyword('instruction');
+const K_C_BRANCH         = keyword('branch');
+const K_C_LINE           = keyword('line');
+const K_C_METHOD         = keyword('method');
+const K_C_CLASS          = keyword('class');
+const K_C_COMPLEXITY     = keyword('complexity');
 
 // Node-Map fields
 const K_FQN           = keyword('fqn');
@@ -495,6 +515,179 @@ function lineRangeSuffix(node) {
     return startLine + '-' + endLine;
 }
 
+// ── mdCoverage: counters table + per-line ranges ───────────────
+
+const COUNTER_ROWS = [
+    [K_C_INSTRUCTION, 'Instructions'],
+    [K_C_BRANCH,      'Branches'],
+    [K_C_LINE,        'Lines'],
+    [K_C_METHOD,      'Methods'],
+    [K_C_CLASS,       'Types'],
+    [K_C_COMPLEXITY,  'Complexity'],
+];
+
+/**
+ * Bundle shape for mdCoverage:
+ *   :node     — detail node-Map of the viewed element (required)
+ *   :coverage — /coverage/node response Map: :counters always,
+ *               :lines block when subject is an ISourceNode
+ *
+ * Layout follows EclEmma's Coverage View vocabulary verbatim:
+ *
+ *   `Element` (header) `Counter | Coverage | Covered | Missed | Total`
+ *
+ * with EclEmma counter names (`Types` not `Classes`, `Complexity`
+ * not `Cxty`) and `0.0 %` ratio format. The Lines section, when
+ * present, splits entries into Covered / Partial / Uncovered with
+ * consecutive line numbers collapsed to ranges (`33-35, 39, 41-50`)
+ * — same idiom as coverage.py's Missing column.
+ */
+function formatMdCoverage(bundle) {
+    ensureMap(bundle, 'mdCoverage');
+    const node = mapGet(bundle, K_NODE);
+    if (!(node instanceof Map)) {
+        throw new TypeError(
+            'mdCoverage: :node must be a node-Map');
+    }
+    const coverage = mapGet(bundle, K_COVERAGE);
+    if (!(coverage instanceof Map)) {
+        throw new TypeError(
+            'mdCoverage: :coverage must be a Map from @coverage, got '
+            + describe(coverage));
+    }
+
+    const out = [];
+    out.push('#### ' + badgeOf(node) + ' '
+            + (mapGet(node, K_FQN) ?? '?'));
+    const loc = locationLine(node);
+    if (loc) out.push(loc);
+    out.push('');
+
+    const counters = mapGet(coverage, K_COUNTERS);
+    if (counters instanceof Map) {
+        out.push('#### Coverage:');
+        out.push('');
+        out.push(...formatCountersTable(counters));
+    }
+
+    const linesBundle = mapGet(coverage, K_LINES_BUNDLE);
+    if (linesBundle instanceof Map) {
+        const entries = mapGet(linesBundle, K_ENTRIES);
+        if (Array.isArray(entries) && entries.length > 0) {
+            out.push('');
+            out.push('#### Lines:');
+            out.push(...formatLinesBlock(entries));
+        }
+    }
+
+    return out.join('\n');
+}
+
+function formatCountersTable(counters) {
+    const lines = [];
+    lines.push(
+        '| Counter      | Coverage | Covered | Missed |    Total |');
+    lines.push(
+        '|--------------|---------:|--------:|-------:|---------:|');
+    for (const [wireKey, label] of COUNTER_ROWS) {
+        const c = mapGet(counters, wireKey);
+        if (!(c instanceof Map)) continue;
+        const cov   = mapGet(c, K_COVERED_COUNT) ?? 0;
+        const miss  = mapGet(c, K_MISSED_COUNT)  ?? 0;
+        const total = mapGet(c, K_TOTAL_COUNT)   ?? 0;
+        const ratio = mapGet(c, K_COVERED_RATIO);
+        lines.push('| ' + label.padEnd(12)
+                + ' | ' + formatRatio(ratio).padStart(8)
+                + ' | ' + String(cov).padStart(7)
+                + ' | ' + String(miss).padStart(6)
+                + ' | ' + String(total).padStart(8)
+                + ' |');
+    }
+    return lines;
+}
+
+/** EclEmma's `0.0 %` format — one decimal, space before `%`. Empty
+ *  string when total = 0 (server emits null ratio in that case). */
+function formatRatio(r) {
+    if (r === null || r === undefined || Number.isNaN(r)) return '';
+    return (r * 100).toFixed(1) + ' %';
+}
+
+function formatLinesBlock(entries) {
+    const covered = [];
+    const partial = [];
+    const uncovered = [];
+    for (const e of entries) {
+        if (!(e instanceof Map)) continue;
+        const status = mapGet(e, K_STATUS);
+        const line = mapGet(e, K_LINE_NUMBER);
+        if (typeof line !== 'number') continue;
+        if (status === 'FULLY_COVERED')      covered.push(line);
+        else if (status === 'PARTLY_COVERED') partial.push(e);
+        else if (status === 'NOT_COVERED')    uncovered.push(line);
+    }
+    const out = [];
+    if (covered.length > 0) {
+        out.push('  Covered:   ' + collapseRanges(covered));
+    }
+    if (partial.length > 0) {
+        out.push('  Partial:   '
+                + partial.map(formatPartialEntry).join(', '));
+    }
+    if (uncovered.length > 0) {
+        out.push('  Uncovered: ' + collapseRanges(uncovered));
+    }
+    return out;
+}
+
+/**
+ * Per-line partial entry: line number plus the branch hover-text
+ * EclEmma uses on its gutter annotations:
+ *
+ *   `{0} of {1} branches missed.`
+ *
+ * (verbatim from `AnnotationTextSomeBranchesMissed_message` in
+ * EclEmma's `uimessages.properties`).
+ */
+function formatPartialEntry(entry) {
+    const line   = mapGet(entry, K_LINE_NUMBER);
+    const missed = mapGet(entry, K_BRANCH_MISSED);
+    const cov    = mapGet(entry, K_BRANCH_COVERED);
+    const total  = (typeof missed === 'number' ? missed : 0)
+                 + (typeof cov    === 'number' ? cov    : 0);
+    if (typeof missed === 'number' && total > 0) {
+        return line + ' (' + missed + ' of ' + total
+                + ' branches missed)';
+    }
+    return String(line);
+}
+
+/**
+ * Collapse a sorted (or unsorted) list of integers into
+ * comma-joined consecutive ranges: `[42,43,44,46,50,51,52]`
+ * → `"42-44, 46, 50-52"`.
+ */
+function collapseRanges(numbers) {
+    if (numbers.length === 0) return '';
+    const sorted = [...numbers].sort((a, b) => a - b);
+    const out = [];
+    let start = sorted[0];
+    let end = sorted[0];
+    for (let i = 1; i < sorted.length; i++) {
+        const n = sorted[i];
+        if (n === end + 1) {
+            end = n;
+        } else {
+            out.push(start === end ? String(start)
+                    : start + '-' + end);
+            start = n;
+            end = n;
+        }
+    }
+    out.push(start === end ? String(start) : start + '-' + end);
+    return out.join(', ');
+}
+
 // ── Operand bindings ───────────────────────────────────────────
 
 export function bindJdtRenderOperands(session) {
@@ -506,4 +699,6 @@ export function bindJdtRenderOperands(session) {
             async (bundle) => formatMdOutline(bundle)));
     session.bind('mdRefs', valueOp('mdRefs', 1,
             async (refs) => formatMdRefs(refs)));
+    session.bind('mdCoverage', valueOp('mdCoverage', 1,
+            async (bundle) => formatMdCoverage(bundle)));
 }

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -23,6 +23,7 @@ import { bindIoOperands } from '@kaluchi/qlang-cli/io-operands';
 import { bindFormatOperands } from '@kaluchi/qlang-cli/format-operands';
 import { bindParseOperands } from '@kaluchi/qlang-cli/parse-operands';
 import { createImpls as createGraphImpls } from '../../lib/jdt/graph.impl.mjs';
+import { createImpls as createCoverageImpls } from '../../lib/jdt/coverage.impl.mjs';
 import { bindJdtRenderOperands } from '../../lib/jdt/render.impl.mjs';
 import { BridgeNotRunningError, isConnectionError } from '../client.mjs';
 
@@ -31,7 +32,8 @@ const MODULE_LIB = join(__dirname, '..', '..', 'lib');
 
 function createLocator() {
   const implFactories = {
-    'jdt/graph': createGraphImpls
+    'jdt/graph':    createGraphImpls,
+    'jdt/coverage': createCoverageImpls,
   };
 
   return (namespaceName) => {
@@ -179,7 +181,8 @@ export async function query(args) {
     bindFormatOperands(session);
     bindParseOperands(session);
     bindJdtRenderOperands(session);
-    const cellEntry = await session.evalCell(`use(:jdt/graph) | ${querySource}`);
+    const cellEntry = await session.evalCell(
+        `use(:jdt/graph) | use(:jdt/coverage) | ${querySource}`);
 
     if (cellEntry.error) {
       printQueryResult(parseErrorToValue(cellEntry.error, cellEntry.uri));
@@ -326,10 +329,19 @@ Sugar conduits:
   type    | @publicOrphans  @deadCode
   Vec     | @sourceOnly  @overview  @inProject(projName)
 
+Coverage axes (need an active or pinned coverage session):
+  node    | @coverage                /coverage/node Map: counters + lines (when ISourceNode)
+  node    | @coverage("MyTest:1234") pin to a specific coverageId
+  @activeCoverageId                  String id of the active session, or null
+  element | @uncovered  @partial  @fullyCovered  — predicates over instruction status
+  ISourceNode | @coveredLines  @uncoveredLines  — Vec<int> line numbers
+  ISourceNode | @partialLines        Vec<entry> with branch counts
+
 Markdown cards (return a String — pipe to a file):
   "pkg.Foo#bar()" | @sourceCard      header + code fence + outgoing / incoming refs
   "pkg.Foo"       | @hierarchyCard   ↑ supers / ↓ subtypes
   "pkg.Foo"       | @outlineCard     fields / methods / inner types
+  "pkg.Foo"       | @coverageCard    counters table + Lines section
   Vec<:reference> | mdRefs           grouped by refKind
 
 Host-bound I/O + format (from qlang-cli):

--- a/cli/test/coverage-examples.test.mjs
+++ b/cli/test/coverage-examples.test.mjs
@@ -1,0 +1,54 @@
+// CI gate for the :jdt/coverage module's documented examples.
+// Mirror of graph-examples.test.mjs — every `:snippet "..."` inside
+// coverage.qlang must parse cleanly as a qlang pipeline. Pure
+// syntactic check; semantic rot (stale fqn, dead coverageId) needs
+// a live session and is out of scope.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { parse } from '@kaluchi/qlang-core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const COVERAGE_QLANG = resolve(
+        __dirname, '..', 'lib', 'jdt', 'coverage.qlang');
+
+const SNIPPET_RE = /:snippet\s+"((?:\\.|[^"\\])*)"/g;
+
+function extractSnippets(source) {
+    const out = [];
+    for (const match of source.matchAll(SNIPPET_RE)) {
+        out.push(unescapeQlangString(match[1]));
+    }
+    return out;
+}
+
+function unescapeQlangString(raw) {
+    return raw
+        .replace(/\\n/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\r/g, '\r')
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, '\\');
+}
+
+describe(':jdt/coverage examples parse as qlang', () => {
+    const source = readFileSync(COVERAGE_QLANG, 'utf8');
+    const snippets = extractSnippets(source);
+
+    it('catalog lists every declared :examples snippet', () => {
+        expect(snippets.length).toBeGreaterThan(0);
+        const occurrences =
+                (source.match(/:snippet\s+"/g) ?? []).length;
+        expect(snippets.length).toBe(occurrences);
+    });
+
+    for (const snippet of snippets) {
+        const label = snippet.length > 60
+                ? snippet.slice(0, 57) + '…' : snippet;
+        it(`parses: ${label}`, () => {
+            expect(() => parse(snippet)).not.toThrow();
+        });
+    }
+});

--- a/cli/test/coverage-impl.test.mjs
+++ b/cli/test/coverage-impl.test.mjs
@@ -1,0 +1,201 @@
+// HTTP-path verification for the :jdt/coverage primitives.
+//
+// Mocks client.mjs#get so each call's URL is observable, then walks
+// every code path of @coverage (0-arity / 1-arity / Map subject /
+// missing-fqn / no-active-session) and @activeCoverageId.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { keyword } from "@kaluchi/qlang-core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODULE_LIB = join(__dirname, "..", "lib");
+
+async function loadSession(mockedGet) {
+    process.env.JDT_GRAPH_CACHE = "0";
+    // JDT_COVERAGE_CACHE left enabled — module-level cache lives
+    // inside the freshly-imported coverage.impl.mjs and dies with
+    // vi.resetModules between tests, which is the right scope.
+    vi.resetModules();
+    vi.doMock("../src/client.mjs", () => ({
+        get: mockedGet,
+        currentInstance: () => null,
+        BridgeNotRunningError: class extends Error {},
+        isConnectionError: () => false,
+    }));
+    const graphImpl    = await import(
+            "../lib/jdt/graph.impl.mjs?v=" + Date.now());
+    const coverageImpl = await import(
+            "../lib/jdt/coverage.impl.mjs?v=" + Date.now());
+    const { createSession } = await import(
+            "@kaluchi/qlang-core/session");
+    return createSession({
+        locator: (ns) => {
+            const path = join(MODULE_LIB, ...ns.split("/")) + ".qlang";
+            const source = readFileSync(path, "utf8");
+            const impls = ns === "jdt/graph"
+                    ? graphImpl.createImpls()
+                    : ns === "jdt/coverage"
+                    ? coverageImpl.createImpls()
+                    : undefined;
+            return { source, impls };
+        },
+    });
+}
+
+afterEach(() => {
+    delete process.env.JDT_GRAPH_CACHE;
+    vi.resetModules();
+    vi.doUnmock("../src/client.mjs");
+});
+
+describe("@coverage routing — 0-arity (active session)", () => {
+    it("hits /coverage/active first, then /coverage/node", async () => {
+        const calls = [];
+        const session = await loadSession(async (path) => {
+            calls.push(path);
+            if (path === "/coverage/active") {
+                return { activeCoverageId: "MyTest:1234" };
+            }
+            return { fqn: "pkg.Foo", elementKind: "type",
+                     counters: {} };
+        });
+        await session.evalCell(
+            'use(:jdt/coverage) | "pkg.Foo" | @coverage');
+        expect(calls).toEqual([
+            "/coverage/active",
+            "/coverage/node?coverageId=MyTest%3A1234&fqn=pkg.Foo",
+        ]);
+    });
+
+    it("caches /coverage/active across calls in one session",
+            async () => {
+        const calls = [];
+        const session = await loadSession(async (path) => {
+            calls.push(path);
+            if (path === "/coverage/active") {
+                return { activeCoverageId: "X:1" };
+            }
+            return { fqn: "x", counters: {} };
+        });
+        await session.evalCell(
+            'use(:jdt/coverage) | ["pkg.A" "pkg.B" "pkg.C"] '
+          + '* @coverage');
+        const activeCalls = calls.filter(
+                p => p === "/coverage/active");
+        expect(activeCalls.length).toBe(1);
+        const nodeCalls = calls.filter(
+                p => p.startsWith("/coverage/node"));
+        expect(nodeCalls.length).toBe(3);
+    });
+
+    it("emits no-active-session error when active is null",
+            async () => {
+        const session = await loadSession(async (path) => {
+            if (path === "/coverage/active") {
+                return { activeCoverageId: null };
+            }
+            throw new Error("unexpected " + path);
+        });
+        const { result } = await session.evalCell(
+            'use(:jdt/coverage) '
+          + '| "pkg.Foo" | @coverage !| /thrown');
+        expect(result).toBe(keyword("CoverageNoActiveSession"));
+    });
+});
+
+describe("@coverage routing — 1-arity (explicit coverageId)", () => {
+    it("skips /coverage/active and uses captured id", async () => {
+        const calls = [];
+        const session = await loadSession(async (path) => {
+            calls.push(path);
+            return { fqn: "pkg.Foo", counters: {} };
+        });
+        await session.evalCell(
+            'use(:jdt/coverage) | "pkg.Foo" '
+          + '| @coverage("OtherTest:9999")');
+        expect(calls).toEqual([
+            "/coverage/node?coverageId=OtherTest%3A9999&fqn=pkg.Foo",
+        ]);
+    });
+
+    it("evaluates captured-arg as a sub-pipeline against pipeValue",
+            async () => {
+        const calls = [];
+        const session = await loadSession(async (path) => {
+            calls.push(path);
+            return { fqn: "pkg.Foo", counters: {} };
+        });
+        // Captured-arg references an `as` snapshot from earlier in
+        // the pipeline. Sub-pipeline evaluation against pipeValue.
+        await session.evalCell(
+            'use(:jdt/coverage) '
+          + '| "MyTest:1" | as(:cov) '
+          + '| "pkg.Foo" | @coverage(cov)');
+        expect(calls).toEqual([
+            "/coverage/node?coverageId=MyTest%3A1&fqn=pkg.Foo",
+        ]);
+    });
+
+    it("emits coverage-id-not-string when captured-arg is not "
+            + "a String", async () => {
+        const session = await loadSession(async () => {
+            throw new Error("should not be called");
+        });
+        const { result } = await session.evalCell(
+            'use(:jdt/coverage) | "pkg.Foo" '
+          + '| @coverage(42) !| /thrown');
+        expect(result).toBe(keyword("CoverageIdNotString"));
+    });
+});
+
+describe("@coverage routing — subject shapes", () => {
+    it("Map subject — extracts :fqn", async () => {
+        const calls = [];
+        const session = await loadSession(async (path) => {
+            calls.push(path);
+            if (path === "/coverage/active") {
+                return { activeCoverageId: "X:1" };
+            }
+            return { fqn: "pkg.Foo", counters: {} };
+        });
+        await session.evalCell(
+            'use(:jdt/coverage) '
+          + '| {:fqn "pkg.Foo" :kind "type"} | @coverage');
+        expect(calls).toContain(
+            "/coverage/node?coverageId=X%3A1&fqn=pkg.Foo");
+    });
+
+    it("subject without fqn — missing-subject error, no HTTP",
+            async () => {
+        const calls = [];
+        const session = await loadSession(async (path) => {
+            calls.push(path);
+            return null;
+        });
+        const { result } = await session.evalCell(
+            'use(:jdt/coverage) | 42 | @coverage !| /thrown');
+        expect(result).toBe(keyword("MissingSubjectFqn"));
+        expect(calls).toEqual([]);
+    });
+});
+
+describe("@activeCoverageId", () => {
+    it("returns String id when active", async () => {
+        const session = await loadSession(async () => ({
+                activeCoverageId: "MyTest:1" }));
+        const { result } = await session.evalCell(
+            'use(:jdt/coverage) | @activeCoverageId');
+        expect(result).toBe("MyTest:1");
+    });
+
+    it("returns null when no active session", async () => {
+        const session = await loadSession(async () => ({
+                activeCoverageId: null }));
+        const { result } = await session.evalCell(
+            'use(:jdt/coverage) | @activeCoverageId');
+        expect(result).toBeNull();
+    });
+});

--- a/cli/test/coverage-module.test.mjs
+++ b/cli/test/coverage-module.test.mjs
@@ -1,0 +1,104 @@
+// Descriptor consistency for the :jdt/coverage module — checks that
+// what coverage.qlang advertises in :modifiers, :returns, :kind and
+// :params matches the underlying coverage.impl.mjs primitives and
+// the qlang conduits' actual params lists.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { keyword } from "@kaluchi/qlang-core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODULE_LIB = join(__dirname, "..", "lib");
+
+async function loadSession() {
+    process.env.JDT_GRAPH_CACHE = "0";
+    process.env.JDT_COVERAGE_CACHE = "0";
+    vi.resetModules();
+    vi.doMock("../src/client.mjs", () => ({
+        get: async () => null,
+        currentInstance: () => null,
+        BridgeNotRunningError: class extends Error {},
+        isConnectionError: () => false,
+    }));
+    const graphImpl    = await import(
+            "../lib/jdt/graph.impl.mjs?v=" + Date.now());
+    const coverageImpl = await import(
+            "../lib/jdt/coverage.impl.mjs?v=" + Date.now());
+    const { createSession } = await import(
+            "@kaluchi/qlang-core/session");
+    return createSession({
+        locator: (ns) => {
+            const path = join(MODULE_LIB, ...ns.split("/")) + ".qlang";
+            const source = readFileSync(path, "utf8");
+            const impls = ns === "jdt/graph"
+                    ? graphImpl.createImpls()
+                    : ns === "jdt/coverage"
+                    ? coverageImpl.createImpls()
+                    : undefined;
+            return { source, impls };
+        },
+    });
+}
+
+afterEach(() => {
+    delete process.env.JDT_GRAPH_CACHE;
+    delete process.env.JDT_COVERAGE_CACHE;
+    vi.resetModules();
+    vi.doUnmock("../src/client.mjs");
+});
+
+async function descriptor(name) {
+    const session = await loadSession();
+    const { result, error } = await session.evalCell(
+        `use(:jdt/coverage) | reify(:${name})`);
+    if (error) throw error;
+    return result;
+}
+
+function field(desc, key) {
+    return desc.get(keyword(key));
+}
+
+describe(":jdt/coverage primitive descriptors", () => {
+    it("@coverage :returns :map, :modifiers carries :string", async () => {
+        const d = await descriptor("@coverage");
+        expect(field(d, "kind")).toBe(keyword("builtin"));
+        expect(field(d, "returns")).toBe(keyword("map"));
+        expect(field(d, "modifiers"))
+                .toEqual([keyword("string")]);
+    });
+
+    it("@activeCoverageId :returns :string, :modifiers empty",
+            async () => {
+        const d = await descriptor("@activeCoverageId");
+        expect(field(d, "kind")).toBe(keyword("builtin"));
+        expect(field(d, "returns")).toBe(keyword("string"));
+        expect(field(d, "modifiers")).toEqual([]);
+    });
+
+    it("@coverage :captured spans 0..1 (overloaded)", async () => {
+        const d = await descriptor("@coverage");
+        expect(field(d, "captured")).toEqual([0, 1]);
+    });
+
+    it("@activeCoverageId :captured is [0 0] (nullary)",
+            async () => {
+        const d = await descriptor("@activeCoverageId");
+        expect(field(d, "captured")).toEqual([0, 0]);
+    });
+});
+
+describe(":jdt/coverage conduits", () => {
+    for (const name of [
+            "@uncovered", "@partial", "@fullyCovered",
+            "@coveredLines", "@uncoveredLines", "@partialLines",
+            "@coverageCard"]) {
+        it(`${name} is a conduit with empty params`, async () => {
+            const d = await descriptor(name);
+            expect(field(d, "kind")).toBe(keyword("conduit"));
+            expect(field(d, "params")).toEqual([]);
+        });
+    }
+});

--- a/cli/test/coverage-uncovered.test.mjs
+++ b/cli/test/coverage-uncovered.test.mjs
@@ -1,0 +1,182 @@
+// Behavioural tests for the :jdt/coverage status predicates —
+// @uncovered, @partial, @fullyCovered.
+//
+// stubOp replaces @coverage with a fixed Map literal, so each
+// predicate exercises pure qlang-side logic without HTTP.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { loadCoverageSession, resetCoverageSession }
+        from "./helpers/coverage-session.mjs";
+import { stubOp } from "./helpers/operand-stub.mjs";
+
+describe("@uncovered — coveredCount==0 predicate", () => {
+    afterEach(resetCoverageSession);
+
+    it("true when instruction.coveredCount is 0", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 0
+                     :missedCount 100
+                     :totalCount 100
+                     :coverageStatus "NOT_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @uncovered`);
+        expect(result).toBe(true);
+    });
+
+    it("false when instruction.coveredCount > 0", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 5
+                     :missedCount 95
+                     :totalCount 100
+                     :coverageStatus "PARTLY_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @uncovered`);
+        expect(result).toBe(false);
+    });
+
+    it("false when fully covered", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 100
+                     :missedCount 0
+                     :totalCount 100
+                     :coverageStatus "FULLY_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @uncovered`);
+        expect(result).toBe(false);
+    });
+});
+
+describe("@partial — PARTLY_COVERED predicate", () => {
+    afterEach(resetCoverageSession);
+
+    it("true on PARTLY_COVERED status", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 30
+                     :missedCount 70
+                     :totalCount 100
+                     :coverageStatus "PARTLY_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @partial`);
+        expect(result).toBe(true);
+    });
+
+    it("false on FULLY_COVERED status", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 100
+                     :missedCount 0
+                     :totalCount 100
+                     :coverageStatus "FULLY_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @partial`);
+        expect(result).toBe(false);
+    });
+
+    it("false on NOT_COVERED status", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 0
+                     :missedCount 100
+                     :totalCount 100
+                     :coverageStatus "NOT_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @partial`);
+        expect(result).toBe(false);
+    });
+});
+
+describe("@fullyCovered — FULLY_COVERED predicate", () => {
+    afterEach(resetCoverageSession);
+
+    it("true on FULLY_COVERED status", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 100
+                     :missedCount 0
+                     :totalCount 100
+                     :coverageStatus "FULLY_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @fullyCovered`);
+        expect(result).toBe(true);
+    });
+
+    it("false on partial coverage", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", `
+                {:counters {:instruction
+                    {:coveredCount 50
+                     :missedCount 50
+                     :totalCount 100
+                     :coverageStatus "PARTLY_COVERED"}}}`),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @fullyCovered`);
+        expect(result).toBe(false);
+    });
+});
+
+describe("line axes — @coveredLines / @uncoveredLines / @partialLines",
+        () => {
+    afterEach(resetCoverageSession);
+
+    const LINES_STUB = `
+        {:counters {:instruction
+            {:coveredCount 4
+             :missedCount 3
+             :totalCount 7
+             :coverageStatus "PARTLY_COVERED"}}
+         :lines {:firstLine 10 :lastLine 16
+                 :entries [
+                    {:line 10 :status "FULLY_COVERED"
+                     :instructionCovered 5 :instructionMissed 0
+                     :branchCovered 0 :branchMissed 0}
+                    {:line 11 :status "FULLY_COVERED"
+                     :instructionCovered 3 :instructionMissed 0
+                     :branchCovered 0 :branchMissed 0}
+                    {:line 12 :status "PARTLY_COVERED"
+                     :instructionCovered 2 :instructionMissed 1
+                     :branchCovered 1 :branchMissed 1}
+                    {:line 14 :status "NOT_COVERED"
+                     :instructionCovered 0 :instructionMissed 4
+                     :branchCovered 0 :branchMissed 0}
+                    {:line 16 :status "NOT_COVERED"
+                     :instructionCovered 0 :instructionMissed 2
+                     :branchCovered 0 :branchMissed 0}]}}`;
+
+    it("@coveredLines returns FULLY_COVERED line numbers",
+            async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", LINES_STUB),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @coveredLines`);
+        expect(result).toEqual([10, 11]);
+    });
+
+    it("@uncoveredLines returns NOT_COVERED line numbers",
+            async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", LINES_STUB),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @uncoveredLines`);
+        expect(result).toEqual([14, 16]);
+    });
+
+    it("@partialLines returns full entry Maps for "
+            + "PARTLY_COVERED lines", async () => {
+        const { result } = await (await loadCoverageSession({
+            implsOverrides: await stubOp("@coverage", LINES_STUB),
+        })).evalCell(
+            `{:fqn "pkg.Foo#bar()" :kind "method"} | @partialLines * /line`);
+        expect(result).toEqual([12]);
+    });
+});

--- a/cli/test/helpers/coverage-session.mjs
+++ b/cli/test/helpers/coverage-session.mjs
@@ -1,0 +1,82 @@
+// Loader for the :jdt/coverage qlang module under test, mirroring
+// graph-session.mjs but pulling in BOTH :jdt/graph and :jdt/coverage
+// (coverage conduits like @coverageCard reach into :jdt/graph axes
+// such as @asNode and @detail).
+//
+//   mockedGet      — async (path) => responseValue. Stubs
+//                    client.mjs#get at the HTTP-path layer; tests
+//                    that verify URL formation observe `path` per
+//                    call.
+//
+//   implsOverrides — { '@operandName': stubImpl } merged over the
+//                    per-namespace createImpls() maps. Spreads into
+//                    BOTH namespace impl maps; conflicts go to the
+//                    one whose operand name matches.
+//
+// When neither is supplied, get() throws loud — no test silently
+// hits the real bridge.
+
+import { vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODULE_LIB     = join(__dirname, "..", "..", "lib");
+const GRAPH_QLANG    = join(MODULE_LIB, "jdt", "graph.qlang");
+const COVERAGE_QLANG = join(MODULE_LIB, "jdt", "coverage.qlang");
+
+export async function loadCoverageSession({
+        implsOverrides = {}, mockedGet } = {}) {
+    process.env.JDT_GRAPH_CACHE = "0";
+    process.env.JDT_COVERAGE_CACHE = "0";
+    vi.resetModules();
+    vi.doMock("../../src/client.mjs", () => ({
+        get: mockedGet ?? (async () => {
+            throw new Error(
+                "HTTP must not be hit; supply mockedGet "
+                + "or implsOverrides");
+        }),
+        currentInstance: () => null,
+        BridgeNotRunningError: class extends Error {},
+        isConnectionError: () => false,
+    }));
+    const graphImpl = await import(
+            "../../lib/jdt/graph.impl.mjs?v=" + Date.now());
+    const coverageImpl = await import(
+            "../../lib/jdt/coverage.impl.mjs?v=" + Date.now());
+    const { createSession } = await import(
+            "@kaluchi/qlang-core/session");
+
+    const ENTRIES = {
+        "jdt/graph": {
+            source: readFileSync(GRAPH_QLANG, "utf8"),
+            factory: graphImpl.createImpls,
+        },
+        "jdt/coverage": {
+            source: readFileSync(COVERAGE_QLANG, "utf8"),
+            factory: coverageImpl.createImpls,
+        },
+    };
+    const session = await createSession({
+        locator: (ns) => {
+            const entry = ENTRIES[ns];
+            if (!entry) return null;
+            return {
+                source: entry.source,
+                impls: { ...entry.factory(), ...implsOverrides },
+            };
+        },
+    });
+    const { error } = await session.evalCell(
+            "use(:jdt/graph) | use(:jdt/coverage)");
+    if (error) throw error;
+    return session;
+}
+
+export function resetCoverageSession() {
+    delete process.env.JDT_GRAPH_CACHE;
+    delete process.env.JDT_COVERAGE_CACHE;
+    vi.resetModules();
+    vi.doUnmock("../../src/client.mjs");
+}


### PR DESCRIPTION
CLI surface for coverage analysis. Two thin HTTP primitives wrapped
by EclEmma-vocabulary conduits and a markdown card renderer.

Primitives
- @coverage  (node | fqn → /coverage/node Map). 0-arity binds to
  active session via @activeCoverageId; 1-arity pins explicit
  coverageId via captured-arg.
- @activeCoverageId  () → /coverage/active String or null.

Conduits (subject-level, composable through filter / any / every)
- @uncovered, @partial, @fullyCovered  — instruction-status predicates
- @coveredLines, @uncoveredLines, @partialLines  — Vec axes over
  the :lines block (ISourceNode subjects only)
- @coverageCard  — bundle for mdCoverage

mdCoverage renderer in render.impl.mjs uses EclEmma's exact
vocabulary (Types not Classes, '0.0 %', 'X of Y branches missed.')
plus collapsed line ranges from coverage.py.

query.mjs registers the new namespace and extends the prelude. The
jdt help q help block grows a Coverage axes section.

Test plan
- [x] All 820 CLI tests pass (782 existing + 38 new)
- [ ] Live verification post-deploy (jdt setup --skip-build) against
  a real coverage session — expect counters matching Coverage View