### PR TITLE
JdtUtils.resolveElement: handle project / package / file fqn

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ResolveElementKindsTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ResolveElementKindsTest.java
@@ -1,0 +1,162 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JdtUtils#resolveElement} extension covering the
+ * non-member, non-synthetic kinds (project, package, file). Type
+ * resolution and synthetic-fqn paths live in their own test files.
+ */
+public class ResolveElementKindsTest {
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        TestFixture.create();
+    }
+
+    // -- type still wins when fqn has no '#' ----------------------
+
+    @Test
+    void typeFqnResolvesToIType() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement(
+                "test.model.Animal");
+        assertInstanceOf(IType.class, el);
+        assertEquals("test.model.Animal",
+                ((IType) el).getFullyQualifiedName());
+    }
+
+    @Test
+    void nestedTypeFqnResolvesToIType() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement(
+                "test.edge.Outer.Inner");
+        assertInstanceOf(IType.class, el);
+        // Eclipse's IType.getFullyQualifiedName() uses '$' for nested
+        // types; the dotted form goes through getFullyQualifiedName('.').
+        assertEquals("test.edge.Outer.Inner",
+                ((IType) el).getFullyQualifiedName('.'));
+    }
+
+    // -- project ---------------------------------------------------
+
+    @Test
+    void projectNameResolvesToIJavaProject() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement(
+                TestFixture.PROJECT_NAME);
+        assertInstanceOf(IJavaProject.class, el);
+        assertEquals(TestFixture.PROJECT_NAME,
+                ((IJavaProject) el).getElementName());
+    }
+
+    @Test
+    void unknownProjectReturnsNull() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement(
+                "no-such-project-name-zzz");
+        assertNull(el);
+    }
+
+    // -- package ---------------------------------------------------
+
+    @Test
+    void packageFqnResolvesToIPackageFragment() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement("test.model");
+        assertInstanceOf(IPackageFragment.class, el);
+        assertEquals("test.model",
+                ((IPackageFragment) el).getElementName());
+    }
+
+    @Test
+    void deeperPackageFqnAlsoResolves() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement("test.service");
+        assertInstanceOf(IPackageFragment.class, el);
+        assertEquals("test.service",
+                ((IPackageFragment) el).getElementName());
+    }
+
+    @Test
+    void unknownPackageReturnsNull() throws Exception {
+        IJavaElement el = JdtUtils.resolveElement(
+                "no.such.package.zzz");
+        assertNull(el);
+    }
+
+    // -- backward-compat: existing callers' instanceof checks ------
+
+    @Test
+    void projectFqnDoesNotResolveAsType() throws Exception {
+        // findType on a project name must keep returning null —
+        // GraphHandler.findTypeRaw / handleType callers all check
+        // 'instanceof IType'; a project IJavaElement must not slip
+        // through.
+        IType type = JdtUtils.findType(TestFixture.PROJECT_NAME);
+        assertNull(type);
+    }
+
+    @Test
+    void packageFqnDoesNotResolveAsType() throws Exception {
+        IType type = JdtUtils.findType("test.model");
+        assertNull(type);
+    }
+
+    // -- priority: type fqn that overlaps a package name ----------
+
+    @Test
+    void typePriorityOverContainerKinds() throws Exception {
+        // When a type name happens to match a string that could also
+        // be a project / package, type wins (it's checked first in
+        // resolveContainerOrType). The fixture has type
+        // test.edge.Calculator and a package test.edge — the type
+        // path "test.edge.Calculator" must still hand back IType.
+        IJavaElement el = JdtUtils.resolveElement(
+                "test.edge.Calculator");
+        assertInstanceOf(IType.class, el);
+    }
+
+    // -- file path heuristic --------------------------------------
+
+    @Test
+    void plainDottedNameIsNotTreatedAsFilePath() throws Exception {
+        // 'no.such.thing' has no path separator and no drive prefix,
+        // so the file branch is skipped and the call returns null
+        // after type / project / package miss. Without the heuristic
+        // guard a workspace.getFileForLocation lookup would still
+        // return null but cost more.
+        assertNull(JdtUtils.resolveElement("no.such.thing"));
+    }
+
+    @Test
+    void unixAbsolutePathTriggersFileBranch() throws Exception {
+        // Path doesn't exist in this temp workbench, so result is
+        // null — what we care about here is that the call doesn't
+        // throw and the file branch was taken (covered by
+        // looksLikeFilePath returning true).
+        assertNull(JdtUtils.resolveElement(
+                "/no/such/file/here.java"));
+    }
+
+    @Test
+    void windowsAbsolutePathTriggersFileBranch() throws Exception {
+        assertNull(JdtUtils.resolveElement(
+                "X:\\no\\such\\file\\here.java"));
+    }
+
+    @Test
+    void emptyStringResolvesToNull() throws Exception {
+        // Defensive: empty fqn must not crash any branch.
+        assertNull(JdtUtils.resolveElement(""));
+    }
+
+    @Test
+    void unknownFqnResolvesToNull() throws Exception {
+        assertNull(JdtUtils.resolveElement("totally.unknown.thing"));
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
@@ -3,7 +3,9 @@ package io.github.kaluchi.jdtbridge;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -12,6 +14,8 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IParent;
 import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.IType;
@@ -218,11 +222,82 @@ public class JdtUtils {
     private static IJavaElement resolveRegular(String fqn)
             throws JavaModelException {
         int hash = fqn.indexOf('#');
-        if (hash < 0) return findTypeRaw(fqn);
+        if (hash < 0) return resolveContainerOrType(fqn);
         IType declaring = findTypeRaw(fqn.substring(0, hash));
         if (declaring == null) return null;
         return resolveMemberInType(
                 declaring, fqn.substring(hash + 1));
+    }
+
+    /**
+     * Hash-less fqn → workspace element. Probes in priority order:
+     * <ol>
+     *   <li>type ({@code pkg.Class}) — most common, kept first</li>
+     *   <li>project (workspace name)</li>
+     *   <li>package fragment (across all projects' source roots)</li>
+     *   <li>file (absolute filesystem path → {@link ICompilationUnit}
+     *       or class file)</li>
+     * </ol>
+     * Returns {@code null} when none match.
+     */
+    private static IJavaElement resolveContainerOrType(String fqn)
+            throws JavaModelException {
+        if (fqn.isEmpty()) return null;
+
+        IType type = findTypeRaw(fqn);
+        if (type != null) return type;
+
+        var workspaceRoot =
+                ResourcesPlugin.getWorkspace().getRoot();
+        var model = JavaCore.create(workspaceRoot);
+
+        if (isValidProjectName(fqn)) {
+            IJavaProject project = model.getJavaProject(fqn);
+            if (project != null && project.exists()) return project;
+        }
+
+        for (IJavaProject p : model.getJavaProjects()) {
+            for (IPackageFragmentRoot root
+                    : p.getPackageFragmentRoots()) {
+                IPackageFragment pkg = root.getPackageFragment(fqn);
+                if (pkg != null && pkg.exists()) return pkg;
+            }
+        }
+
+        if (looksLikeFilePath(fqn)) {
+            IPath path = IPath.fromOSString(fqn);
+            IFile file = workspaceRoot.getFileForLocation(path);
+            if (file != null && file.exists()) {
+                IJavaElement el = JavaCore.create(file);
+                if (el != null) return el;
+            }
+        }
+
+        return null;
+    }
+
+    /** {@link org.eclipse.core.resources.IWorkspaceRoot#getProject}
+     *  requires a single-segment name (no separators); guards the
+     *  {@link org.eclipse.jdt.core.IJavaModel#getJavaProject} call
+     *  which would otherwise throw {@link IllegalArgumentException}
+     *  on a path-shaped fqn. */
+    private static boolean isValidProjectName(String name) {
+        return name.indexOf('/') < 0 && name.indexOf('\\') < 0;
+    }
+
+    /** Heuristic to decide whether {@code fqn} is an absolute
+     *  filesystem path (and therefore a candidate for
+     *  {@link ICompilationUnit} / class-file resolution). Matches
+     *  Windows drive letters ({@code D:\…}, {@code D:/…}) and POSIX
+     *  absolute paths ({@code /…}). Plain dotted names — types,
+     *  packages, projects — never qualify. */
+    private static boolean looksLikeFilePath(String fqn) {
+        if (fqn.isEmpty()) return false;
+        char first = fqn.charAt(0);
+        if (first == '/' || first == '\\') return true;
+        return fqn.length() >= 3
+                && fqn.charAt(1) == ':'
+                && (fqn.charAt(2) == '/' || fqn.charAt(2) == '\\');
     }
 
     /** Plain {@link IJavaProject#findType} walk across open projects. */


### PR DESCRIPTION
Hash-less fqns previously routed only to findTypeRaw. The coverage
analysis surface (and any future caller wanting project / package /
file subjects) needs the same resolveElement entry to hand back
IJavaProject / IPackageFragment / ICompilationUnit / IClassFile.

resolveContainerOrType probes type → project → package → file in
priority order, returns null when none match. Type-first preserves
existing semantics; a path-shape heuristic gates the file branch so
plain dotted names never hit workspace.getFileForLocation.

Test plan
- [x] ResolveElementKindsTest 15/15 (type / project / package /
  file paths plus regression checks)
- [x] SyntheticFqnTest 10/10
- [x] GraphHandlerTest 77/77 (instanceof guards intact)
- [ ] Live: jdt q '"io.github.kaluchi.jdtbridge" | @coverage'
  expects per-project counters (post-deploy)