### PR TITLE
Route /coverage/node through coverageBridge.dispatch

### DIFF
--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -679,6 +679,7 @@ public class HttpServer {
                 case "/coverage/run", "/coverage/dump",
                         "/coverage/refresh", "/coverage/relaunch",
                         "/coverage/runs", "/coverage/session",
+                        "/coverage/node",
                         "/coverage/active", "/coverage/activate",
                         "/coverage/merge", "/coverage/remove" ->
                         Response.json(coverageBridge.dispatch(


### PR DESCRIPTION
The /coverage/* dispatch in HttpServer.handleRequest is an explicit
case-list allowlist. PR #109 added /coverage/node to CoverageRouter
but missed the HttpServer entry, so live requests fell through to
the default Unknown-path branch and never reached the handler.

Test plan
- [x] jdt build --project io.github.kaluchi.jdtbridge (0 errors)
- [ ] Live: jdt setup --skip-build, then jdt q '"<fqn>" | @coverage'
  against an active session — expect counters Map, not
  '{:error "Unknown path: /coverage/node"}'