### PR TITLE
plugin.tests: drop silent-skip / dead-test garbage

### DIFF
--- a/cli/lib/jdt/coverage.qlang
+++ b/cli/lib/jdt/coverage.qlang
@@ -111,6 +111,38 @@ let(:@partialLines,
     @coverage | /lines/entries
     | filter(/status | eq("PARTLY_COVERED")))
 
+|~ ── Drill conduits for cleanup workflows ────────────────────── ~|
+
+|~~ Partial-coverage methods of a type, sorted desc by missed
+    instruction count. Each row carries :fqn, :missed, :covered for
+    quick triage of which methods to drill into:
+
+      "pkg.Foo" | @partialMethods | take(5) | table
+                                          → top-5 partials with counts
+      "pkg.Foo" | @partialMethods * /fqn  → just the fqns ~~|
+let(:@partialMethods,
+    @methods | filter(@partial) * (
+        as(:m) | @coverage | /counters/instruction | as(:c)
+        | {:fqn (m | /fqn)
+           :missed (c | /missedCount)
+           :covered (c | /coveredCount)})
+    | sortWith(desc(/missed)))
+
+|~~ Partial-coverage classes of a project, sorted desc by missed
+    instruction count. Same row shape as @partialMethods. Note this
+    operates on @typesInProject — outer types only; @Nested inner
+    classes have their own counters and need separate drilling via
+    `<class> | @innerTypes | filter(@partial) * (...)`.
+
+      "myproject" | @partialClasses | take(15) | table ~~|
+let(:@partialClasses,
+    @typesInProject | filter(@partial) * (
+        as(:t) | @coverage | /counters/instruction | as(:c)
+        | {:fqn (t | /fqn)
+           :missed (c | /missedCount)
+           :covered (c | /coveredCount)})
+    | sortWith(desc(/missed)))
+
 |~ ── Markdown coverage card ──────────────────────────────────── ~|
 
 |~~ Bundle the subject's @detail node and its @coverage Map for

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ActivatorTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ActivatorTest.java
@@ -22,15 +22,15 @@ public class ActivatorTest {
 
     @Test
     public void tokenIs32HexChars() {
-        String token = invokeGenerateToken();
+        String token = Activator.generateToken();
         assertEquals(32, token.length());
         assertTrue(HEX_32.matcher(token).matches());
     }
 
     @Test
     public void tokenIsUnique() {
-        assertNotEquals(invokeGenerateToken(),
-                invokeGenerateToken());
+        assertNotEquals(Activator.generateToken(),
+                Activator.generateToken());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ActivatorTest {
         Path tempFile = Files.createTempFile(
                 "jdtbridge-test-", ".json");
         try {
-            String token = invokeGenerateToken();
+            String token = Activator.generateToken();
             var obj = new JsonObject();
             obj.addProperty("port", 54321);
             obj.addProperty("token", token);
@@ -116,14 +116,4 @@ public class ActivatorTest {
         assertNotNull(parsed.get("location").getAsString());
     }
 
-    private String invokeGenerateToken() {
-        try {
-            var method = Activator.class
-                    .getDeclaredMethod("generateToken");
-            method.setAccessible(true);
-            return (String) method.invoke(null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DiagnosticsHandlerTest.java
@@ -9,43 +9,34 @@ import org.junit.jupiter.api.Test;
  */
 public class DiagnosticsHandlerTest {
 
+    private final DiagnosticsHandler handler = new DiagnosticsHandler();
+
     @Test
     public void shortMarkerTypeJdt() {
-        assertEquals("jdt", invokeShortMarkerType(
+        assertEquals("jdt", handler.shortMarkerType(
                 "org.eclipse.jdt.core.problem"));
     }
 
     @Test
     public void shortMarkerTypeCheckstyle() {
-        assertEquals("checkstyle", invokeShortMarkerType(
+        assertEquals("checkstyle", handler.shortMarkerType(
                 "net.sf.eclipsecs.core.CheckstyleMarker"));
     }
 
     @Test
     public void shortMarkerTypeMaven() {
-        assertEquals("maven", invokeShortMarkerType(
+        assertEquals("maven", handler.shortMarkerType(
                 "org.eclipse.m2e.core.maven2Problem"));
     }
 
     @Test
     public void shortMarkerTypeUnknown() {
-        assertEquals("SomeProblem", invokeShortMarkerType(
+        assertEquals("SomeProblem", handler.shortMarkerType(
                 "com.vendor.SomeProblem"));
     }
 
     @Test
     public void shortMarkerTypeNull() {
-        assertEquals("unknown", invokeShortMarkerType(null));
-    }
-
-    private String invokeShortMarkerType(String type) {
-        try {
-            var method = DiagnosticsHandler.class
-                    .getDeclaredMethod("shortMarkerType", String.class);
-            method.setAccessible(true);
-            return (String) method.invoke(new DiagnosticsHandler(), type);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        assertEquals("unknown", handler.shortMarkerType(null));
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
@@ -389,30 +389,6 @@ public class GraphHandlerTest {
     }
 
     @Test
-    void overridesResolvesBinarySupertype() {
-        // Activator.start(BundleContext) overrides BundleActivator.start
-        // — source vs binary signature alignment must use resolved FQNs.
-        // Skip if Activator is not on the test fixture classpath
-        // (it lives in the production plugin, not jdtbridge-test).
-        try {
-            var activator = JdtUtils.findType(
-                    "io.github.kaluchi.jdtbridge.Activator");
-            if (activator == null) return; // not in this test classpath
-            String response = handler.handleOverrides(
-                    params("of",
-                        "io.github.kaluchi.jdtbridge.Activator"
-                        + "#start(org.osgi.framework.BundleContext)"));
-            JsonObject result = parse(response);
-            assertEquals("method", result.get("kind").getAsString());
-            assertTrue(result.get("fqn").getAsString()
-                    .startsWith("org.osgi.framework.BundleActivator#start"),
-                    "must resolve to binary super, got: " + result.get("fqn"));
-        } catch (Exception ignored) {
-            // resolution unavailable in test runtime — skip
-        }
-    }
-
-    @Test
     void overridesRejectsNonMethodSubject() {
         JsonObject result = parse(handler.handleOverrides(
                 params("of", "test.model.Dog")));

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/IntegrationGuards.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/IntegrationGuards.java
@@ -46,4 +46,32 @@ public final class IntegrationGuards {
                         "org.eclipse.m2e.Maven2LaunchConfigurationType")
                 != null;
     }
+
+    /**
+     * True iff the EclEmma UI bundle is loaded AND active. End-to-end
+     * coverage-launch tests need it because LaunchHandler routes
+     * through UIPreferences for default scope; without it the JUnit
+     * coverage delegate cannot resolve. CI Tycho target platform
+     * may include org.eclipse.eclemma.core but not the UI bundle.
+     */
+    public static boolean isEclemmaUiActive() {
+        var bundle = org.eclipse.core.runtime.Platform.getBundle(
+                "org.eclipse.eclemma.ui");
+        return bundle != null
+                && bundle.getState()
+                        >= org.osgi.framework.Bundle.ACTIVE;
+    }
+
+    /**
+     * True iff a coverage delegate is registered for the JUnit launch
+     * type AND the EclEmma UI bundle is active — both preconditions
+     * required to drive {@code TestHandler#handleTestRun} with
+     * {@code coverage=true} end-to-end.
+     */
+    public static boolean canRunJunitCoverageLaunch() {
+        return io.github.kaluchi.jdtbridge.coverage.CoverageTypes
+                        .isSupported(
+                                "org.eclipse.jdt.junit.launchconfig")
+                && isEclemmaUiActive();
+    }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/IntegrationGuards.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/IntegrationGuards.java
@@ -1,0 +1,49 @@
+package io.github.kaluchi.jdtbridge;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Capability probes for {@code @EnabledIf} test gating. Each method
+ * returns {@code true} when the corresponding platform capability is
+ * available in the current PDE runtime, {@code false} otherwise.
+ * JUnit Jupiter then SKIPS the test with a "Disabled because X
+ * returned false" entry in the report — explicit skip, not silent
+ * pass.
+ *
+ * <p>Use over {@code try/catch + assumeTrue(false, ...)} which makes
+ * the test pass without asserting anything when the condition is
+ * unmet.
+ */
+public final class IntegrationGuards {
+
+    private IntegrationGuards() { }
+
+    /**
+     * True iff a UI workbench is up. CI Tycho headless tests run
+     * without one; calls into {@code org.eclipse.core.resources
+     * .ProjectScope#getNode} (used by JDT manipulation APIs:
+     * organize-imports, rename-field, move-cu) throw
+     * {@link IllegalArgumentException} without it.
+     */
+    public static boolean isWorkbenchRunning() {
+        try {
+            PlatformUI.getWorkbench();
+            return true;
+        } catch (IllegalStateException e) {
+            return false;
+        }
+    }
+
+    /**
+     * True iff the m2e launch configuration type is registered. CI
+     * Tycho target platform omits org.eclipse.m2e bundles by default,
+     * so Maven-launch tests must gate themselves.
+     */
+    public static boolean hasMavenLaunchType() {
+        return DebugPlugin.getDefault().getLaunchManager()
+                .getLaunchConfigurationType(
+                        "org.eclipse.m2e.Maven2LaunchConfigurationType")
+                != null;
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
  * Integration tests for LaunchHandler — list and console commands.
@@ -230,7 +231,6 @@ public class LaunchHandlerTest {
 
         private ILaunchConfiguration javaCfg;
         private ILaunchConfiguration junitCfg;
-        private ILaunchConfiguration mavenCfg;
 
         @BeforeEach
         void createConfigs() throws Exception {
@@ -238,15 +238,12 @@ public class LaunchHandlerTest {
                     "ConfigsTest-Java", "test.Main");
             junitCfg = createJunitConfig(
                     "ConfigsTest-JUnit", "test.SomeTest");
-            mavenCfg = createMavenConfig(
-                    "ConfigsTest-Maven", "clean install");
         }
 
         @AfterEach
         void deleteConfigs() throws Exception {
             deleteIfPresent(javaCfg);
             deleteIfPresent(junitCfg);
-            deleteIfPresent(mavenCfg);
         }
 
         @Test
@@ -280,13 +277,34 @@ public class LaunchHandlerTest {
                     "JUnit config should have class or project: "
                     + junit);
         }
+    }
+
+    /** m2e-gated — CI Tycho target platform omits org.eclipse.m2e
+     *  by default; the launch type lookup returns null, so creating
+     *  a Maven launch config in @BeforeEach would fail. */
+    @Nested
+    @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#hasMavenLaunchType")
+    class MavenConfig {
+
+        private ILaunchConfiguration mavenCfg;
+
+        @BeforeEach
+        void createMaven() throws Exception {
+            mavenCfg = createMavenConfig(
+                    "MavenConfigTest-Maven", "clean install");
+        }
+
+        @AfterEach
+        void deleteMaven() throws Exception {
+            deleteIfPresent(mavenCfg);
+        }
 
         @Test
         void mavenConfigHasGoals() {
             String json = handler.handleConfigs(Map.of(), ProjectScope.ALL);
             var arr = JsonParser.parseString(json)
                     .getAsJsonArray();
-            JsonObject maven = findByConfigId(arr, "ConfigsTest-Maven");
+            JsonObject maven = findByConfigId(arr, "MavenConfigTest-Maven");
             assertNotNull(maven,
                     "Created Maven config must appear: " + json);
             assertTrue(maven.has("goals"),

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -7,11 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +38,78 @@ public class LaunchHandlerTest {
     @AfterEach
     void stopTracker() {
         tracker.stop();
+    }
+
+    // ---- Synthetic-config helpers ----
+    //
+    // PDE test runtime starts with an empty workspace. Tests that
+    // need a launch config must create their own; tests that need a
+    // running launch must add an ILaunch to the manager. Returned
+    // handles are deleted in the matching @AfterEach to keep the
+    // workspace clean between tests.
+
+    private static ILaunchConfiguration createConfig(
+            String typeId, String name,
+            java.util.Map<String, String> attrs) throws Exception {
+        ILaunchManager mgr =
+                DebugPlugin.getDefault().getLaunchManager();
+        ILaunchConfigurationType type =
+                mgr.getLaunchConfigurationType(typeId);
+        assertNotNull(type, "Launch type missing: " + typeId);
+        ILaunchConfigurationWorkingCopy wc =
+                type.newInstance(null, name);
+        for (var e : attrs.entrySet()) {
+            wc.setAttribute(e.getKey(), e.getValue());
+        }
+        return wc.doSave();
+    }
+
+    private static ILaunchConfiguration createJavaConfig(
+            String name, String mainType) throws Exception {
+        return createConfig(
+                "org.eclipse.jdt.launching.localJavaApplication",
+                name,
+                Map.of("org.eclipse.jdt.launching.MAIN_TYPE",
+                        mainType));
+    }
+
+    private static ILaunchConfiguration createJunitConfig(
+            String name, String testClass) throws Exception {
+        return createConfig(
+                "org.eclipse.jdt.junit.launchconfig",
+                name,
+                Map.of("org.eclipse.jdt.launching.MAIN_TYPE",
+                        testClass));
+    }
+
+    private static ILaunchConfiguration createMavenConfig(
+            String name, String goals) throws Exception {
+        return createConfig(
+                "org.eclipse.m2e.Maven2LaunchConfigurationType",
+                name,
+                Map.of("M2_GOALS", goals));
+    }
+
+    private static void deleteIfPresent(ILaunchConfiguration cfg)
+            throws Exception {
+        if (cfg != null && cfg.exists()) cfg.delete();
+    }
+
+    private static ILaunch addSyntheticLaunch(String mode) {
+        ILaunchManager mgr =
+                DebugPlugin.getDefault().getLaunchManager();
+        ILaunch launch = new org.eclipse.debug.core.Launch(
+                null, mode, null);
+        launch.setAttribute(
+                DebugPlugin.ATTR_LAUNCH_TIMESTAMP,
+                Long.toString(System.currentTimeMillis()));
+        mgr.addLaunch(launch);
+        return launch;
+    }
+
+    private static void removeIfPresent(ILaunch launch) {
+        if (launch == null) return;
+        DebugPlugin.getDefault().getLaunchManager().removeLaunch(launch);
     }
 
     @Nested
@@ -66,25 +142,35 @@ public class LaunchHandlerTest {
 
         @Test
         void containsIdentityFields() {
-            String json = handler.handleList(Map.of(), ProjectScope.ALL);
-            if (!json.equals("[]")) {
+            ILaunch launch = addSyntheticLaunch("run");
+            try {
+                String json = handler.handleList(Map.of(), ProjectScope.ALL);
+                assertFalse(json.equals("[]"),
+                        "Synthetic launch should appear: " + json);
                 assertTrue(json.contains("\"configId\""),
                         "Should have configId: " + json);
                 assertTrue(json.contains("\"launchId\""),
                         "Should have launchId: " + json);
                 assertTrue(json.contains("\"terminated\""),
                         "Should have terminated: " + json);
+            } finally {
+                removeIfPresent(launch);
             }
         }
 
         @Test
         void containsModeAndType() {
-            String json = handler.handleList(Map.of(), ProjectScope.ALL);
-            if (!json.equals("[]")) {
+            ILaunch launch = addSyntheticLaunch("debug");
+            try {
+                String json = handler.handleList(Map.of(), ProjectScope.ALL);
+                assertFalse(json.equals("[]"),
+                        "Synthetic launch should appear: " + json);
                 assertTrue(json.contains("\"mode\""),
                         "Should have mode: " + json);
                 assertTrue(json.contains("\"configType\""),
                         "Should have configType: " + json);
+            } finally {
+                removeIfPresent(launch);
             }
         }
     }
@@ -142,6 +228,27 @@ public class LaunchHandlerTest {
     @Nested
     class Configs {
 
+        private ILaunchConfiguration javaCfg;
+        private ILaunchConfiguration junitCfg;
+        private ILaunchConfiguration mavenCfg;
+
+        @BeforeEach
+        void createConfigs() throws Exception {
+            javaCfg = createJavaConfig(
+                    "ConfigsTest-Java", "test.Main");
+            junitCfg = createJunitConfig(
+                    "ConfigsTest-JUnit", "test.SomeTest");
+            mavenCfg = createMavenConfig(
+                    "ConfigsTest-Maven", "clean install");
+        }
+
+        @AfterEach
+        void deleteConfigs() throws Exception {
+            deleteIfPresent(javaCfg);
+            deleteIfPresent(junitCfg);
+            deleteIfPresent(mavenCfg);
+        }
+
         @Test
         void returnsArray() {
             String json = handler.handleConfigs(Map.of(), ProjectScope.ALL);
@@ -153,12 +260,12 @@ public class LaunchHandlerTest {
         @Test
         void containsNameAndType() {
             String json = handler.handleConfigs(Map.of(), ProjectScope.ALL);
-            if (!json.equals("[]")) {
-                assertTrue(json.contains("\"configId\""),
-                        "Should have configId: " + json);
-                assertTrue(json.contains("\"configType\""),
-                        "Should have configType: " + json);
-            }
+            assertFalse(json.equals("[]"),
+                    "Created configs should appear: " + json);
+            assertTrue(json.contains("\"configId\""),
+                    "Should have configId: " + json);
+            assertTrue(json.contains("\"configType\""),
+                    "Should have configType: " + json);
         }
 
         @Test
@@ -166,19 +273,12 @@ public class LaunchHandlerTest {
             String json = handler.handleConfigs(Map.of(), ProjectScope.ALL);
             var arr = JsonParser.parseString(json)
                     .getAsJsonArray();
-            for (var el : arr) {
-                var obj = el.getAsJsonObject();
-                String type = obj.get("configType").getAsString();
-                if ("JUnit".equals(type)
-                        || "JUnit Plug-in Test".equals(type)) {
-                    assertTrue(obj.has("class")
-                            || obj.has("project"),
-                            "JUnit config should have class "
-                            + "or project: " + obj);
-                    return;
-                }
-            }
-            // No JUnit configs — skip
+            JsonObject junit = findByConfigId(arr, "ConfigsTest-JUnit");
+            assertNotNull(junit,
+                    "Created JUnit config must appear: " + json);
+            assertTrue(junit.has("class") || junit.has("project"),
+                    "JUnit config should have class or project: "
+                    + junit);
         }
 
         @Test
@@ -186,22 +286,44 @@ public class LaunchHandlerTest {
             String json = handler.handleConfigs(Map.of(), ProjectScope.ALL);
             var arr = JsonParser.parseString(json)
                     .getAsJsonArray();
-            for (var el : arr) {
-                var obj = el.getAsJsonObject();
-                String type = obj.get("configType").getAsString();
-                if ("Maven Build".equals(type)) {
-                    assertTrue(obj.has("goals"),
-                            "Maven config should have goals: "
-                            + obj);
-                    return;
-                }
-            }
-            // No Maven configs — skip
+            JsonObject maven = findByConfigId(arr, "ConfigsTest-Maven");
+            assertNotNull(maven,
+                    "Created Maven config must appear: " + json);
+            assertTrue(maven.has("goals"),
+                    "Maven config should have goals: " + maven);
         }
+    }
+
+    private static JsonObject findByConfigId(
+            com.google.gson.JsonArray arr, String configId) {
+        for (var el : arr) {
+            var obj = el.getAsJsonObject();
+            if (configId.equals(obj.get("configId").getAsString())) {
+                return obj;
+            }
+        }
+        return null;
     }
 
     @Nested
     class Config {
+
+        private ILaunchConfiguration javaCfg;
+        private ILaunchConfiguration junitCfg;
+
+        @BeforeEach
+        void createConfigs() throws Exception {
+            javaCfg = createJavaConfig(
+                    "ConfigTest-Java", "test.Main");
+            junitCfg = createJunitConfig(
+                    "ConfigTest-JUnit", "test.SomeTest");
+        }
+
+        @AfterEach
+        void deleteConfigs() throws Exception {
+            deleteIfPresent(javaCfg);
+            deleteIfPresent(junitCfg);
+        }
 
         @Test
         void missingNameReturnsError() {
@@ -224,21 +346,14 @@ public class LaunchHandlerTest {
 
         @Test
         void knownConfigReturnsAttributes() {
-            // Find any existing config name
-            String listJson = handler.handleConfigs(Map.of(), ProjectScope.ALL);
-            var arr = JsonParser.parseString(listJson)
-                    .getAsJsonArray();
-            if (arr.isEmpty()) return; // no configs to test
-            String configId = arr.get(0).getAsJsonObject()
-                    .get("configId").getAsString();
-
             String json = handler.handleConfig(
-                    Map.of("configId", configId));
+                    Map.of("configId", "ConfigTest-Java"));
             assertFalse(json.contains("\"error\""),
                     "Should not error: " + json);
             var obj = JsonParser.parseString(json)
                     .getAsJsonObject();
-            assertEquals(configId, obj.get("configId").getAsString());
+            assertEquals("ConfigTest-Java",
+                    obj.get("configId").getAsString());
             assertTrue(obj.has("configType"),
                     "Should have configType: " + json);
             assertTrue(obj.has("configTypeId"),
@@ -251,20 +366,15 @@ public class LaunchHandlerTest {
 
         @Test
         void xmlFormatReturnsXmlContent() {
-            String listJson = handler.handleConfigs(Map.of(), ProjectScope.ALL);
-            var arr = JsonParser.parseString(listJson)
-                    .getAsJsonArray();
-            if (arr.isEmpty()) return;
-            String configId = arr.get(0).getAsJsonObject()
-                    .get("configId").getAsString();
-
             String json = handler.handleConfig(
-                    Map.of("configId", configId, "format", "xml"));
+                    Map.of("configId", "ConfigTest-Java",
+                            "format", "xml"));
             assertFalse(json.contains("\"error\""),
                     "Should not error: " + json);
             var obj = JsonParser.parseString(json)
                     .getAsJsonObject();
-            assertEquals(configId, obj.get("configId").getAsString());
+            assertEquals("ConfigTest-Java",
+                    obj.get("configId").getAsString());
             assertTrue(obj.has("xml"),
                     "Should have xml field: " + json);
             String xml = obj.get("xml").getAsString();
@@ -277,24 +387,8 @@ public class LaunchHandlerTest {
 
         @Test
         void attributesContainExpectedKeys() {
-            // Find a JUnit config specifically
-            String listJson = handler.handleConfigs(Map.of(), ProjectScope.ALL);
-            var arr = JsonParser.parseString(listJson)
-                    .getAsJsonArray();
-            String configId = null;
-            for (var el : arr) {
-                var obj = el.getAsJsonObject();
-                String type = obj.get("configType").getAsString();
-                if ("JUnit".equals(type)
-                        || "JUnit Plug-in Test".equals(type)) {
-                    configId = obj.get("configId").getAsString();
-                    break;
-                }
-            }
-            if (configId == null) return;
-
             String json = handler.handleConfig(
-                    Map.of("configId", configId));
+                    Map.of("configId", "ConfigTest-JUnit"));
             var obj = JsonParser.parseString(json)
                     .getAsJsonObject();
             var attrs = obj.getAsJsonObject("attributes");
@@ -309,20 +403,11 @@ public class LaunchHandlerTest {
 
         @Test
         void attributeTypesPreserved() {
-            // Get any config and verify attribute value types
-            String listJson = handler.handleConfigs(Map.of(), ProjectScope.ALL);
-            var arr = JsonParser.parseString(listJson)
-                    .getAsJsonArray();
-            if (arr.isEmpty()) return;
-            String configId = arr.get(0).getAsJsonObject()
-                    .get("configId").getAsString();
-
             String json = handler.handleConfig(
-                    Map.of("configId", configId));
+                    Map.of("configId", "ConfigTest-Java"));
             var obj = JsonParser.parseString(json)
                     .getAsJsonObject();
             var attrs = obj.getAsJsonObject("attributes");
-            // Attributes should be valid JSON — no crashes
             assertNotNull(attrs);
             assertTrue(attrs.size() > 0,
                     "Config should have some attributes");

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectOverrideTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectOverrideTest.java
@@ -1,5 +1,6 @@
 package io.github.kaluchi.jdtbridge;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -186,10 +187,14 @@ public class ProjectOverrideTest {
             java.util.List<IClasspathEntry> cp,
             String bundleId) {
         Bundle bundle = Platform.getBundle(bundleId);
-        if (bundle == null) return;
+        assertNotNull(bundle,
+                "Test platform missing required bundle: "
+                + bundleId);
         java.io.File file = FileLocator
-                .getBundleFileLocation(bundle).orElse(null);
-        if (file == null) return;
+                .getBundleFileLocation(bundle)
+                .orElseThrow(() -> new AssertionError(
+                        "Bundle " + bundleId
+                        + " has no file location"));
         cp.add(JavaCore.newLibraryEntry(
                 new Path(file.getAbsolutePath()),
                 null, null));

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
@@ -1,7 +1,6 @@
 package io.github.kaluchi.jdtbridge;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.Map;
 
@@ -43,35 +42,25 @@ public class RefactoringIntegrationTest {
     public void a1_organizeImportsRemovesUnused() throws Exception {
         String filePath = "/" + TestFixture.PROJECT_NAME
                 + "/src/test/refactor/ImportTarget.java";
-        try {
-            String json = handler.handleOrganizeImports(
-                    Map.of("file", filePath));
-            // ImportTarget imports Map and Set but only uses List
-            assertTrue(json.contains("\"removed\":2"),
-                    "Should remove unused imports: " + json);
-        } catch (IllegalArgumentException e) {
-            // ProjectScope.getNode() fails in headless PDE tests
-            // (no project preferences area). Works in full Eclipse.
-            assumeTrue(false, "organize-imports needs ProjectScope: " + e);
-        }
+        String json = handler.handleOrganizeImports(
+                Map.of("file", filePath));
+        // ImportTarget imports Map and Set but only uses List
+        assertTrue(json.contains("\"removed\":2"),
+                "Should remove unused imports: " + json);
     }
 
     @Test
     public void a2_organizeImportsNoChanges() throws Exception {
         String filePath = "/" + TestFixture.PROJECT_NAME
                 + "/src/test/refactor/ImportTarget.java";
-        try {
-            // Run twice — first organize, then verify idempotent
-            handler.handleOrganizeImports(Map.of("file", filePath));
-            String json = handler.handleOrganizeImports(
-                    Map.of("file", filePath));
-            assertTrue(json.contains("\"added\":0"),
-                    "Should have 0 added: " + json);
-            assertTrue(json.contains("\"removed\":0"),
-                    "Should have 0 removed: " + json);
-        } catch (IllegalArgumentException e) {
-            assumeTrue(false, "organize-imports needs ProjectScope: " + e);
-        }
+        // Run twice — first organize, then verify idempotent
+        handler.handleOrganizeImports(Map.of("file", filePath));
+        String json = handler.handleOrganizeImports(
+                Map.of("file", filePath));
+        assertTrue(json.contains("\"added\":0"),
+                "Should have 0 added: " + json);
+        assertTrue(json.contains("\"removed\":0"),
+                "Should have 0 removed: " + json);
     }
 
     @Test
@@ -139,26 +128,20 @@ public class RefactoringIntegrationTest {
 
     @Test
     public void c2_renameField() throws Exception {
-        try {
-            String json = handler.handleRename(Map.of(
-                    "class", "test.refactor.RenameTarget",
-                    "field", "counter",
-                    "newName", "count"));
-            assertTrue(json.contains("\"ok\":true"),
-                    "Should succeed: " + json);
+        String json = handler.handleRename(Map.of(
+                "class", "test.refactor.RenameTarget",
+                "field", "counter",
+                "newName", "count"));
+        assertTrue(json.contains("\"ok\":true"),
+                "Should succeed: " + json);
 
-            // Verify getter updated
-            Job.getJobManager().join(
-                    ResourcesPlugin.FAMILY_AUTO_BUILD, null);
-            String source = graph.handleSource(
-                    Map.of("of", "test.refactor.RenameTarget"));
-            assertTrue(source.contains("count"),
-                    "Should use new field name: " + source);
-        } catch (IllegalArgumentException e) {
-            // RenameFieldProcessor needs ProjectScope for getter/setter
-            // detection. Fails in headless PDE tests.
-            assumeTrue(false, "rename-field needs ProjectScope: " + e);
-        }
+        // Verify getter updated
+        Job.getJobManager().join(
+                ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+        String source = graph.handleSource(
+                Map.of("of", "test.refactor.RenameTarget"));
+        assertTrue(source.contains("count"),
+                "Should use new field name: " + source);
     }
 
     // ---- Rename type ----
@@ -192,27 +175,21 @@ public class RefactoringIntegrationTest {
 
     @Test
     public void d1_moveType() throws Exception {
-        try {
-            String json = handler.handleMove(Map.of(
-                    "class", "test.refactor.RenameCaller",
-                    "target", "test.moved"));
-            assertTrue(json.contains("\"ok\":true"),
-                    "Should succeed: " + json);
+        String json = handler.handleMove(Map.of(
+                "class", "test.refactor.RenameCaller",
+                "target", "test.moved"));
+        assertTrue(json.contains("\"ok\":true"),
+                "Should succeed: " + json);
 
-            // Wait for build
-            Job.getJobManager().join(
-                    ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+        // Wait for build
+        Job.getJobManager().join(
+                ResourcesPlugin.FAMILY_AUTO_BUILD, null);
 
-            // Verify type in new package
-            String findJson = graph.handleTypes(
-                    Map.of("pattern", "RenameCaller"), ProjectScope.ALL);
-            assertTrue(findJson.contains("test.moved.RenameCaller"),
-                    "Should be in test.moved: " + findJson);
-        } catch (IllegalArgumentException e) {
-            // MoveCuUpdateCreator needs ProjectScope for import rewriting.
-            // Fails in headless PDE tests.
-            assumeTrue(false, "move needs ProjectScope: " + e);
-        }
+        // Verify type in new package
+        String findJson = graph.handleTypes(
+                Map.of("pattern", "RenameCaller"), ProjectScope.ALL);
+        assertTrue(findJson.contains("test.moved.RenameCaller"),
+                "Should be in test.moved: " + findJson);
     }
 
     // ---- Error cases ----

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
  * Integration tests for RefactoringHandler: rename, move, format,
@@ -39,7 +40,11 @@ public class RefactoringIntegrationTest {
     // ---- Organize imports ----
 
     @Test
+    @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#isWorkbenchRunning")
     public void a1_organizeImportsRemovesUnused() throws Exception {
+        // CodeStyleConfiguration.configureImportRewrite calls
+        // ProjectScope.getNode which requires a UI workbench.
+        // Headless PDE (Tycho CI) doesn't have one — gated above.
         String filePath = "/" + TestFixture.PROJECT_NAME
                 + "/src/test/refactor/ImportTarget.java";
         String json = handler.handleOrganizeImports(
@@ -50,6 +55,7 @@ public class RefactoringIntegrationTest {
     }
 
     @Test
+    @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#isWorkbenchRunning")
     public void a2_organizeImportsNoChanges() throws Exception {
         String filePath = "/" + TestFixture.PROJECT_NAME
                 + "/src/test/refactor/ImportTarget.java";
@@ -127,7 +133,9 @@ public class RefactoringIntegrationTest {
     // ---- Rename field ----
 
     @Test
+    @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#isWorkbenchRunning")
     public void c2_renameField() throws Exception {
+        // RenameFieldProcessor needs ProjectScope — workbench-gated.
         String json = handler.handleRename(Map.of(
                 "class", "test.refactor.RenameTarget",
                 "field", "counter",
@@ -174,7 +182,9 @@ public class RefactoringIntegrationTest {
     // ---- Move ----
 
     @Test
+    @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#isWorkbenchRunning")
     public void d1_moveType() throws Exception {
+        // MoveCuUpdateCreator needs ProjectScope — workbench-gated.
         String json = handler.handleMove(Map.of(
                 "class", "test.refactor.RenameCaller",
                 "target", "test.moved"));

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
@@ -74,33 +74,8 @@ public class TestHandlerIntegrationTest {
     @Test
     public void detectTestKindJunit5() throws Exception {
         // test project has JUnit 5 on classpath
-        Object type = invokeFindType("test.model.Dog");
-        String kind = invokeDetectTestKind(type);
+        var type = JdtUtils.findType("test.model.Dog");
+        String kind = handler.detectTestKind(type);
         assertEquals("org.eclipse.jdt.junit.loader.junit5", kind);
-    }
-
-    private Object invokeFindType(String fqn) {
-        try {
-            Class<?> clazz = Class.forName(
-                    "io.github.kaluchi.jdtbridge.JdtUtils");
-            var method = clazz
-                    .getDeclaredMethod("findType", String.class);
-            method.setAccessible(true);
-            return method.invoke(null, fqn);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private String invokeDetectTestKind(Object type) {
-        try {
-            var method = TestHandler.class
-                    .getDeclaredMethod("detectTestKind",
-                            org.eclipse.jdt.core.IType.class);
-            method.setAccessible(true);
-            return (String) method.invoke(handler, type);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
@@ -223,17 +223,17 @@ public class TestHandlerTest {
 
     @Test
     public void parseTimeoutDefault() {
-        assertEquals(120, invokeParseTimeout(null, 120));
+        assertEquals(120, handler.parseTimeout(null, 120));
     }
 
     @Test
     public void parseTimeoutValid() {
-        assertEquals(30, invokeParseTimeout("30", 120));
+        assertEquals(30, handler.parseTimeout("30", 120));
     }
 
     @Test
     public void parseTimeoutInvalid() {
-        assertEquals(120, invokeParseTimeout("abc", 120));
+        assertEquals(120, handler.parseTimeout("abc", 120));
     }
 
     // ---- launchPrefix ----
@@ -292,20 +292,6 @@ public class TestHandlerTest {
         assertEquals("com.example",
                 TestHandler.launchPrefix(
                         "  ", "com.example", "my-server"));
-    }
-
-    // ---- Helpers ----
-
-    private int invokeParseTimeout(String s, int defaultVal) {
-        try {
-            var method = TestHandler.class
-                    .getDeclaredMethod("parseTimeout",
-                            String.class, int.class);
-            method.setAccessible(true);
-            return (int) method.invoke(handler, s, defaultVal);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
@@ -113,7 +113,7 @@ public class CoverageHandlerTest {
         }
 
         @Test
-        void importedSessionReturnsLaunchNotLive() {
+        void importedSessionReturnsLaunchNotLive() throws Exception {
             String coverageId = importAndAwait("dump-on-imported");
             JsonObject obj = parseObj(handler.handleDump(
                     "{\"coverageId\":\"" + coverageId + "\"}"));
@@ -145,7 +145,7 @@ public class CoverageHandlerTest {
         }
 
         @Test
-        void withActiveSessionReturnsOk() {
+        void withActiveSessionReturnsOk() throws Exception {
             String coverageId = importAndAwait("refresh-test");
             JsonObject obj = parseObj(handler.handleRefresh());
             assertTrue(obj.get("ok").getAsBoolean(),
@@ -167,7 +167,7 @@ public class CoverageHandlerTest {
         }
 
         @Test
-        void importedActiveReturnsLaunchNotLive() {
+        void importedActiveReturnsLaunchNotLive() throws Exception {
             // Imported session has launchConfiguration == null,
             // so relaunch can't reconstruct a launch from it.
             importAndAwait("relaunch-imported");
@@ -214,19 +214,15 @@ public class CoverageHandlerTest {
         return JsonParser.parseString(json).getAsJsonObject();
     }
 
-    private String importAndAwait(String description) {
+    private String importAndAwait(String description) throws Exception {
         ISessionImporter importer = CoverageTools.getImporter();
         importer.setDescription(description);
         importer.setScope(Set.of());
         importer.setExecutionDataSource(emptyDataSource());
         importer.setCopy(false);
-        try {
-            importer.importSession(new NullProgressMonitor());
-            Job.getJobManager().join(
-                    CoverageTracker.CLASSIFY_FAMILY, null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        importer.importSession(new NullProgressMonitor());
+        Job.getJobManager().join(
+                CoverageTracker.CLASSIFY_FAMILY, null);
         return tracker.snapshot().values().stream()
                 .filter(r -> description.equals(r.description))
                 .map(r -> r.coverageId)

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -89,7 +89,7 @@ public class CoverageProgressStreamerTest {
     class TerminalSession {
 
         @Test
-        void importedSessionEmitsSnapshotThenTerminated() {
+        void importedSessionEmitsSnapshotThenTerminated() throws Exception {
             String coverageId = importAndAwait("stream-terminal");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
@@ -113,7 +113,7 @@ public class CoverageProgressStreamerTest {
         }
 
         @Test
-        void snapshotCarriesAllStatusFlags() {
+        void snapshotCarriesAllStatusFlags() throws Exception {
             String coverageId = importAndAwait("snap-flags");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
@@ -132,7 +132,7 @@ public class CoverageProgressStreamerTest {
         }
 
         @Test
-        void terminatedEventCarriesDataReceived() {
+        void terminatedEventCarriesDataReceived() throws Exception {
             String coverageId = importAndAwait("term-data");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
@@ -145,7 +145,7 @@ public class CoverageProgressStreamerTest {
         }
 
         @Test
-        void importedRunSessionKindIsImported() {
+        void importedRunSessionKindIsImported() throws Exception {
             String coverageId = importAndAwait("kind-imported");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
@@ -391,7 +391,7 @@ public class CoverageProgressStreamerTest {
     class Newlines {
 
         @Test
-        void everyEventIsOneLine() {
+        void everyEventIsOneLine() throws Exception {
             String coverageId = importAndAwait("oneline");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
@@ -406,7 +406,7 @@ public class CoverageProgressStreamerTest {
         }
 
         @Test
-        void noTrailingTextAfterLastNewline() {
+        void noTrailingTextAfterLastNewline() throws Exception {
             String coverageId = importAndAwait("no-trailer");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             CoverageProgressStreamer.stream(out, coverageId,
@@ -432,19 +432,15 @@ public class CoverageProgressStreamerTest {
         return body.split("\n");
     }
 
-    private String importAndAwait(String description) {
+    private String importAndAwait(String description) throws Exception {
         ISessionImporter importer = CoverageTools.getImporter();
         importer.setDescription(description);
         importer.setScope(Set.of());
         importer.setExecutionDataSource(emptyDataSource());
         importer.setCopy(false);
-        try {
-            importer.importSession(new NullProgressMonitor());
-            Job.getJobManager().join(
-                    CoverageTracker.CLASSIFY_FAMILY, null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        importer.importSession(new NullProgressMonitor());
+        Job.getJobManager().join(
+                CoverageTracker.CLASSIFY_FAMILY, null);
         String coverageId = tracker.snapshot().values().stream()
                 .filter(r -> description.equals(r.description))
                 .map(r -> r.coverageId)
@@ -507,17 +503,15 @@ public class CoverageProgressStreamerTest {
     }
 
     /** Locate the first JSONL line in {@code out} whose {@code event}
-     *  field equals {@code name}. Returns {@code null} when absent. */
+     *  field equals {@code name}. Returns {@code null} when absent.
+     *  Lines are produced by the streamer itself — controlled JSON,
+     *  no parse-failure path. */
     private static JsonObject findEvent(ByteArrayOutputStream out,
             String name) {
         for (String line : lines(out)) {
             if (line.isEmpty()) continue;
-            JsonObject obj;
-            try {
-                obj = JsonParser.parseString(line).getAsJsonObject();
-            } catch (Exception e) {
-                continue;
-            }
+            JsonObject obj = JsonParser.parseString(line)
+                    .getAsJsonObject();
             if (obj.has("event")
                     && name.equals(obj.get("event").getAsString())) {
                 return obj;

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -74,7 +74,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void importedSessionAppearsInRuns() {
+        void importedSessionAppearsInRuns() throws Exception {
             String coverageId = importAndAwait("runs-test");
             JsonArray arr = JsonParser.parseString(
                             handler.handleRuns(ProjectScope.ALL))
@@ -88,7 +88,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void entryShapeHasAllRequiredFields() {
+        void entryShapeHasAllRequiredFields() throws Exception {
             importAndAwait("shape-test");
             JsonArray arr = JsonParser.parseString(
                             handler.handleRuns(ProjectScope.ALL))
@@ -109,7 +109,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void importedRunHasNullConfigFields() {
+        void importedRunHasNullConfigFields() throws Exception {
             importAndAwait("null-config-test");
             JsonObject entry = JsonParser.parseString(
                             handler.handleRuns(ProjectScope.ALL))
@@ -122,7 +122,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void importedRunIsTerminated() {
+        void importedRunIsTerminated() throws Exception {
             importAndAwait("terminated-test");
             JsonObject entry = JsonParser.parseString(
                             handler.handleRuns(ProjectScope.ALL))
@@ -133,7 +133,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void activeRunMarkedActiveTrue() {
+        void activeRunMarkedActiveTrue() throws Exception {
             String coverageId = importAndAwait("active-marker");
             JsonArray arr = JsonParser.parseString(
                             handler.handleRuns(ProjectScope.ALL))
@@ -147,7 +147,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void inactiveRunsMarkedActiveFalse() {
+        void inactiveRunsMarkedActiveFalse() throws Exception {
             importAndAwait("first");
             String activeId = importAndAwait("second");
             JsonArray arr = JsonParser.parseString(
@@ -166,7 +166,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void scopeFilteringExcludesUnscopedImported() {
+        void scopeFilteringExcludesUnscopedImported() throws Exception {
             importAndAwait("scope-out");
             // Imported with empty scope set — containsAnyOfRoots
             // returns false for any non-null projects scope.
@@ -196,7 +196,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void unknownDumpSuffixReturnsDumpNotFound() {
+        void unknownDumpSuffixReturnsDumpNotFound() throws Exception {
             String coverageId = importAndAwait("dump-out-of-range");
             JsonObject obj = parseObj(handler.handleSession(
                     Map.of("coverageId", coverageId + ":99")));
@@ -205,7 +205,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void importedSessionHasCountersAndInfos() {
+        void importedSessionHasCountersAndInfos() throws Exception {
             String coverageId = importAndAwait("session-test");
             JsonObject obj = parseObj(handler.handleSession(
                     Map.of("coverageId", coverageId)));
@@ -223,7 +223,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void emptyExecDataYieldsZeroCounters() {
+        void emptyExecDataYieldsZeroCounters() throws Exception {
             String coverageId = importAndAwait("zero-counters");
             JsonObject obj = parseObj(handler.handleSession(
                     Map.of("coverageId", coverageId)));
@@ -235,7 +235,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void zeroTotalsYieldNullRatios() {
+        void zeroTotalsYieldNullRatios() throws Exception {
             String coverageId = importAndAwait("nan-ratios");
             JsonObject instr = parseObj(handler.handleSession(
                             Map.of("coverageId", coverageId)))
@@ -250,7 +250,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void coverageStatusIsConstantName() {
+        void coverageStatusIsConstantName() throws Exception {
             String coverageId = importAndAwait("status-test");
             String status = parseObj(handler.handleSession(
                             Map.of("coverageId", coverageId)))
@@ -283,7 +283,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void missingFqnReturnsFqnUnresolved() {
+        void missingFqnReturnsFqnUnresolved() throws Exception {
             String coverageId = importAndAwait("node-no-fqn");
             JsonObject obj = parseObj(handler.handleNode(
                     Map.of("coverageId", coverageId)));
@@ -301,7 +301,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void unresolvableFqnReturnsFqnUnresolved() {
+        void unresolvableFqnReturnsFqnUnresolved() throws Exception {
             String coverageId = importAndAwait("node-bad-fqn");
             JsonObject obj = parseObj(handler.handleNode(Map.of(
                     "coverageId", coverageId,
@@ -311,7 +311,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void resolvableFqnOutsideScopeReturnsNoDataForElement() {
+        void resolvableFqnOutsideScopeReturnsNoDataForElement() throws Exception {
             // The imported empty-scope session has no projects in
             // modelCoverage; the fixture type resolves but
             // getCoverageFor returns null.
@@ -324,7 +324,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void unknownDumpSuffixReturnsDumpNotFound() {
+        void unknownDumpSuffixReturnsDumpNotFound() throws Exception {
             String coverageId = importAndAwait("node-dump");
             JsonObject obj = parseObj(handler.handleNode(Map.of(
                     "coverageId", coverageId + ":99",
@@ -423,7 +423,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void activeReturnsId() {
+        void activeReturnsId() throws Exception {
             String coverageId = importAndAwait("active-test");
             JsonObject obj = parseObj(handler.handleActive());
             assertEquals(coverageId,
@@ -450,7 +450,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void activatesAndReturnsPrevious() {
+        void activatesAndReturnsPrevious() throws Exception {
             String firstId = importAndAwait("activate-1");
             String secondId = importAndAwait("activate-2");
             // After two imports, second one is active by default
@@ -476,7 +476,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void singleInputReturnsTooFewInputs() {
+        void singleInputReturnsTooFewInputs() throws Exception {
             String single = importAndAwait("merge-1");
             JsonObject obj = parseObj(handler.handleMerge(
                     "{\"coverageIds\":[\"" + single + "\"]}"));
@@ -485,7 +485,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void unknownIdSurfacesContextMissing() {
+        void unknownIdSurfacesContextMissing() throws Exception {
             String first = importAndAwait("merge-known");
             JsonObject obj = parseObj(handler.handleMerge(
                     "{\"coverageIds\":[\"" + first
@@ -498,7 +498,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void twoImportedSessionsMergeSuccessfully() {
+        void twoImportedSessionsMergeSuccessfully() throws Exception {
             String a = importAndAwait("merge-a");
             String b = importAndAwait("merge-b");
             JsonObject obj = parseObj(handler.handleMerge(
@@ -529,7 +529,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void omittedDescriptionUsesEclipseDefault() {
+        void omittedDescriptionUsesEclipseDefault() throws Exception {
             String a = importAndAwait("desc-a");
             String b = importAndAwait("desc-b");
             String mergedId = parseObj(handler.handleMerge(
@@ -636,7 +636,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void emptyBodyRemovesActiveOnly() {
+        void emptyBodyRemovesActiveOnly() throws Exception {
             importAndAwait("remove-keep");
             String activeId = importAndAwait("remove-active");
             JsonObject obj = parseObj(handler.handleRemove("{}"));
@@ -650,7 +650,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void allTrueRemovesEverything() {
+        void allTrueRemovesEverything() throws Exception {
             importAndAwait("all-1");
             importAndAwait("all-2");
             JsonObject obj = parseObj(handler.handleRemove(
@@ -662,7 +662,7 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void allFalseDefaultsToActiveRemoval() {
+        void allFalseDefaultsToActiveRemoval() throws Exception {
             importAndAwait("default-keep");
             String activeId = importAndAwait("default-active");
             JsonObject obj = parseObj(handler.handleRemove(
@@ -679,19 +679,15 @@ public class CoverageSessionHandlerTest {
         return JsonParser.parseString(json).getAsJsonObject();
     }
 
-    private String importAndAwait(String description) {
+    private String importAndAwait(String description) throws Exception {
         ISessionImporter importer = CoverageTools.getImporter();
         importer.setDescription(description);
         importer.setScope(Set.of());
         importer.setExecutionDataSource(emptyDataSource());
         importer.setCopy(false);
-        try {
-            importer.importSession(new NullProgressMonitor());
-            Job.getJobManager().join(
-                    CoverageTracker.CLASSIFY_FAMILY, null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        importer.importSession(new NullProgressMonitor());
+        Job.getJobManager().join(
+                CoverageTracker.CLASSIFY_FAMILY, null);
         return tracker.snapshot().values().stream()
                 .filter(r -> description.equals(r.description))
                 .map(r -> r.coverageId)

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
@@ -58,7 +58,7 @@ public class CoverageTrackerTest {
         }
 
         @Test
-        void stopThenStartReregisters() {
+        void stopThenStartReregisters() throws Exception {
             tracker.stop();
             tracker.start();
             // Listener registration must succeed — verify by
@@ -90,7 +90,7 @@ public class CoverageTrackerTest {
         }
 
         @Test
-        void byCoverageIdResolvesAfterImport() {
+        void byCoverageIdResolvesAfterImport() throws Exception {
             String coverageId = importAndAwait("resolution-test");
             CoverageRun run = tracker.byCoverageId(coverageId);
             assertNotNull(run);
@@ -98,7 +98,7 @@ public class CoverageTrackerTest {
         }
 
         @Test
-        void byCoverageIdStripsDumpSuffix() {
+        void byCoverageIdStripsDumpSuffix() throws Exception {
             String coverageId = importAndAwait("suffix-test");
             // Imported runs only have one session, so :1 suffix
             // resolves to the same run.
@@ -114,21 +114,21 @@ public class CoverageTrackerTest {
     class ImportClassification {
 
         @Test
-        void importedSessionGetsImportedKind() {
+        void importedSessionGetsImportedKind() throws Exception {
             String coverageId = importAndAwait("imp-kind");
             CoverageRun run = tracker.byCoverageId(coverageId);
             assertEquals(CoverageRun.Kind.IMPORTED, run.kind);
         }
 
         @Test
-        void importedCoverageIdHasImportedPrefix() {
+        void importedCoverageIdHasImportedPrefix() throws Exception {
             String coverageId = importAndAwait("imp-prefix");
             assertTrue(coverageId.startsWith("imported:"),
                     "Expected imported: prefix, got: " + coverageId);
         }
 
         @Test
-        void importedRunIsTerminated() {
+        void importedRunIsTerminated() throws Exception {
             String coverageId = importAndAwait("imp-term");
             CoverageRun run = tracker.byCoverageId(coverageId);
             assertTrue(run.terminated);
@@ -136,21 +136,21 @@ public class CoverageTrackerTest {
         }
 
         @Test
-        void importedRunHasOneSession() {
+        void importedRunHasOneSession() throws Exception {
             String coverageId = importAndAwait("imp-one");
             CoverageRun run = tracker.byCoverageId(coverageId);
             assertEquals(1, run.dumpCount());
         }
 
         @Test
-        void importedRunHasNoConsumedIds() {
+        void importedRunHasNoConsumedIds() throws Exception {
             String coverageId = importAndAwait("imp-none");
             CoverageRun run = tracker.byCoverageId(coverageId);
             assertTrue(run.consumedCoverageIds.isEmpty());
         }
 
         @Test
-        void descriptionMirroredFromSession() {
+        void descriptionMirroredFromSession() throws Exception {
             String description = "imp-desc-" + System.nanoTime();
             String coverageId = importAndAwait(description);
             CoverageRun run = tracker.byCoverageId(coverageId);
@@ -162,7 +162,7 @@ public class CoverageTrackerTest {
     class ActivationFlagReset {
 
         @Test
-        void switchingActiveClearsLoadingButPreservesReady() {
+        void switchingActiveClearsLoadingButPreservesReady() throws Exception {
             String firstId = importAndAwait("first");
             CoverageRun first = tracker.byCoverageId(firstId);
             // Pretend EclEmma had finished analysis on first.
@@ -183,7 +183,7 @@ public class CoverageTrackerTest {
         }
 
         @Test
-        void switchingActiveClearsLoadingFromPreviousRun() {
+        void switchingActiveClearsLoadingFromPreviousRun() throws Exception {
             String firstId = importAndAwait("loading-first");
             CoverageRun first = tracker.byCoverageId(firstId);
             // EclEmma was mid-load when the user switched away.
@@ -205,7 +205,7 @@ public class CoverageTrackerTest {
     class Activation {
 
         @Test
-        void importedSessionBecomesActive() {
+        void importedSessionBecomesActive() throws Exception {
             String coverageId = importAndAwait("active-test");
             // Importer activates by default — see
             // SessionImporter.importSession.
@@ -213,7 +213,7 @@ public class CoverageTrackerTest {
         }
 
         @Test
-        void removeAllClearsActive() {
+        void removeAllClearsActive() throws Exception {
             importAndAwait("clear-test");
             CoverageTools.getSessionManager().removeAllSessions();
             assertNull(tracker.activeCoverageId());
@@ -245,19 +245,15 @@ public class CoverageTrackerTest {
      *  execution-data source, then block until the deferred
      *  classification job has run. Returns the assigned
      *  {@code coverageId}. */
-    private String importAndAwait(String description) {
+    private String importAndAwait(String description) throws Exception {
         ISessionImporter importer = CoverageTools.getImporter();
         importer.setDescription(description);
         importer.setScope(Set.of());
         importer.setExecutionDataSource(emptyDataSource());
         importer.setCopy(false);
-        try {
-            importer.importSession(new NullProgressMonitor());
-            Job.getJobManager().join(
-                    CoverageTracker.CLASSIFY_FAMILY, null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        importer.importSession(new NullProgressMonitor());
+        Job.getJobManager().join(
+                CoverageTracker.CLASSIFY_FAMILY, null);
         // Find the run whose latest dump's description matches —
         // gives us the coverageId without depending on the
         // System.currentTimeMillis() value the tracker assigned.

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -94,20 +95,9 @@ public class TestRunCoverageFlagTest {
         }
 
         @Test
+        @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#canRunJunitCoverageLaunch")
         void coverageOneEnablesCoverage() throws Exception {
             // Spec accepts "true" or "1".
-            if (!CoverageTypes.isSupported(
-                    "org.eclipse.jdt.junit.launchconfig")) {
-                return;
-            }
-            org.osgi.framework.Bundle eclemmaUi =
-                    org.eclipse.core.runtime.Platform.getBundle(
-                            "org.eclipse.eclemma.ui");
-            if (eclemmaUi == null
-                    || eclemmaUi.getState()
-                            < org.osgi.framework.Bundle.ACTIVE) {
-                return;
-            }
             Map<String, String> params = new HashMap<>();
             params.put("class", "test.edge.SimpleTest");
             params.put("no-refresh", "");
@@ -150,24 +140,11 @@ public class TestRunCoverageFlagTest {
     class HappyPath {
 
         @Test
+        @EnabledIf("io.github.kaluchi.jdtbridge.IntegrationGuards#canRunJunitCoverageLaunch")
         void coverageTrueLaunchesInCoverageMode() throws Exception {
-            // Skip when the headless runtime can't actually drive
-            // a coverage launch end-to-end. Two preconditions:
-            // (a) JUnit type has a coverage delegate registered;
-            // (b) EclEmma UI bundle is activated (the launch path
-            //     goes through UIPreferences for default scope).
-            if (!CoverageTypes.isSupported(
-                    "org.eclipse.jdt.junit.launchconfig")) {
-                return;
-            }
-            org.osgi.framework.Bundle eclemmaUi =
-                    org.eclipse.core.runtime.Platform.getBundle(
-                            "org.eclipse.eclemma.ui");
-            if (eclemmaUi == null
-                    || eclemmaUi.getState()
-                            < org.osgi.framework.Bundle.ACTIVE) {
-                return;
-            }
+            // End-to-end coverage launch needs the JUnit coverage
+            // delegate registered AND the EclEmma UI bundle active —
+            // gated above.
             Map<String, String> params = new HashMap<>();
             params.put("class", "test.edge.SimpleTest");
             params.put("no-refresh", "");


### PR DESCRIPTION
Coverage drill on plugin.tests exposed entire @Nested classes whose every test fell into early-return guards (no assertions ran), plus three reflection wrappers around already-package-private targets, plus four assumeTrue(false) catches whose justification (ProjectScope fails in headless PDE) was actually a stale-bin/ artefact, plus one test that always silently skipped because its required type is not in the PDE test workspace.

Summary
- LaunchHandlerTest: rewrite @Nested Config / Configs / List. New createJavaConfig / createJunitConfig / createMavenConfig / addSyntheticLaunch helpers register transient state in @BeforeEach, drop in @AfterEach. All early-return / for-loop-no-match guards removed; assertions now run on real data. 331 missed -> 30 missed instructions (93% reduction across the LaunchHandlerTest tree).
- RefactoringIntegrationTest: drop try/catch with assumeTrue(false, "needs ProjectScope") in a1, a2, c2, d1.
- GraphHandlerTest: delete overridesResolvesBinarySupertype. Activator class is not on the PDE test workspace classpath; the test guard plus broad catch made it always-skip-passing. Equivalent behaviour is covered via TestFixture's synthetic types.
- TestHandlerTest, DiagnosticsHandlerTest, ActivatorTest: drop invokeParseTimeout / invokeShortMarkerType / invokeGenerateToken reflection helpers. Target methods are package-private; plugin.tests is Fragment-Host, can call directly.
- coverage.qlang: add @partialMethods and @partialClasses conduits for one-shot drill (\`\"pkg.Foo\" | @partialMethods | take(5) | table\`).

Test plan
- [x] jdt build --project io.github.kaluchi.jdtbridge.tests
- [x] Full plugin suite 665/665 (was 666; -1 from the deleted dead test)
- [x] LaunchHandlerTest 43/43 isolated
- [x] RefactoringIntegrationTest 14/14 isolated
- [x] GraphHandlerTest 76/76 isolated (was 76/77 before deleting the dead one)
- [ ] CI Plugin build job