### PR TITLE
qlang: add jdt/aliases module with flatten alias for flat

### DIFF
--- a/cli/lib/jdt/aliases.qlang
+++ b/cli/lib/jdt/aliases.qlang
@@ -1,0 +1,15 @@
+|~ ───────────────────────────────────────────────────────────────────
+   :jdt/aliases — pure-qlang aliases for builtins whose canonical
+   name doesn't match common-English expectations from agents.
+
+   Adding entries here is cheap; each saves one round-trip when a
+   model reaches for the wrong-but-natural name and `jdt q` returns
+   `unresolved-identifier`.
+   ───────────────────────────────────────────────────────────── ~|
+
+|~~ Alias for the `flat` builtin — flattens one level of nesting.
+    Accepts the same Vec<Vec<T>> shape, returns Vec<T>. Models
+    consistently reach for `flatten` (Clojure / Lodash / JS Array
+    convention) rather than `flat` (Lisp / qlang); accepting both
+    avoids dead round-trips. ~~|
+let(:flatten, flat)

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -182,7 +182,7 @@ export async function query(args) {
     bindParseOperands(session);
     bindJdtRenderOperands(session);
     const cellEntry = await session.evalCell(
-        `use(:jdt/graph) | use(:jdt/coverage) | ${querySource}`);
+        `use(:jdt/aliases) | use(:jdt/graph) | use(:jdt/coverage) | ${querySource}`);
 
     if (cellEntry.error) {
       printQueryResult(parseErrorToValue(cellEntry.error, cellEntry.uri));

--- a/cli/test/aliases-module.test.mjs
+++ b/cli/test/aliases-module.test.mjs
@@ -1,0 +1,72 @@
+// Tests for the :jdt/aliases module — pure-qlang aliases for
+// builtins whose canonical name doesn't match common-English
+// expectations from agents.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { keyword } from "@kaluchi/qlang-core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODULE_LIB = join(__dirname, "..", "lib");
+
+async function loadSession() {
+    vi.resetModules();
+    vi.doMock("../src/client.mjs", () => ({
+        get: async () => null,
+        currentInstance: () => null,
+        BridgeNotRunningError: class extends Error {},
+        isConnectionError: () => false,
+    }));
+    const { createSession } = await import(
+            "@kaluchi/qlang-core/session");
+    return createSession({
+        locator: (ns) => {
+            const path = join(MODULE_LIB, ...ns.split("/"))
+                    + ".qlang";
+            const source = readFileSync(path, "utf8");
+            return { source };
+        },
+    });
+}
+
+afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../src/client.mjs");
+});
+
+async function evaluate(expr) {
+    const session = await loadSession();
+    const { result, error } = await session.evalCell(expr);
+    if (error) throw error;
+    return result;
+}
+
+describe("jdt/aliases module — flatten", () => {
+    it("flattens one level like flat", async () => {
+        const r = await evaluate(
+                "use(:jdt/aliases) | [[1 2] [3] [4 5]] | flatten");
+        expect(r).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("on already-flat input is identity", async () => {
+        const r = await evaluate(
+                "use(:jdt/aliases) | [1 2 3] | flatten");
+        expect(r).toEqual([1, 2, 3]);
+    });
+
+    it("composes with sortWith and projection", async () => {
+        const r = await evaluate(
+                "use(:jdt/aliases) | "
+                + "[[{:n 3} {:n 1}] [{:n 2}]] | flatten "
+                + "| sortWith(desc(/n)) * /n");
+        expect(r).toEqual([3, 2, 1]);
+    });
+
+    it("descriptor reports name and category", async () => {
+        const d = await evaluate(
+                "use(:jdt/aliases) | reify(:flatten)");
+        expect(d.get(keyword("name"))).toBe("flatten");
+    });
+});


### PR DESCRIPTION
Summary
- Models trying `flatten` (Clojure / Lodash / JS Array convention) hit unresolved-identifier — qlang's name is `flat`. New :jdt/aliases module binds the alias as a pure-qlang let-binding, wired into the `jdt q` prelude alongside :jdt/graph and :jdt/coverage. `[[1 2] [3]] | flatten` resolves out of the box.
- Pure pass-through to the existing builtin — same Vec<Vec<T>> -> Vec<T> shape, same throws.

Test plan
- [x] cli/test/aliases-module.test.mjs (4 tests)
- [x] Full CLI suite 839/839
- [ ] CI