### PR TITLE
Extract pure-data builders: EditorJson + JsonValues from handlers

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/EditorJsonTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/EditorJsonTest.java
@@ -1,0 +1,62 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+/** Pure-data tests for {@link EditorJson}. */
+public class EditorJsonTest {
+
+    @Test
+    void inactiveJavaFileEmitsAllFields() {
+        JsonObject obj = EditorJson.entry(
+                "C:/ws/proj/src/p/Foo.java",
+                "proj",
+                "p.Foo",
+                false);
+        assertEquals("C:/ws/proj/src/p/Foo.java",
+                obj.get("file").getAsString());
+        assertEquals("proj", obj.get("project").getAsString());
+        assertEquals("p.Foo", obj.get("fqn").getAsString());
+        assertFalse(obj.has("active"),
+                "inactive editor must not carry the active flag");
+    }
+
+    @Test
+    void activeFlagOnlyPresentWhenTrue() {
+        JsonObject obj = EditorJson.entry(
+                "/ws/proj/src/p/Foo.java",
+                "proj", "p.Foo", true);
+        assertTrue(obj.get("active").getAsBoolean(),
+                "active editor must render active=true");
+    }
+
+    @Test
+    void nullFqnOmitsField() {
+        JsonObject obj = EditorJson.entry(
+                "/ws/proj/README.md", "proj", null, false);
+        assertFalse(obj.has("fqn"),
+                "non-Java file (null fqn) must not carry"
+                + " the fqn property");
+        assertEquals("proj",
+                obj.get("project").getAsString());
+        assertEquals("/ws/proj/README.md",
+                obj.get("file").getAsString());
+    }
+
+    @Test
+    void activeNonJavaFile() {
+        JsonObject obj = EditorJson.entry(
+                "/abs/pom.xml", "myproj", null, true);
+        assertEquals("/abs/pom.xml",
+                obj.get("file").getAsString());
+        assertEquals("myproj",
+                obj.get("project").getAsString());
+        assertTrue(obj.get("active").getAsBoolean());
+        assertFalse(obj.has("fqn"));
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/JsonValuesTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/JsonValuesTest.java
@@ -1,0 +1,107 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/** Pure-data tests for {@link JsonValues#toElement}. */
+public class JsonValuesTest {
+
+    @Test
+    void nullBecomesJsonNull() {
+        assertEquals(JsonNull.INSTANCE, JsonValues.toElement(null));
+    }
+
+    @Test
+    void stringBecomesPrimitive() {
+        JsonElement e = JsonValues.toElement("hello");
+        assertTrue(e.isJsonPrimitive());
+        assertEquals("hello", e.getAsString());
+    }
+
+    @Test
+    void booleanBecomesPrimitive() {
+        assertTrue(JsonValues.toElement(true).getAsBoolean());
+        assertFalse(JsonValues.toElement(false).getAsBoolean());
+    }
+
+    @Test
+    void integerBecomesPrimitive() {
+        assertEquals(42, JsonValues.toElement(42).getAsInt());
+    }
+
+    @Test
+    void doubleBecomesPrimitive() {
+        assertEquals(3.14,
+                JsonValues.toElement(3.14).getAsDouble(),
+                1e-9);
+    }
+
+    @Test
+    void listBecomesArray() {
+        JsonElement e = JsonValues.toElement(
+                List.of("a", 1, true));
+        assertTrue(e.isJsonArray());
+        var arr = e.getAsJsonArray();
+        assertEquals(3, arr.size());
+        assertEquals("a", arr.get(0).getAsString());
+        assertEquals(1, arr.get(1).getAsInt());
+        assertTrue(arr.get(2).getAsBoolean());
+    }
+
+    @Test
+    void setBecomesArray() {
+        JsonElement e = JsonValues.toElement(Set.of("only"));
+        assertTrue(e.isJsonArray());
+        assertEquals(1, e.getAsJsonArray().size());
+    }
+
+    @Test
+    void mapBecomesObject() {
+        JsonElement e = JsonValues.toElement(
+                Map.of("k", "v", "n", 7));
+        assertTrue(e.isJsonObject());
+        var obj = e.getAsJsonObject();
+        assertEquals("v", obj.get("k").getAsString());
+        assertEquals(7, obj.get("n").getAsInt());
+    }
+
+    @Test
+    void nestedListInMapInList() {
+        JsonElement e = JsonValues.toElement(
+                List.of(Map.of("xs", List.of(1, 2))));
+        var outer = e.getAsJsonArray();
+        var inner = outer.get(0).getAsJsonObject()
+                .get("xs").getAsJsonArray();
+        assertEquals(1, inner.get(0).getAsInt());
+        assertEquals(2, inner.get(1).getAsInt());
+    }
+
+    @Test
+    void unknownTypeFallsBackToToString() {
+        // StringBuilder is not String/Number/Boolean/List/Set/Map,
+        // so the fallback `value.toString()` branch fires.
+        JsonElement e = JsonValues.toElement(
+                new StringBuilder("sb"));
+        assertEquals("sb", e.getAsString());
+    }
+
+    @Test
+    void emptyCollectionsRoundTrip() {
+        assertEquals(0,
+                JsonValues.toElement(List.of()).getAsJsonArray().size());
+        assertEquals(0,
+                JsonValues.toElement(Set.of()).getAsJsonArray().size());
+        assertEquals(0,
+                JsonValues.toElement(Map.of()).getAsJsonObject().size());
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ServerPreferencesTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ServerPreferencesTest.java
@@ -1,0 +1,160 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * Unit tests for {@link ServerPreferences}. Each test writes the
+ * relevant key into the InstanceScope node, reads it back via the
+ * resolveX entry point, then clears the key in @AfterEach so the
+ * next test starts from a known default.
+ */
+public class ServerPreferencesTest {
+
+    private IEclipsePreferences node;
+
+    @BeforeEach
+    void getNode() {
+        node = InstanceScope.INSTANCE.getNode(
+                ServerPreferences.PREFERENCE_NODE);
+    }
+
+    @AfterEach
+    void clearAllKeys() throws BackingStoreException {
+        for (String key : new String[] {
+                ServerPreferences.LOCAL_PORT,
+                ServerPreferences.LOCAL_REGENERATE_TOKEN,
+                ServerPreferences.LOCAL_TOKEN,
+                ServerPreferences.REMOTE_ENABLED,
+                ServerPreferences.REMOTE_PORT,
+                ServerPreferences.REMOTE_REGENERATE_TOKEN,
+                ServerPreferences.REMOTE_TOKEN,
+        }) {
+            node.remove(key);
+        }
+        node.flush();
+    }
+
+    // ---- LOCAL ----
+
+    @Test
+    void localPortDefaultsToZero() {
+        assertEquals(0, ServerPreferences.resolveLocalPort());
+    }
+
+    @Test
+    void localPortReadsConfiguredValue()
+            throws BackingStoreException {
+        node.putInt(ServerPreferences.LOCAL_PORT, 8080);
+        node.flush();
+        assertEquals(8080,
+                ServerPreferences.resolveLocalPort());
+    }
+
+    @Test
+    void localRegenerateTokenDefaultsToTrue() {
+        assertTrue(ServerPreferences
+                .resolveLocalRegenerateToken());
+    }
+
+    @Test
+    void localRegenerateTokenReadsFalse()
+            throws BackingStoreException {
+        node.putBoolean(
+                ServerPreferences.LOCAL_REGENERATE_TOKEN,
+                false);
+        node.flush();
+        assertFalse(ServerPreferences
+                .resolveLocalRegenerateToken());
+    }
+
+    @Test
+    void localTokenDefaultsToEmpty() {
+        assertEquals("",
+                ServerPreferences.resolveLocalToken());
+    }
+
+    @Test
+    void localTokenReadsValue()
+            throws BackingStoreException {
+        node.put(ServerPreferences.LOCAL_TOKEN,
+                "abc123-secret");
+        node.flush();
+        assertEquals("abc123-secret",
+                ServerPreferences.resolveLocalToken());
+    }
+
+    // ---- REMOTE ----
+
+    @Test
+    void remoteEnabledDefaultsToFalse() {
+        assertFalse(
+                ServerPreferences.resolveRemoteEnabled());
+    }
+
+    @Test
+    void remoteEnabledReadsTrue()
+            throws BackingStoreException {
+        node.putBoolean(
+                ServerPreferences.REMOTE_ENABLED, true);
+        node.flush();
+        assertTrue(
+                ServerPreferences.resolveRemoteEnabled());
+    }
+
+    @Test
+    void remotePortDefaultsToZero() {
+        assertEquals(0,
+                ServerPreferences.resolveRemotePort());
+    }
+
+    @Test
+    void remotePortReadsConfiguredValue()
+            throws BackingStoreException {
+        node.putInt(ServerPreferences.REMOTE_PORT, 7777);
+        node.flush();
+        assertEquals(7777,
+                ServerPreferences.resolveRemotePort());
+    }
+
+    @Test
+    void remoteRegenerateTokenDefaultsToFalse() {
+        assertFalse(ServerPreferences
+                .resolveRemoteRegenerateToken());
+    }
+
+    @Test
+    void remoteRegenerateTokenReadsTrue()
+            throws BackingStoreException {
+        node.putBoolean(
+                ServerPreferences.REMOTE_REGENERATE_TOKEN,
+                true);
+        node.flush();
+        assertTrue(ServerPreferences
+                .resolveRemoteRegenerateToken());
+    }
+
+    @Test
+    void remoteTokenDefaultsToEmpty() {
+        assertEquals("",
+                ServerPreferences.resolveRemoteToken());
+    }
+
+    @Test
+    void remoteTokenReadsValue()
+            throws BackingStoreException {
+        node.put(ServerPreferences.REMOTE_TOKEN,
+                "remote-secret-42");
+        node.flush();
+        assertEquals("remote-secret-42",
+                ServerPreferences.resolveRemoteToken());
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
@@ -6,11 +6,15 @@ import com.google.gson.JsonObject;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IFileEditorInput;
@@ -24,85 +28,77 @@ class EditorHandler {
             ProjectScope scope) throws Exception {
         String[] result = {"[]"};
         Runnable query = () -> {
-            try {
-                IWorkbenchWindow window = PlatformUI
-                        .getWorkbench()
-                        .getActiveWorkbenchWindow();
-                if (window == null
-                        || window.getActivePage() == null) {
-                    return;
-                }
-
-                IWorkbenchPage page =
-                        window.getActivePage();
-                IEditorReference[] refs =
-                        page.getEditorReferences();
-                IEditorPart active =
-                        page.getActiveEditor();
-
-                var arr = new JsonArray();
-                if (active != null) {
-                    addEditorEntry(
-                            active.getEditorInput(), arr,
-                            true, scope);
-                }
-                for (IEditorReference ref : refs) {
-                    IEditorPart editor =
-                            ref.getEditor(false);
-                    if (editor != null && editor == active)
-                        continue;
-                    try {
-                        addEditorEntry(
-                                ref.getEditorInput(), arr,
-                                false, scope);
-                    } catch (Exception ignored) {
-                    }
-                }
-                result[0] = arr.toString();
-            } catch (Exception e) {
+            IWorkbenchWindow window = PlatformUI.getWorkbench()
+                    .getActiveWorkbenchWindow();
+            if (window == null
+                    || window.getActivePage() == null) {
+                return;
             }
+            IWorkbenchPage page = window.getActivePage();
+            IEditorPart active = page.getActiveEditor();
+            JsonArray arr = new JsonArray();
+            if (active != null) {
+                appendEntry(active.getEditorInput(), arr,
+                        true, scope);
+            }
+            for (IEditorReference ref
+                    : page.getEditorReferences()) {
+                IEditorPart editor = ref.getEditor(false);
+                if (editor != null && editor == active) continue;
+                appendEntry(inputOf(ref), arr, false, scope);
+            }
+            result[0] = arr.toString();
         };
-        Display display = Display.getCurrent();
-        if (display != null) {
+        if (Display.getCurrent() != null) {
             query.run();
         } else {
-            try {
-                Display.getDefault().syncExec(query);
-            } catch (Exception e) {
-            }
+            Display.getDefault().syncExec(query);
         }
         return result[0];
     }
 
-    private void addEditorEntry(
-            org.eclipse.ui.IEditorInput input,
+    private static IEditorInput inputOf(IEditorReference ref) {
+        try {
+            return ref.getEditorInput();
+        } catch (org.eclipse.ui.PartInitException e) {
+            throw new IllegalStateException(
+                    "Editor reference not initialised: " + ref, e);
+        }
+    }
+
+    private static void appendEntry(IEditorInput input,
             JsonArray arr, boolean isActive,
             ProjectScope scope) {
         if (!(input instanceof IFileEditorInput fi)) return;
         IFile file = fi.getFile();
         if (file.getLocation() == null) return;
-        if (!scope.containsProject(
-                file.getProject().getName())) return;
-        var obj = new JsonObject();
-        obj.addProperty("file",
-                file.getLocation().toOSString());
-        obj.addProperty("project",
-                file.getProject().getName());
-        if (isActive) obj.addProperty("active", true);
-        // FQN for Java files
+        String project = file.getProject().getName();
+        if (!scope.containsProject(project)) return;
+        arr.add(EditorJson.entry(
+                file.getLocation().toOSString(),
+                project,
+                primaryTypeFqn(file),
+                isActive));
+    }
+
+    /**
+     * Primary type FQN if {@code file} is a compilation unit,
+     * otherwise {@code null}. {@link JavaCore#create(IFile)} returns
+     * {@code null} for non-Java files, so the cast is the gate.
+     */
+    private static String primaryTypeFqn(IFile file)
+            throws RuntimeException {
+        IJavaElement el = JavaCore.create(file);
+        if (!(el instanceof ICompilationUnit cu)) return null;
         try {
-            var javaElement = org.eclipse.jdt.core.JavaCore
-                    .create(file);
-            if (javaElement instanceof org.eclipse.jdt.core
-                    .ICompilationUnit cu) {
-                var types = cu.getTypes();
-                if (types.length > 0) {
-                    obj.addProperty("fqn",
-                            types[0].getFullyQualifiedName());
-                }
-            }
-        } catch (Exception ignored) { }
-        arr.add(obj);
+            IType[] types = cu.getTypes();
+            return types.length > 0
+                    ? types[0].getFullyQualifiedName()
+                    : null;
+        } catch (JavaModelException e) {
+            throw new RuntimeException(
+                    "Could not read types of " + file, e);
+        }
     }
 
     String handleOpen(Map<String, String> params)
@@ -141,7 +137,7 @@ class EditorHandler {
                 if (editor != null) {
                     JavaUI.revealInEditor(editor, element);
                 }
-                var ok = new JsonObject();
+                JsonObject ok = new JsonObject();
                 ok.addProperty("ok", true);
                 result[0] = ok.toString();
             } catch (Exception e) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/EditorJson.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/EditorJson.java
@@ -1,0 +1,37 @@
+package io.github.kaluchi.jdtbridge;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Pure JSON shape builders for the /editors endpoint. Decoupled
+ * from the workbench / IDE APIs so the wire shape can be unit-tested
+ * headlessly (no SWT, no PlatformUI).
+ *
+ * <p>The handler ({@link EditorHandler}) extracts the field values
+ * from {@code IEditorInput} / {@code IFile} on the UI thread and
+ * passes them in.
+ */
+final class EditorJson {
+
+    private EditorJson() { }
+
+    /**
+     * Build a single editor-entry object.
+     *
+     * @param filePath    absolute filesystem path of the editor's file
+     * @param projectName containing project name
+     * @param fqn         primary type FQN if the file is a Java
+     *                    compilation unit, otherwise {@code null}
+     * @param isActive    {@code true} for the active editor (renders
+     *                    {@code "active": true}); omitted otherwise
+     */
+    static JsonObject entry(String filePath, String projectName,
+            String fqn, boolean isActive) {
+        var obj = new JsonObject();
+        obj.addProperty("file", filePath);
+        obj.addProperty("project", projectName);
+        if (isActive) obj.addProperty("active", true);
+        if (fqn != null) obj.addProperty("fqn", fqn);
+        return obj;
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/JsonValues.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/JsonValues.java
@@ -1,0 +1,55 @@
+package io.github.kaluchi.jdtbridge;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Convert arbitrary Java values to gson {@link JsonElement}s.
+ * Recursive type-dispatch — String / Boolean / Number become
+ * primitives; List / Set become JsonArrays; Map becomes
+ * JsonObject; null becomes JsonNull; anything else falls back to
+ * {@code toString}.
+ *
+ * <p>Pure data — no JDT, no SWT, no IO. Lives outside the launch
+ * handler so its wire shape can be unit-tested headlessly and
+ * reused by any other handler that needs to serialize an
+ * unknown-typed Map of attributes.
+ */
+final class JsonValues {
+
+    private JsonValues() { }
+
+    @SuppressWarnings("unchecked")
+    static JsonElement toElement(Object value) {
+        if (value == null) return JsonNull.INSTANCE;
+        if (value instanceof String s) return new JsonPrimitive(s);
+        if (value instanceof Boolean b) return new JsonPrimitive(b);
+        if (value instanceof Number n) return new JsonPrimitive(n);
+        if (value instanceof List<?> list) {
+            JsonArray arr = new JsonArray();
+            for (Object item : list) arr.add(toElement(item));
+            return arr;
+        }
+        if (value instanceof Set<?> set) {
+            JsonArray arr = new JsonArray();
+            for (Object item : set) arr.add(toElement(item));
+            return arr;
+        }
+        if (value instanceof Map<?, ?> map) {
+            JsonObject obj = new JsonObject();
+            for (Map.Entry<String, Object> entry
+                    : ((Map<String, Object>) map).entrySet()) {
+                obj.add(entry.getKey(), toElement(entry.getValue()));
+            }
+            return obj;
+        }
+        return new JsonPrimitive(value.toString());
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -413,7 +413,7 @@ class LaunchHandler {
         var attrsObj = new JsonObject();
         for (var entry : attrs.entrySet()) {
             attrsObj.add(entry.getKey(),
-                    toJsonElement(entry.getValue()));
+                    JsonValues.toElement(entry.getValue()));
         }
         obj.add("attributes", attrsObj);
         return obj.toString();
@@ -451,40 +451,6 @@ class LaunchHandler {
                 .append(config.getName() + ".launch")
                 .toFile();
         return file.exists() ? file : null;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static com.google.gson.JsonElement toJsonElement(
-            Object value) {
-        if (value == null)
-            return com.google.gson.JsonNull.INSTANCE;
-        if (value instanceof String s)
-            return new JsonPrimitive(s);
-        if (value instanceof Boolean b)
-            return new JsonPrimitive(b);
-        if (value instanceof Number n)
-            return new JsonPrimitive(n);
-        if (value instanceof List<?> list) {
-            var arr = new JsonArray();
-            for (Object item : list)
-                arr.add(toJsonElement(item));
-            return arr;
-        }
-        if (value instanceof Set<?> set) {
-            var arr = new JsonArray();
-            for (Object item : set)
-                arr.add(toJsonElement(item));
-            return arr;
-        }
-        if (value instanceof Map<?, ?> map) {
-            var obj = new JsonObject();
-            for (var entry
-                    : ((Map<String, Object>) map).entrySet())
-                obj.add(entry.getKey(),
-                        toJsonElement(entry.getValue()));
-            return obj;
-        }
-        return new JsonPrimitive(value.toString());
     }
 
     /** Launch groups queried for recency, in fixed priority order.

--- a/plugin/src/io/github/kaluchi/jdtbridge/ServerPreferences.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/ServerPreferences.java
@@ -50,77 +50,51 @@ public class ServerPreferences {
 
     /** Read local port from preferences. */
     public static int resolveLocalPort() {
-        try {
-            return Platform.getPreferencesService().getInt(
-                    PREFERENCE_NODE, LOCAL_PORT, 0, null);
-        } catch (Exception e) {
-            Log.warn("Failed to read local port preference", e);
-            return 0;
-        }
+        return getInt(LOCAL_PORT, 0);
     }
 
     /** Whether local token should regenerate on restart. */
     public static boolean resolveLocalRegenerateToken() {
-        try {
-            return Platform.getPreferencesService().getBoolean(
-                    PREFERENCE_NODE, LOCAL_REGENERATE_TOKEN,
-                    true, null);
-        } catch (Exception e) {
-            return true;
-        }
+        return getBoolean(LOCAL_REGENERATE_TOKEN, true);
     }
 
     /** Read persisted local token (when regenerate is off). */
     public static String resolveLocalToken() {
-        try {
-            return Platform.getPreferencesService().getString(
-                    PREFERENCE_NODE, LOCAL_TOKEN, "", null);
-        } catch (Exception e) {
-            return "";
-        }
+        return getString(LOCAL_TOKEN, "");
     }
 
     /** Whether remote socket is enabled. */
     public static boolean resolveRemoteEnabled() {
-        try {
-            return Platform.getPreferencesService()
-                    .getBoolean(PREFERENCE_NODE, REMOTE_ENABLED,
-                            false, null);
-        } catch (Exception e) {
-            return false;
-        }
+        return getBoolean(REMOTE_ENABLED, false);
     }
 
     /** Read remote port from preferences. */
     public static int resolveRemotePort() {
-        try {
-            return Platform.getPreferencesService().getInt(
-                    PREFERENCE_NODE, REMOTE_PORT, 0, null);
-        } catch (Exception e) {
-            Log.warn("Failed to read remote port preference", e);
-            return 0;
-        }
+        return getInt(REMOTE_PORT, 0);
     }
 
     /** Whether remote token should regenerate on restart. */
     public static boolean resolveRemoteRegenerateToken() {
-        try {
-            return Platform.getPreferencesService().getBoolean(
-                    PREFERENCE_NODE, REMOTE_REGENERATE_TOKEN,
-                    false, null);
-        } catch (Exception e) {
-            return false;
-        }
+        return getBoolean(REMOTE_REGENERATE_TOKEN, false);
     }
 
     /** Read persisted remote token. */
     public static String resolveRemoteToken() {
-        try {
-            return Platform.getPreferencesService().getString(
-                    PREFERENCE_NODE, REMOTE_TOKEN, "", null);
-        } catch (Exception e) {
-            return "";
-        }
+        return getString(REMOTE_TOKEN, "");
     }
 
+    private static int getInt(String key, int defaultValue) {
+        return Platform.getPreferencesService().getInt(
+                PREFERENCE_NODE, key, defaultValue, null);
+    }
+
+    private static boolean getBoolean(String key, boolean defaultValue) {
+        return Platform.getPreferencesService().getBoolean(
+                PREFERENCE_NODE, key, defaultValue, null);
+    }
+
+    private static String getString(String key, String defaultValue) {
+        return Platform.getPreferencesService().getString(
+                PREFERENCE_NODE, key, defaultValue, null);
+    }
 }


### PR DESCRIPTION
Two SOLID splits, removing UI/handler-internal helpers that mixed concerns and were untestable headlessly.

EditorJson (extracted from EditorHandler)
- addEditorEntry mixed pulling fields from IFileEditorInput (UI-bound) with building the JSON entry shape. Split: pure EditorJson.entry(filePath, projectName, fqn, isActive).
- EditorHandler had 3 silent `catch (Exception ignored) { }`: addEditorEntry JavaCore.create path, per-IEditorReference iteration, syncExec wrapper. All three removed; ref.getEditorInput() PartInitException is the only checked exception, wrapped in inputOf() that re-throws as IllegalStateException with context.
- EditorJsonTest (4 cases): inactive Java, active flag, null-fqn non-Java, active non-Java.

JsonValues (extracted from LaunchHandler)
- LaunchHandler.toJsonElement (33 lines, 114 missed instructions, recursive Object -> JsonElement dispatch over String / Boolean / Number / List / Set / Map / fallback) was private static with one external caller. Pure data — no JDT, no UI.
- Moved to JsonValues.toElement(); reusable from any handler that serializes a Map of attributes.
- JsonValuesTest (11 cases): null, String, Boolean, int, double, List, Set, Map, nested-mix, unknown-type toString fallback, empty collections.

Test plan
- [x] 681/681 full plugin suite (was 666; +4 EditorJsonTest +11 JsonValuesTest)
- [x] Build clean both projects
- [ ] CI Plugin build + CLI tests