### PR TITLE
test run: server-side polymorphic target resolve via JdtUtils

### DIFF
--- a/cli/src/commands/test-run.mjs
+++ b/cli/src/commands/test-run.mjs
@@ -1,5 +1,5 @@
 import { get } from "../client.mjs";
-import { extractPositional, parseFlags, parseFqn } from "../args.mjs";
+import { extractPositional, parseFlags } from "../args.mjs";
 import { preflightCompileErrors } from "../preflight-compile-errors.mjs";
 import {
   formatTestRunHeader,
@@ -18,27 +18,19 @@ export async function testRun(args) {
   const pos = extractPositional(filtered);
   const flags = parseFlags(args);
 
-  let url = "/test/run?";
-  const parsed = parseFqn(pos[0]);
-  const fqn = parsed.className;
-
-  if (fqn) {
-    url += `class=${encodeURIComponent(fqn)}`;
-    const method = parsed.method;
-    if (method) url += `&method=${encodeURIComponent(method)}`;
-    if (flags.project)
-      url += `&project=${encodeURIComponent(flags.project)}`;
-  } else if (flags.project) {
-    url += `project=${encodeURIComponent(flags.project)}`;
-    if (flags.package)
-      url += `&package=${encodeURIComponent(flags.package)}`;
-  } else {
+  const target = pos[0];
+  if (!target) {
     console.error(
-      "Usage: test run <FQN>[#method] | test run --project <name> [--package <pkg>]",
-    );
+      "Usage: jdt test run <target> [--project <name>]"
+      + " [-f] [-q] [--json] [--coverage]"
+      + " [--no-refresh] [--ignore-compile-errors]");
     process.exit(1);
   }
 
+  let url = `/test/run?target=${encodeURIComponent(target)}`;
+  if (flags.project) {
+    url += `&project=${encodeURIComponent(flags.project)}`;
+  }
   if (args.includes("--no-refresh")) url += "&no-refresh";
   const coverage = args.includes("--coverage");
   if (coverage) url += "&coverage=true";
@@ -111,31 +103,44 @@ function sleep(ms) {
 
 export const help = `Launch tests non-blocking with real-time progress.
 
-Usage:  jdt test run <FQN>[#method] [--project <name>] [-f] [-q] [--json]
-        jdt test run --project <name> [--package <pkg>] [-f] [-q] [--json]
+Usage:  jdt test run <target> [--project <name>] [-f] [-q] [--json]
 
 Without -f, launches and prints a guide with available commands.
 With -f, launches and streams test progress until completion.
 
-When --project is used with <FQN>, the test class is resolved by name
-but launched using the specified project's classpath. This is useful when
-test sources live in one project but need dependencies from another.
+The target is one positional, polymorphically resolved by the bridge
+via JDT model lookup. Accepted shapes:
+
+  com.example.MyTest             test class (run all tests in class)
+  com.example.MyTest#testFoo     single test method
+  com.example.MyTest#testFoo(String)   method with overload signature
+  com.example                    package (run all tests in package)
+  my-project                     project name (run all tests in project)
+  /abs/path/to/Foo.java          file (run tests in file's primary type)
 
 Flags:
-  --project <name>          override the project for classpath resolution
+  --project <name>          override classpath/runtime context — use this
+                            project's classpath even if the test class
+                            physically lives in another project (test
+                            reuse across projects, e.g. test class in
+                            project A but dependencies from project B)
   -f, --follow              stream test status (only failures by default)
   -q, --quiet               suppress onboarding guide
   --all                     include passed tests in output (with -f)
   --ignored                 show only ignored tests (with -f)
   --json                    output as JSONL when streaming (-f), or JSON snapshot
+  --coverage                launch in coverage mode (EclEmma)
+  --no-refresh              skip the workspace refresh before launching
   --ignore-compile-errors   launch despite workspace compile errors
 
 Examples:
-  jdt test run com.example.MyTest                       run + show guide
-  jdt test run com.example.MyTest --project Build -f    run with Build classpath
-  jdt test run com.example.MyTest -f --all              run + stream all tests
-  jdt test run --project my-project -f                  run project tests + stream
-  jdt test run com.example.MyTest -f --json             stream as JSONL
+  jdt test run com.example.MyTest                  run + show guide
+  jdt test run com.example.MyTest#testFoo -f       single method, streamed
+  jdt test run my-project -f                       project tests + stream
+  jdt test run com.example -f                      package tests + stream
+  jdt test run com.example.MyTest --project Build -f
+                                                   reuse class, classpath = Build
+  jdt test run com.example.MyTest -f --json        stream as JSONL
 
 The output shows testRunId (for test commands) and launchId (for launch commands):
   jdt test status <testRunId> -f          test pass/fail details

--- a/cli/src/format/test-status.mjs
+++ b/cli/src/format/test-status.mjs
@@ -6,10 +6,11 @@ import { red, green, yellow, bold, dim } from "../color.mjs";
 import { alignCmds } from "./align.mjs";
 
 /**
- * Format a test status snapshot (JSON from /test/status).
- * Shows summary line + failure/ignored details based on filter.
+ * Single-line aggregate summary — header used by both the snapshot
+ * path and the end-of-stream tail in {@link followTestStream}.
+ * Format:  `#### <label> — <completed>/<total>, <counts>`
  */
-export function formatTestStatus(result) {
+export function formatTestSummaryLine(result) {
   const state = result.state === "running"
     ? " (running)"
     : result.state === "stopped"
@@ -21,9 +22,15 @@ export function formatTestStatus(result) {
     ? `${result.completed}/${result.total}`
     : `${result.total}/${result.total}`;
 
-  console.log(
-    `#### ${label} — ${progress}${state}, ${formatCounts(result)}`,
-  );
+  return `#### ${label} — ${progress}${state}, ${formatCounts(result)}`;
+}
+
+/**
+ * Format a test status snapshot (JSON from /test/status).
+ * Shows summary line + failure/ignored details based on filter.
+ */
+export function formatTestStatus(result) {
+  console.log(formatTestSummaryLine(result));
 
   const entries = result.entries || result.failures || [];
   if (entries.length > 0) {
@@ -189,9 +196,16 @@ Add \`-q\` to suppress this guide.`;
  * Stream test status via JSONL and format output.
  * Shared by test-run -f and test-status -f.
  * Returns exit code: 0 if all pass, 1 if any failures.
+ *
+ * On clean stream completion (terminal `finished` / `stopped` event)
+ * fetches the final /test/status snapshot and prints the aggregate
+ * summary header — same `#### <label> — N/N, X passed, Y failed`
+ * shape as the snapshot path emits, so the tail of `-f` carries the
+ * verdict line, not just the per-event firehose.
  */
 export async function followTestStream(testRunId, args) {
   const { followJsonlStream } = await import("./stream.mjs");
+  const { get } = await import("../client.mjs");
   const jsonFlag = args.includes("--json");
 
   let filter = "failures";
@@ -213,5 +227,19 @@ export async function followTestStream(testRunId, args) {
     } catch { /* ignore parse errors */ }
   });
   if (exit !== 0) return exit;
+
+  if (!jsonFlag) {
+    const snap = await get(
+      `/test/status?testRunId=${encodeURIComponent(testRunId)}`,
+      5_000);
+    if (snap.error) {
+      console.error(snap.error);
+      return 1;
+    }
+    if (snap.total > 0) {
+      console.log();
+      console.log(formatTestSummaryLine(snap));
+    }
+  }
   return hasFailed ? 1 : 0;
 }

--- a/cli/test/test-commands.test.mjs
+++ b/cli/test/test-commands.test.mjs
@@ -65,10 +65,10 @@ describe("test commands", () => {
 
   // --- test run ---
 
-  it("test run sends class param", async () => {
+  it("test run sends class FQN as target", async () => {
     await setupMock((req, res) => {
       if (req.url.includes("/test/run")) {
-        expect(req.url).toContain("class=com.example.FooTest");
+        expect(req.url).toContain("target=com.example.FooTest");
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ ok: true, configId: "FooTest", testRunId: "FooTest:1775000", launchId: "FooTest:100", pid: "100", reused: false, project: "my-project", runner: "JUnit 5" }));
       } else if (req.url.includes("/test/status")) {
@@ -81,10 +81,10 @@ describe("test commands", () => {
     expect(io.logs.some((l) => l.includes("FooTest"))).toBe(true);
   });
 
-  it("test run sends project param", async () => {
+  it("test run sends project name as target", async () => {
     await setupMock((req, res) => {
       if (req.url.includes("/test/run")) {
-        expect(req.url).toContain("project=my-project");
+        expect(req.url).toContain("target=my-project");
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ ok: true, configId: "my-project", testRunId: "my-project:1775001", launchId: "my-project:200", pid: "200", reused: false }));
       } else if (req.url.includes("/test/status")) {
@@ -93,7 +93,7 @@ describe("test commands", () => {
       }
     });
     const { testRun } = await import("../src/commands/test-run.mjs");
-    await testRun(["--project", "my-project", "-q"]);
+    await testRun(["my-project", "-q"]);
     expect(io.logs.some((l) => l.includes("my-project"))).toBe(true);
   });
 
@@ -132,11 +132,27 @@ describe("test commands", () => {
     expect(io.errors[0]).toContain("Something went wrong");
   });
 
-  it("test run sends method param with FQN#method", async () => {
+  it("test run sends --project as separate URL param alongside target", async () => {
     await setupMock((req, res) => {
       if (req.url.includes("/test/run")) {
-        expect(req.url).toContain("class=com.example.FooTest");
-        expect(req.url).toContain("method=testBar");
+        expect(req.url).toContain("target=com.example.FooTest");
+        expect(req.url).toContain("project=Build");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, configId: "FooTest", testRunId: "FooTest:1775099", launchId: "FooTest:900", pid: "900", reused: false, project: "Build" }));
+      } else if (req.url.includes("/test/status")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ total: 3 }));
+      }
+    });
+    const { testRun } = await import("../src/commands/test-run.mjs");
+    await testRun(["com.example.FooTest", "--project", "Build", "-q"]);
+  });
+
+  it("test run sends FQN#method form as target verbatim", async () => {
+    await setupMock((req, res) => {
+      if (req.url.includes("/test/run")) {
+        expect(req.url).toContain(
+            "target=com.example.FooTest%23testBar");
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ ok: true, configId: "FooTest", testRunId: "FooTest:1775003", launchId: "FooTest:400", pid: "400", reused: false }));
       } else if (req.url.includes("/test/status")) {
@@ -149,11 +165,10 @@ describe("test commands", () => {
     expect(io.logs.some((l) => l.includes("FooTest"))).toBe(true);
   });
 
-  it("test run sends package param", async () => {
+  it("test run sends package name as target", async () => {
     await setupMock((req, res) => {
       if (req.url.includes("/test/run")) {
-        expect(req.url).toContain("project=my-project");
-        expect(req.url).toContain("package=com.example.dao");
+        expect(req.url).toContain("target=com.example.dao");
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ ok: true, configId: "com.example.service", testRunId: "com.example.service:1775004", launchId: "com.example.service:500", pid: "500", reused: false }));
       } else if (req.url.includes("/test/status")) {
@@ -162,7 +177,7 @@ describe("test commands", () => {
       }
     });
     const { testRun } = await import("../src/commands/test-run.mjs");
-    await testRun(["--project", "my-project", "--package", "com.example.dao", "-q"]);
+    await testRun(["com.example.dao", "-q"]);
   });
 
   it("test run sends no-refresh param", async () => {
@@ -178,6 +193,34 @@ describe("test commands", () => {
     });
     const { testRun } = await import("../src/commands/test-run.mjs");
     await testRun(["com.example.FooTest", "--no-refresh", "-q"]);
+  });
+
+  it("test run -f prints aggregate summary line at end of stream", async () => {
+    await setupMock((req, res) => {
+      if (req.url.includes("/test/run")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, configId: "SumTest", testRunId: "SumTest:1775101", launchId: "SumTest:1010", pid: "1010", reused: false }));
+      } else if (req.url.includes("/test/status/stream")) {
+        res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+        res.write(JSON.stringify({ event: "finished", total: 5, passed: 4, failed: 1, errors: 0, ignored: 0, time: 1.5 }) + "\n");
+        res.end();
+      } else if (req.url.includes("/test/status")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          configId: "SumTest", label: "SumTest",
+          total: 5, completed: 5, state: "finished",
+          passed: 4, failed: 1, errors: 0, ignored: 0,
+          time: 1.5,
+        }));
+      }
+    });
+    const { testRun } = await import("../src/commands/test-run.mjs");
+    await expect(testRun(["com.example.SumTest", "-f", "-q"])).rejects.toThrow("exit(1)");
+    const allLogs = io.logs.join("\n");
+    expect(allLogs).toContain("#### SumTest");
+    expect(allLogs).toContain("5/5");
+    expect(allLogs).toContain("4 passed");
+    expect(allLogs).toContain("1 failed");
   });
 
   it("test run -f exits 1 on test failures", async () => {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectOverrideTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectOverrideTest.java
@@ -106,7 +106,7 @@ public class ProjectOverrideTest {
     void nonexistentProjectOverrideReturnsError()
             throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put("class", "test.override.SimpleTest");
+        params.put("target", "test.override.SimpleTest");
         params.put("project", "nonexistent-xyz");
         params.put("no-refresh", "");
         String json = handler.handleTestRun(params);
@@ -117,7 +117,7 @@ public class ProjectOverrideTest {
     @Test
     void projectOverrideUsedInLaunch() throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put("class", "test.override.SimpleTest");
+        params.put("target", "test.override.SimpleTest");
         params.put("project", LAUNCHER_PROJECT);
         params.put("no-refresh", "");
         String json = handler.handleTestRun(params);
@@ -126,6 +126,21 @@ public class ProjectOverrideTest {
         assertTrue(json.contains(
                 "\"project\":\"" + LAUNCHER_PROJECT + "\""),
                 "Should use launcher project: " + json);
+    }
+
+    @Test
+    void targetWithoutProjectUsesEnclosing()
+            throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "test.override.SimpleTest");
+        params.put("no-refresh", "");
+        String json = handler.handleTestRun(params);
+        assertTrue(json.contains("\"ok\":true"),
+                "Should launch: " + json);
+        assertTrue(json.contains(
+                "\"project\":\"" + SOURCE_PROJECT + "\""),
+                "Without override, project comes from enclosing"
+                + " project of resolved type: " + json);
     }
 
     // ---- helpers ----

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
@@ -40,35 +40,39 @@ public class TestHandlerIntegrationTest {
     @Test
     public void typeNotFound() throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put("class", "no.such.TestClass");
+        params.put("target", "no.such.TestClass");
         params.put("no-refresh", "");
         String json = handler.handleTestRun(params);
         assertTrue(json.contains("error"),
                 "Should return error: " + json);
-        assertTrue(json.contains("not found"),
-                "Should mention not found: " + json);
+        assertTrue(json.contains("target-not-found"),
+                "Should mention target-not-found: " + json);
     }
 
     @Test
     public void projectNotFound() throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put("project", "nonexistent-project-xyz");
+        params.put("target", "nonexistent-project-xyz");
         params.put("no-refresh", "");
         String json = handler.handleTestRun(params);
         assertTrue(json.contains("error"),
                 "Should return error: " + json);
+        assertTrue(json.contains("target-not-found"),
+                "Should mention target-not-found: " + json);
     }
 
     @Test
     public void notJavaProject() throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put("project", TestFixture.NON_JAVA_PROJECT_NAME);
+        params.put("target", TestFixture.NON_JAVA_PROJECT_NAME);
         params.put("no-refresh", "");
         String json = handler.handleTestRun(params);
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
-        assertTrue(json.contains("Not a Java project"),
-                "Should say not Java: " + json);
+        // IJavaProject.exists() is false on a project without the
+        // Java nature, so resolveContainerOrType skips it and the
+        // resolve falls through to the target-not-found error —
+        // same shape as a non-existent project name.
+        assertTrue(json.contains("target-not-found"),
+                "Non-Java project should be unresolvable: " + json);
     }
 
     @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageFlagTest.java
@@ -58,7 +58,7 @@ public class TestRunCoverageFlagTest {
             // No coverage param → response must not carry the
             // coverage fields, regardless of the prepare result.
             Map<String, String> params = new HashMap<>();
-            params.put("class", "no.such.TestClass");
+            params.put("target", "no.such.TestClass");
             params.put("no-refresh", "");
             String json = handler.handleTestRun(params);
             assertFalse(json.contains("\"coverageId\""),
@@ -70,7 +70,7 @@ public class TestRunCoverageFlagTest {
         @Test
         void coverageFalseDoesNotEnableCoverage() throws Exception {
             Map<String, String> params = new HashMap<>();
-            params.put("class", "no.such.TestClass");
+            params.put("target", "no.such.TestClass");
             params.put("no-refresh", "");
             params.put("coverage", "false");
             String json = handler.handleTestRun(params);
@@ -84,7 +84,7 @@ public class TestRunCoverageFlagTest {
             // enable coverage — fix for the empty-string surprise
             // flagged in PR review.
             Map<String, String> params = new HashMap<>();
-            params.put("class", "no.such.TestClass");
+            params.put("target", "no.such.TestClass");
             params.put("no-refresh", "");
             params.put("coverage", "");
             String json = handler.handleTestRun(params);
@@ -99,7 +99,7 @@ public class TestRunCoverageFlagTest {
         void coverageOneEnablesCoverage() throws Exception {
             // Spec accepts "true" or "1".
             Map<String, String> params = new HashMap<>();
-            params.put("class", "test.edge.SimpleTest");
+            params.put("target", "test.edge.SimpleTest");
             params.put("no-refresh", "");
             params.put("coverage", "1");
             String json = handler.handleTestRun(params);
@@ -114,25 +114,25 @@ public class TestRunCoverageFlagTest {
         @Test
         void unknownClassReturnsTypeNotFound() throws Exception {
             Map<String, String> params = new HashMap<>();
-            params.put("class", "no.such.TestClass");
+            params.put("target", "no.such.TestClass");
             params.put("no-refresh", "");
             params.put("coverage", "true");
             String json = handler.handleTestRun(params);
-            // prepareLaunch fails first → "Type not found" surfaces
-            // before coverage-mode-not-supported has a chance.
-            assertTrue(json.contains("not found"),
-                    "Should report type not found: " + json);
+            // resolveElement returns null first → target-not-found
+            // surfaces before coverage-mode-not-supported has a chance.
+            assertTrue(json.contains("target-not-found"),
+                    "Should report target-not-found: " + json);
         }
 
         @Test
         void unknownProjectReturnsProjectNotFound() throws Exception {
             Map<String, String> params = new HashMap<>();
-            params.put("project", "nonexistent-project-xyz");
+            params.put("target", "nonexistent-project-xyz");
             params.put("no-refresh", "");
             params.put("coverage", "true");
             String json = handler.handleTestRun(params);
-            assertTrue(json.contains("error"),
-                    "Should error: " + json);
+            assertTrue(json.contains("target-not-found"),
+                    "Should report target-not-found: " + json);
         }
     }
 
@@ -146,7 +146,7 @@ public class TestRunCoverageFlagTest {
             // delegate registered AND the EclEmma UI bundle active —
             // gated above.
             Map<String, String> params = new HashMap<>();
-            params.put("class", "test.edge.SimpleTest");
+            params.put("target", "test.edge.SimpleTest");
             params.put("no-refresh", "");
             params.put("coverage", "true");
             String json = handler.handleTestRun(params);

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -14,8 +14,10 @@ import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
@@ -25,6 +27,7 @@ import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.osgi.framework.Version;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.Manifest;
 
@@ -90,6 +93,74 @@ public class TestHandler {
             boolean reused,
             String project,
             String runner) {}
+
+    /**
+     * Translate a resolved {@link IJavaElement} into the
+     * class/method/project/package shape consumed by
+     * {@link #prepareLaunch}. An explicit {@code project} entry in
+     * {@code params} wins over the element's enclosing project for
+     * IMethod / IType / IPackageFragment / ICompilationUnit; for
+     * IJavaProject targets the resolved project is authoritative.
+     */
+    private static Map<String, String> synthesizeFromTarget(
+            Map<String, String> params, IJavaElement element)
+            throws JavaModelException {
+        Map<String, String> out = new HashMap<>(params);
+        out.remove("target");
+        String override = out.get("project");
+        boolean hasOverride = override != null
+                && !override.isBlank();
+
+        if (element instanceof IMethod m) {
+            IType t = m.getDeclaringType();
+            out.put("class", t.getFullyQualifiedName('.'));
+            out.put("method", m.getElementName());
+            if (!hasOverride) {
+                out.put("project",
+                        t.getJavaProject().getElementName());
+            }
+        } else if (element instanceof IType t) {
+            out.put("class", t.getFullyQualifiedName('.'));
+            if (!hasOverride) {
+                out.put("project",
+                        t.getJavaProject().getElementName());
+            }
+        } else if (element instanceof IJavaProject p) {
+            out.put("project", p.getElementName());
+        } else if (element instanceof IPackageFragment pkg) {
+            out.put("package", pkg.getElementName());
+            if (!hasOverride) {
+                out.put("project",
+                        pkg.getJavaProject().getElementName());
+            }
+        } else if (element instanceof ICompilationUnit cu) {
+            IType primary = cu.findPrimaryType();
+            if (primary == null) {
+                throw new IllegalArgumentException(
+                        "compilation-unit-no-primary-type: "
+                        + cu.getElementName());
+            }
+            out.put("class",
+                    primary.getFullyQualifiedName('.'));
+            if (!hasOverride) {
+                out.put("project",
+                        cu.getJavaProject().getElementName());
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "unsupported-target-kind: "
+                    + element.getClass().getSimpleName());
+        }
+        return out;
+    }
+
+    private static String targetNotFoundError(String target) {
+        var err = new JsonObject();
+        err.addProperty("error", "target-not-found: " + target);
+        err.addProperty("kind", "target-not-found");
+        err.addProperty("target", target);
+        return err.toString();
+    }
 
     /**
      * Common launch preparation: refresh, create config,
@@ -224,10 +295,26 @@ public class TestHandler {
      */
     public String handleTestRun(Map<String, String> params)
             throws Exception {
-        boolean coverage = parseBool(params.get("coverage"));
+        String target = params.get("target");
+        if (target == null || target.isBlank()) {
+            return HttpServer.jsonError(
+                    "Missing 'target' parameter");
+        }
+        IJavaElement element = JdtUtils.resolveElement(target);
+        if (element == null) {
+            return targetNotFoundError(target);
+        }
+        Map<String, String> synth;
+        try {
+            synth = synthesizeFromTarget(params, element);
+        } catch (IllegalArgumentException e) {
+            return HttpServer.jsonError(e.getMessage());
+        }
+
+        boolean coverage = parseBool(synth.get("coverage"));
 
         String[] errorOut = { null };
-        PreparedLaunch pl = prepareLaunch(params, errorOut);
+        PreparedLaunch pl = prepareLaunch(synth, errorOut);
         if (pl == null) return errorOut[0];
 
         if (coverage) {


### PR DESCRIPTION
Summary
- jdt test run now takes ONE positional target — resolved server-side via JdtUtils.resolveElement (the same polymorphic resolver coverage uses). Dispatches on JDT element kind: IType / IMethod / IJavaProject / IPackageFragment / ICompilationUnit. One lookup, one branch per kind, loud target-not-found on miss. No client-side try-class-then-project fallback.
- --project flag preserved as classpath/runtime context override (PR #60 / ProjectOverrideTest semantics). When passed alongside target=, it wins over the element's enclosing project for IMethod / IType / IPackageFragment / ICompilationUnit. For IJavaProject targets the resolved project is authoritative.
- Test run -f path: after the JSONL stream completes, fetch the final /test/status snapshot and print the aggregate summary header — same `#### <label> — N/N, X passed, Y failed` shape as the snapshot path. The previous behaviour terminated the stream silently, leaving the user with the per-event firehose but no verdict line.

Notes for reviewers
- Includes the setup-fail-loud commits from PR #117 (cherry-picked dependency). That PR should merge first; once it does, this PR's diff against master will be just the test-run changes.

Test plan
- [x] Full plugin suite 666/666 (was 665, +1 from new ProjectOverrideTest case `targetWithoutProjectUsesEnclosing`)
- [x] CLI suite 837/837
- [x] Live: jdt test run io.github.kaluchi.jdtbridge.LaunchHandlerTest -f → 43/43 + summary line
- [ ] CI Plugin build + CLI tests