### PR TITLE
test/coverage run: refuse on workspace compile errors

### DIFF
--- a/cli/src/commands/coverage.mjs
+++ b/cli/src/commands/coverage.mjs
@@ -4,6 +4,7 @@
 import { get, post } from "../client.mjs";
 import { extractPositional, parseFlags } from "../args.mjs";
 import { output } from "../output.mjs";
+import { preflightCompileErrors } from "../preflight-compile-errors.mjs";
 import { renderRunsTable } from "../format/coverage-runs.mjs";
 import {
   analyzeNextStepsTail,
@@ -30,6 +31,9 @@ export async function coverageRun(args) {
   if (flags.args) url += `&args=${encodeURIComponent(flags.args)}`;
 
   const jsonFlag = args.includes("--json");
+  const cleared = await preflightCompileErrors(args, { json: jsonFlag });
+  if (!cleared) process.exit(1);
+
   const result = await get(url, 30_000);
   if (result.error) {
     if (jsonFlag) console.log(JSON.stringify(result));
@@ -61,10 +65,11 @@ export const coverageRunHelp = `Launch a coverage run (non-blocking).
 Usage:  jdt coverage run <configId> [-f] [-q] [--json]
 
 Flags:
-  -f, --follow    stream state events until analysis terminates
-  -q, --quiet     suppress onboarding guide
-  --args <text>   extra arguments appended to launch config
-  --json          JSON snapshot output
+  -f, --follow              stream state events until analysis terminates
+  -q, --quiet               suppress onboarding guide
+  --args <text>             extra arguments appended to launch config
+  --json                    JSON snapshot output
+  --ignore-compile-errors   launch despite workspace compile errors
 
 Examples:
   jdt coverage run MyTest

--- a/cli/src/commands/test-run.mjs
+++ b/cli/src/commands/test-run.mjs
@@ -1,5 +1,6 @@
 import { get } from "../client.mjs";
 import { extractPositional, parseFlags, parseFqn } from "../args.mjs";
+import { preflightCompileErrors } from "../preflight-compile-errors.mjs";
 import {
   formatTestRunHeader,
   testRunGuide,
@@ -42,6 +43,10 @@ export async function testRun(args) {
   const coverage = args.includes("--coverage");
   if (coverage) url += "&coverage=true";
 
+  const jsonFlag = args.includes("--json");
+  const cleared = await preflightCompileErrors(args, { json: jsonFlag });
+  if (!cleared) process.exit(1);
+
   const result = await get(url, 30_000);
   if (result.error) {
     console.error(result.error);
@@ -70,7 +75,6 @@ export async function testRun(args) {
   result.launchId = launchId;
   result.testRunId = testRunId;
 
-  const jsonFlag = args.includes("--json");
   if (!jsonFlag) console.log(formatTestRunHeader(result));
 
   if (coverage && !jsonFlag) {
@@ -118,12 +122,13 @@ but launched using the specified project's classpath. This is useful when
 test sources live in one project but need dependencies from another.
 
 Flags:
-  --project <name>  override the project for classpath resolution
-  -f, --follow      stream test status (only failures by default)
-  -q, --quiet       suppress onboarding guide
-  --all             include passed tests in output (with -f)
-  --ignored         show only ignored tests (with -f)
-  --json            output as JSONL when streaming (-f), or JSON snapshot
+  --project <name>          override the project for classpath resolution
+  -f, --follow              stream test status (only failures by default)
+  -q, --quiet               suppress onboarding guide
+  --all                     include passed tests in output (with -f)
+  --ignored                 show only ignored tests (with -f)
+  --json                    output as JSONL when streaming (-f), or JSON snapshot
+  --ignore-compile-errors   launch despite workspace compile errors
 
 Examples:
   jdt test run com.example.MyTest                       run + show guide

--- a/cli/src/format/align.mjs
+++ b/cli/src/format/align.mjs
@@ -1,0 +1,18 @@
+// Align command/description rows so descriptions start at the same column.
+// Used by `*RunGuide` blocks that mix variable-length commands (with
+// embedded launchId / coverageId) and short descriptions.
+
+/**
+ * @param {Array<[string, string]>} rows - [command, description] pairs
+ * @param {object} [opts]
+ * @param {string} [opts.indent="  "] - line prefix
+ * @param {number} [opts.gap=2] - spaces between command and description
+ * @returns {string} joined lines, no trailing newline
+ */
+export function alignCmds(rows, { indent = "  ", gap = 2 } = {}) {
+  const widest = Math.max(...rows.map(([cmd]) => cmd.length));
+  return rows.map(([cmd, desc]) => {
+    const pad = " ".repeat(widest - cmd.length + gap);
+    return `${indent}\`${cmd}\`${pad}${desc}`;
+  }).join("\n");
+}

