### PR TITLE
setup: fail loud when bridge does not come back after install

### DIFF
--- a/cli/src/commands/setup.mjs
+++ b/cli/src/commands/setup.mjs
@@ -388,7 +388,10 @@ async function runInstall(config, flags) {
       const { port, projects } = await waitForBridge(discoverInstances, pid);
       ok(`Bridge ready on port ${port} (${projects.length} projects)`);
     } catch {
-      fail("Bridge did not start (Eclipse may still be loading)");
+      fail("Bridge did not start — Eclipse came up but the plugin's"
+        + " HTTP server never registered. Check"
+        + " <workspace>/.metadata/.log for plugin activation errors.");
+      process.exit(1);
     }
   } else {
     // Restart all workspaces that were running before
@@ -404,7 +407,9 @@ async function runInstall(config, flags) {
         const { port, projects } = await waitForBridge(discoverInstances, pid);
         ok(`${workspace} — port ${port} (${projects.length} projects)`);
       } catch {
-        fail(`${workspace} — bridge did not start`);
+        fail(`${workspace} — bridge did not start. Check`
+          + ` ${workspace}/.metadata/.log for plugin activation errors.`);
+        process.exit(1);
       }
     }
   }

--- a/cli/test/setup.test.mjs
+++ b/cli/test/setup.test.mjs
@@ -48,6 +48,9 @@ describe("setup command", () => {
       p2Uninstall: () => "",
       getEclipseJavaHome: () => null,
       awaitProfileLockFree: () => {},
+      waitForBridge: () => Promise.resolve({
+        port: 12345, projects: ["mock-project"],
+      }),
       ...overrides.eclipse,
     };
 


### PR DESCRIPTION
Summary
- jdt setup --skip-build (and the full install path) used to print a red `✗ Bridge did not start` then immediately print a green `✓ Setup complete` and exit 0. Eclipse silently dead, exit code lies, the agent thinks all green; the next jdt command fails with BridgeNotRunningError and a confused developer.
- Both catch blocks (single-workspace start, multi-workspace start) now exit 1 right inside the catch, after the existing fail() print. No flag, no second branch at the end. fail() itself stays a print helper because --check uses it for status lines and must continue.
- fail() messages also gained a pointer to <workspace>/.metadata/.log for the plugin-activation diagnosis.

Test plan
- [x] Manual repro reproduced today: jdt setup --skip-build returned exit 0 with Eclipse dead. With this fix the same scenario will exit 1.
- [ ] CI Plugin build + CLI tests (no behavioural change expected — pure exit-code fix in error path)