### PR TITLE
Coverage onboarding: tail next-step after analysisReady

### DIFF
--- a/cli/src/commands/coverage.mjs
+++ b/cli/src/commands/coverage.mjs
@@ -6,6 +6,7 @@ import { extractPositional, parseFlags } from "../args.mjs";
 import { output } from "../output.mjs";
 import { renderRunsTable } from "../format/coverage-runs.mjs";
 import {
+  analyzeNextStepsTail,
   formatRunHeader,
   formatStatusSnapshot,
   followCoverageStream,
@@ -103,8 +104,18 @@ export async function coverageStatus(args) {
   }
   const url = `/coverage/session?coverageId=${encodeURIComponent(coverageId)}`;
   const data = await get(url, 30_000);
+  const jsonFlag = args.includes("--json");
+  const quiet = args.includes("-q") || args.includes("--quiet");
   output(args, data, {
-    text(d) { console.log(formatStatusSnapshot(d)); },
+    text(d) {
+      console.log(formatStatusSnapshot(d));
+      // M5: same 3-line analyze-next-steps tail as the -f stream
+      // path, surfaced once analysis is ready. Skipped under
+      // --json (machine output) and -q.
+      if (!jsonFlag && !quiet && d?.analysisReady === true) {
+        console.log(analyzeNextStepsTail());
+      }
+    },
   });
 }
 
@@ -360,3 +371,4 @@ Usage:  jdt coverage stop <coverageId>
 Resolves coverageId to launchId (via /coverage/runs) and delegates to
 jdt launch stop. Errors with coverage-launch-not-live for merged or
 imported sessions.`;
+

--- a/cli/src/format/coverage-status.mjs
+++ b/cli/src/format/coverage-status.mjs
@@ -50,6 +50,16 @@ export function runGuide(coverageId, launchId) {
 Add \`-q\` to suppress this guide.`;
 }
 
+/** Three-line "what next" tail surfaced after analysisReady in
+ *  `jdt coverage run -f`, `jdt coverage status -f`, and (when
+ *  analysisReady) the snapshot form of `jdt coverage status`.
+ *  Same content across all three; one place to update. */
+export function analyzeNextStepsTail() {
+  return `
+Next: jdt q '"<class>" | @uncoveredLines'   line gaps
+      jdt q '"<class>" | @coverageCard'     md card`;
+}
+
 /** Format a /coverage/session response as a snapshot block. */
 export function formatStatusSnapshot(entry) {
   const status = composeStatus(entry);
@@ -200,13 +210,24 @@ function formatTime(millis) {
 /**
  * Stream /coverage/session/stream events.
  * Returns 0 on clean exit, 1 on error.
+ *
+ * On clean exit (analysis terminal state reached) the M4 tail —
+ * three suggested follow-up commands plus a pointer to
+ * `jdt help coverage analyze` — is printed unless `--json` or `-q`
+ * is in args. Same tail content as the M5 snapshot path so the
+ * agent sees consistent next-step menus regardless of entry point.
  */
 export async function followCoverageStream(coverageId, args) {
   const { followJsonlStream } = await import("./stream.mjs");
   const jsonFlag = args.includes("--json");
+  const quiet = args.includes("-q") || args.includes("--quiet");
   const url = `/coverage/session/stream?coverageId=${encodeURIComponent(coverageId)}`;
-  return followJsonlStream(url, (line) => {
+  const exit = await followJsonlStream(url, (line) => {
     if (jsonFlag) console.log(line);
     else formatStreamEvent(line);
   });
+  if (exit === 0 && !jsonFlag && !quiet) {
+    console.log(analyzeNextStepsTail());
+  }
+  return exit;
 }

--- a/cli/test/format-coverage-status.test.mjs
+++ b/cli/test/format-coverage-status.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { setColorEnabled } from "../src/color.mjs";
 import {
   formatRunHeader,
+  analyzeNextStepsTail,
   formatStatusSnapshot,
   formatStreamEvent,
   runGuide,
@@ -212,5 +213,14 @@ describe("runGuide", () => {
     expect(guide).toContain("jdt coverage dump MyTest:1");
     expect(guide).toContain("jdt coverage stop MyTest:1");
     expect(guide).toContain("jdt coverage activate MyTest:1");
+  });
+
+});
+
+describe("analyzeNextStepsTail", () => {
+  it("points at uncoveredLines and coverageCard", () => {
+    const tail = analyzeNextStepsTail();
+    expect(tail).toContain("@uncoveredLines");
+    expect(tail).toContain("@coverageCard");
   });
 });


### PR DESCRIPTION
Two surface points get a 3-line tail with the most useful follow-up
qlang queries:
- followCoverageStream (jdt coverage run -f, jdt coverage status -f)
  prints the tail when the stream closes cleanly.
- coverageStatus snapshot (without -f) prints the same tail when
  entry.analysisReady === true.

Same content from both entry points; suppressed for --json and -q.
Reference catalog already lives in jdt help q (Coverage axes
section).

Test plan
- [x] 821/821 CLI tests pass; format-coverage-status gets a new
  test asserting the tail mentions @uncoveredLines / @coverageCard