--- a/cli/src/format/coverage-status.mjs
+++ b/cli/src/format/coverage-status.mjs
@@ -1,6 +1,7 @@
 // Renderers for jdt coverage run / status / -f stream.
 
 import { bold, dim, green, red, yellow } from "../color.mjs";
+import { alignCmds } from "./align.mjs";
 import { composeStatus } from "./coverage-state.mjs";
 
 /** Header printed by `jdt coverage run`. */
@@ -25,27 +26,33 @@ export function formatRunHeader(result) {
 export function runGuide(coverageId, launchId) {
   return `
 **Coverage status** (coverageId = ${coverageId}):
-  \`jdt coverage status ${coverageId}\`             snapshot
-  \`jdt coverage status ${coverageId} -f\`          follow until ready
-  \`jdt coverage active\`                            show active session
+${alignCmds([
+  [`jdt coverage status ${coverageId}`, "snapshot"],
+  [`jdt coverage status ${coverageId} -f`, "follow until ready"],
+  [`jdt coverage active`, "show active session"],
+])}
 
 **Console output** (launchId = ${launchId}):
   \`jdt launch logs ${launchId}\`
   \`jdt launch logs ${launchId} --tail 50\`
 
 **Manage running launch:**
-  \`jdt coverage dump ${coverageId}\`               request a dump
-  \`jdt coverage dump ${coverageId} --reset\`       dump + reset agent probes
-  \`jdt coverage stop ${coverageId}\`               terminate
+${alignCmds([
+  [`jdt coverage dump ${coverageId}`, "request a dump"],
+  [`jdt coverage dump ${coverageId} --reset`, "dump + reset agent probes"],
+  [`jdt coverage stop ${coverageId}`, "terminate"],
+])}
 
 **Sessions:**
-  \`jdt coverage runs\`                              list all sessions
-  \`jdt coverage activate ${coverageId}\`           switch IDE display
-  \`jdt coverage refresh\`                           re-analyze active
-  \`jdt coverage relaunch\`                          re-launch active in coverage mode
-  \`jdt coverage merge <coverageId> <coverageId>\`  merge two or more
-  \`jdt coverage remove\`                            remove active
-  \`jdt coverage remove --all\`                      remove all
+${alignCmds([
+  [`jdt coverage runs`, "list all sessions"],
+  [`jdt coverage activate ${coverageId}`, "switch IDE display"],
+  [`jdt coverage refresh`, "re-analyze active"],
+  [`jdt coverage relaunch`, "re-launch active in coverage mode"],
+  [`jdt coverage merge <coverageId> <coverageId>`, "merge two or more"],
+  [`jdt coverage remove`, "remove active"],
+  [`jdt coverage remove --all`, "remove all"],
+])}
 
 Add \`-q\` to suppress this guide.`;
 }

--- a/cli/src/format/test-status.mjs
+++ b/cli/src/format/test-status.mjs
@@ -3,6 +3,7 @@
 // Uses FQN with # separator and [M] badges for navigation.
 
 import { red, green, yellow, bold, dim } from "../color.mjs";
+import { alignCmds } from "./align.mjs";
 
 /**
  * Format a test status snapshot (JSON from /test/status).
@@ -157,23 +158,29 @@ export function formatTestRunHeader(result) {
 export function testRunGuide(testRunId, launchId) {
   return `
 **Test status** (testRunId = ${testRunId}):
-  \`jdt test status ${testRunId}\`            failures only (default)
-  \`jdt test status ${testRunId} -f\`         stream live until done
-  \`jdt test status ${testRunId} --all\`      all tests including passed
-  \`jdt test status ${testRunId} --ignored\`  only skipped/disabled tests
+${alignCmds([
+  [`jdt test status ${testRunId}`, "failures only (default)"],
+  [`jdt test status ${testRunId} -f`, "stream live until done"],
+  [`jdt test status ${testRunId} --all`, "all tests including passed"],
+  [`jdt test status ${testRunId} --ignored`, "only skipped/disabled tests"],
+])}
 
 **Console output** (launchId = ${launchId}):
   \`jdt launch logs ${launchId}\`
   \`jdt launch logs ${launchId} --tail 50\`
 
 **Manage:**
-  \`jdt test runs\`                          list test runs
-  \`jdt launch stop ${launchId}\`            abort
-  \`jdt launch clear ${launchId}\`           remove
+${alignCmds([
+  [`jdt test runs`, "list test runs"],
+  [`jdt launch stop ${launchId}`, "abort"],
+  [`jdt launch clear ${launchId}`, "remove"],
+])}
 
 **Navigate** — FQNs from status output are copy-pasteable:
-  \`jdt q '"<FQN>" | @source'\`            view test source
-  \`jdt test run <FQN> -f\`                re-run single test
+${alignCmds([
+  [`jdt q '"<FQN>" | @source'`, "view test source"],
+  [`jdt test run <FQN> -f`, "re-run single test"],
+])}
 
 Add \`-q\` to suppress this guide.`;
 }

--- a/cli/src/preflight-compile-errors.mjs
+++ b/cli/src/preflight-compile-errors.mjs
@@ -1,0 +1,87 @@
+// Pre-flight gate for jdt test run / jdt coverage run.
+// Refuses launch when @problems carries any error-severity marker.
+// Bypassed by --ignore-compile-errors.
+
+import { get } from "./client.mjs";
+import { bold, dim, red } from "./color.mjs";
+
+const FLAG = "--ignore-compile-errors";
+const SAMPLE_LIMIT = 5;
+
+/**
+ * @param {string[]} args - argv (used for flag detection)
+ * @param {object} opts
+ * @param {boolean} [opts.json] - --json mode (machine output)
+ * @returns {Promise<boolean>} true → caller proceeds; false → caller exits 1
+ */
+export async function preflightCompileErrors(args, { json = false } = {}) {
+  const problems = await get("/problems");
+  const errors = (Array.isArray(problems) ? problems : [])
+    .filter((p) => p?.severity === "error");
+  if (errors.length === 0) return true;
+
+  if (args.includes(FLAG)) {
+    if (!json) console.error(dim(bypassWarning(errors.length)));
+    return true;
+  }
+
+  if (json) {
+    console.log(JSON.stringify({
+      error: "workspace-has-compile-errors",
+      count: errors.length,
+      markers: errors.slice(0, SAMPLE_LIMIT).map(toMarker),
+      hint: `pass ${FLAG} to launch anyway`,
+    }));
+  } else {
+    printRefusal(errors);
+  }
+  return false;
+}
+
+function bypassWarning(count) {
+  return `(${FLAG}: workspace has ${count} compile `
+    + `${plural(count, "error")}; expect missing/empty results)`;
+}
+
+function toMarker(p) {
+  return {
+    file: p.location?.file,
+    line: p.location?.startLine,
+    message: p.message,
+  };
+}
+
+function printRefusal(errors) {
+  const cwd = process.cwd();
+  console.error(red(bold(
+    `#### Refused: workspace has ${errors.length} compile `
+      + plural(errors.length, "error"))));
+  console.error("");
+  for (const p of errors.slice(0, SAMPLE_LIMIT)) {
+    const file = relPath(p.location?.file, cwd);
+    const line = p.location?.startLine ?? "?";
+    console.error(`  ${file}:${line}  ${p.message}`);
+  }
+  if (errors.length > SAMPLE_LIMIT) {
+    console.error("");
+    console.error(dim(
+      `(showing ${SAMPLE_LIMIT} of ${errors.length} `
+        + `— full list: jdt q '@problems | filter(/error)')`));
+  }
+  console.error("");
+  console.error("Tests / coverage on a broken workspace produce meaningless");
+  console.error("results (no instrumented classes loaded, JUnit reports 0 tests).");
+  console.error(`Fix the errors, or pass ${FLAG} to launch anyway.`);
+}
+
+function plural(n, word) { return n === 1 ? word : word + "s"; }
+
+function relPath(absPath, cwd) {
+  if (!absPath) return "?";
+  const norm = absPath.replace(/\\/g, "/");
+  const cwdNorm = cwd.replace(/\\/g, "/");
+  if (norm.toLowerCase().startsWith(cwdNorm.toLowerCase() + "/")) {
+    return norm.slice(cwdNorm.length + 1);
+  }
+  return absPath;
+}

--- a/cli/src/preflight-compile-errors.mjs
+++ b/cli/src/preflight-compile-errors.mjs
@@ -16,8 +16,7 @@ const SAMPLE_LIMIT = 5;
  */
 export async function preflightCompileErrors(args, { json = false } = {}) {
   const problems = await get("/problems");
-  const errors = (Array.isArray(problems) ? problems : [])
-    .filter((p) => p?.severity === "error");
+  const errors = problems.filter((p) => p.severity === "error");
   if (errors.length === 0) return true;
 
   if (args.includes(FLAG)) {

--- a/cli/test/commands.coverage.test.mjs
+++ b/cli/test/commands.coverage.test.mjs
@@ -51,7 +51,16 @@ describe("commands.coverage", () => {
   });
 
   async function setupMock(handler) {
-    ({ server, port } = await startServer(handler));
+    ({ server, port } = await startServer((req, res) => {
+      // Default /problems → [] so the coverage-run preflight clears
+      // without each test having to mock it.
+      if (req.url.startsWith("/problems")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("[]");
+        return;
+      }
+      handler(req, res);
+    }));
     vi.doMock("../src/resolve.mjs", () => ({
       resolveInstance: async () => ({
         port, token: null, pid: process.pid,

--- a/cli/test/format-align.test.mjs
+++ b/cli/test/format-align.test.mjs
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { alignCmds } from "../src/format/align.mjs";
+
+describe("alignCmds", () => {
+  it("aligns descriptions to the widest command + 2 spaces", () => {
+    const out = alignCmds([
+      ["a", "short"],
+      ["abcdefgh", "long-cmd"],
+      ["abcd", "mid"],
+    ]);
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(3);
+    // widest = 8 ("abcdefgh"); descriptions all start at idx 2+1+8+1+2 = 14
+    // (indent 2 + ` + cmd + ` + gap 2)
+    const idx = lines.map((l) => l.indexOf(/\S/.test(l[14]) ? l[14] : ""));
+    expect(lines[0]).toBe("  `a`         short");
+    expect(lines[1]).toBe("  `abcdefgh`  long-cmd");
+    expect(lines[2]).toBe("  `abcd`      mid");
+  });
+
+  it("single row → just gap of 2", () => {
+    expect(alignCmds([["x", "y"]])).toBe("  `x`  y");
+  });
+
+  it("custom indent and gap", () => {
+    const out = alignCmds(
+      [["a", "x"], ["bc", "y"]],
+      { indent: "    ", gap: 4 },
+    );
+    expect(out.split("\n")).toEqual([
+      "    `a`     x",
+      "    `bc`    y",
+    ]);
+  });
+
+  it("equal-width commands → uniform 2-space gap", () => {
+    expect(alignCmds([["foo", "1"], ["bar", "2"]])).toBe(
+      "  `foo`  1\n  `bar`  2",
+    );
+  });
+});

--- a/cli/test/format-align.test.mjs
+++ b/cli/test/format-align.test.mjs
@@ -8,14 +8,11 @@ describe("alignCmds", () => {
       ["abcdefgh", "long-cmd"],
       ["abcd", "mid"],
     ]);
-    const lines = out.split("\n");
-    expect(lines).toHaveLength(3);
-    // widest = 8 ("abcdefgh"); descriptions all start at idx 2+1+8+1+2 = 14
-    // (indent 2 + ` + cmd + ` + gap 2)
-    const idx = lines.map((l) => l.indexOf(/\S/.test(l[14]) ? l[14] : ""));
-    expect(lines[0]).toBe("  `a`         short");
-    expect(lines[1]).toBe("  `abcdefgh`  long-cmd");
-    expect(lines[2]).toBe("  `abcd`      mid");
+    expect(out.split("\n")).toEqual([
+      "  `a`         short",
+      "  `abcdefgh`  long-cmd",
+      "  `abcd`      mid",
+    ]);
   });
 
   it("single row → just gap of 2", () => {

--- a/cli/test/preflight-compile-errors.test.mjs
+++ b/cli/test/preflight-compile-errors.test.mjs
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createServer } from "node:http";
+import { setColorEnabled } from "../src/color.mjs";
+
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: server.address().port }),
+    );
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+function mockResolve(port) {
+  vi.doMock("../src/resolve.mjs", () => ({
+    resolveInstance: async () => ({
+      port,
+      token: null,
+      pid: process.pid,
+      workspace: "/test",
+      host: "127.0.0.1",
+      file: "",
+    }),
+  }));
+}
+
+function problem(file, line, message, severity = "error") {
+  return {
+    severity,
+    message,
+    location: { file, startLine: line, endLine: line },
+  };
+}
+
+describe("preflightCompileErrors", () => {
+  let server;
+  let stderr;
+  let stdout;
+  const origErr = console.error;
+  const origLog = console.log;
+
+  beforeEach(() => {
+    setColorEnabled(false);
+    stderr = [];
+    stdout = [];
+    console.error = (...a) => stderr.push(a.join(" "));
+    console.log = (...a) => stdout.push(a.join(" "));
+  });
+
+  afterEach(async () => {
+    console.error = origErr;
+    console.log = origLog;
+    if (server) {
+      await stopServer(server);
+      server = null;
+    }
+    vi.resetModules();
+  });
+
+  function serve(problems) {
+    return startServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(problems));
+    });
+  }
+
+  it("clean workspace → proceed, no output", async () => {
+    let port;
+    ({ server, port } = await serve([]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    const cleared = await preflightCompileErrors([]);
+    expect(cleared).toBe(true);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([]);
+  });
+
+  it("only warnings → proceed (severity filter)", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/x/Foo.java", 1, "unused import", "warning"),
+      problem("/x/Bar.java", 2, "deprecated", "warning"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(await preflightCompileErrors([])).toBe(true);
+    expect(stderr).toEqual([]);
+  });
+
+  it("1 error, no flag → refuse, singular wording", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/x/Foo.java", 42, "cannot find symbol Bar"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(await preflightCompileErrors([])).toBe(false);
+    const text = stderr.join("\n");
+    expect(text).toContain("workspace has 1 compile error");
+    expect(text).not.toContain("compile errors");
+    expect(text).toContain("Foo.java:42");
+    expect(text).toContain("cannot find symbol Bar");
+    expect(text).toContain("--ignore-compile-errors");
+    expect(text).not.toContain("showing");
+  });
+
+  it("3 errors, no flag → all listed, no truncation banner", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/x/A.java", 1, "msg-A"),
+      problem("/x/B.java", 2, "msg-B"),
+      problem("/x/C.java", 3, "msg-C"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(await preflightCompileErrors([])).toBe(false);
+    const text = stderr.join("\n");
+    expect(text).toContain("3 compile errors");
+    expect(text).toContain("A.java:1");
+    expect(text).toContain("B.java:2");
+    expect(text).toContain("C.java:3");
+    expect(text).not.toContain("showing");
+  });
+
+  it("137 errors → first 5 listed + truncation banner", async () => {
+    const many = Array.from({ length: 137 }, (_, i) =>
+      problem(`/x/F${i}.java`, i + 1, `m-${i}`));
+    let port;
+    ({ server, port } = await serve(many));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(await preflightCompileErrors([])).toBe(false);
+    const text = stderr.join("\n");
+    expect(text).toContain("137 compile errors");
+    expect(text).toContain("F0.java:1");
+    expect(text).toContain("F4.java:5");
+    expect(text).not.toContain("F5.java:6");
+    expect(text).toContain("(showing 5 of 137");
+    expect(text).toContain("jdt q '@problems | filter(/error)'");
+  });
+
+  it("errors + --ignore-compile-errors → bypass with dim warning", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/x/Foo.java", 1, "boom"),
+      problem("/x/Bar.java", 2, "boom"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(
+      await preflightCompileErrors(["--ignore-compile-errors"]),
+    ).toBe(true);
+    const text = stderr.join("\n");
+    expect(text).toContain("--ignore-compile-errors");
+    expect(text).toContain("workspace has 2 compile errors");
+    expect(text).toContain("expect missing/empty results");
+    expect(text).not.toContain("Refused");
+    expect(stdout).toEqual([]);
+  });
+
+  it("errors + --json → JSON to stdout, no human text", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/x/Foo.java", 7, "boom"),
+      problem("/x/Bar.java", 9, "bang"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(
+      await preflightCompileErrors([], { json: true }),
+    ).toBe(false);
+    expect(stderr).toEqual([]);
+    expect(stdout).toHaveLength(1);
+    const payload = JSON.parse(stdout[0]);
+    expect(payload).toMatchObject({
+      error: "workspace-has-compile-errors",
+      count: 2,
+      hint: "pass --ignore-compile-errors to launch anyway",
+    });
+    expect(payload.markers).toHaveLength(2);
+    expect(payload.markers[0]).toEqual({
+      file: "/x/Foo.java",
+      line: 7,
+      message: "boom",
+    });
+  });
+
+  it("errors + --ignore-compile-errors + --json → silent bypass", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/x/Foo.java", 1, "boom"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    expect(
+      await preflightCompileErrors(
+        ["--ignore-compile-errors"],
+        { json: true },
+      ),
+    ).toBe(true);
+    expect(stderr).toEqual([]);
+    expect(stdout).toEqual([]);
+  });
+
+  it("file under cwd renders as relative path", async () => {
+    const cwd = process.cwd().replace(/\\/g, "/");
+    let port;
+    ({ server, port } = await serve([
+      problem(`${cwd}/sub/dir/Foo.java`, 5, "msg"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    await preflightCompileErrors([]);
+    const text = stderr.join("\n");
+    expect(text).toContain("sub/dir/Foo.java:5");
+    expect(text).not.toContain(cwd + "/sub");
+  });
+
+  it("file outside cwd kept as absolute path", async () => {
+    let port;
+    ({ server, port } = await serve([
+      problem("/elsewhere/Foo.java", 1, "msg"),
+    ]));
+    mockResolve(port);
+    const { preflightCompileErrors } = await import(
+      "../src/preflight-compile-errors.mjs"
+    );
+    await preflightCompileErrors([]);
+    const text = stderr.join("\n");
+    expect(text).toContain("/elsewhere/Foo.java:1");
+  });
+});

--- a/cli/test/test-commands.test.mjs
+++ b/cli/test/test-commands.test.mjs
@@ -48,7 +48,16 @@ describe("test commands", () => {
   });
 
   async function setupMock(handler) {
-    ({ server, port } = await startServer(handler));
+    ({ server, port } = await startServer((req, res) => {
+      // Default /problems → [] so the test-run/coverage-run preflight
+      // (preflightCompileErrors) clears without each test having to mock it.
+      if (req.url.startsWith("/problems")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("[]");
+        return;
+      }
+      handler(req, res);
+    }));
     vi.doMock("../src/resolve.mjs", () => ({
       resolveInstance: async () => ({ port, token: null, pid: process.pid, workspace: "/test", host: "127.0.0.1", file: "" }),
     }));


### PR DESCRIPTION
Summary
- jdt test run / jdt coverage run gain a pre-flight that calls GET /problems, filters severity=error, and refuses the launch when any are present.
- Refusal text: count, first 5 markers (file:line - message) with paths relative to cwd, dim "showing 5 of N - full list: jdt q '@problems | filter(/error)'" line, two-line why-it-matters, and the override hint. Exit 1.
- Override: --ignore-compile-errors. Help lists it as a single line in Flags:; the prose explanation lives ONLY in the runtime refusal so onboarding fires at the moment the gate trips, not in an up-front help dump.
- Bonus fix: testRunGuide / coverageRunGuide alignment. Manage: and Sessions: blocks used hardcoded space-padding that broke when launchId / coverageId length varied. New alignCmds helper pads each section to the widest command + 2 spaces.

Test plan
- [x] cli/test/preflight-compile-errors.test.mjs (10 tests: clean / warnings-only / 1 error / 3 errors / 137 errors / bypass / json / json+bypass / cwd-relative / outside-cwd absolute)
- [x] cli/test/format-align.test.mjs (4 tests)
- [x] Updated test/test-commands.test.mjs and test/commands.coverage.test.mjs to mock /problems -> [] in setupMock so existing tests keep passing
- [x] Local: 835/835 pass
- [x] Live verification: broken file in plugin/, jdt test run refused with 6 real markers and exit 1; --ignore-compile-errors bypassed with dim warning and proceeded