### PR TITLE
ReferenceCollector + HttpServer pure helpers: tests + DisconnectSignatures extract

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/DisconnectSignaturesTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/DisconnectSignaturesTest.java
@@ -1,0 +1,115 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Locale-by-locale match cases for {@link DisconnectSignatures}. */
+public class DisconnectSignaturesTest {
+
+    @Test
+    void posixBrokenPipe() {
+        assertTrue(DisconnectSignatures.matches(
+                "java.io.IOException: Broken pipe"));
+    }
+
+    @Test
+    void posixConnectionReset() {
+        assertTrue(DisconnectSignatures.matches(
+                "Connection reset by peer"));
+    }
+
+    @Test
+    void windowsEnglishConnectionAborted() {
+        assertTrue(DisconnectSignatures.matches(
+                "An established connection was aborted"
+                + " by the software in your host machine"));
+    }
+
+    @Test
+    void windowsEnglishForciblyClosed() {
+        assertTrue(DisconnectSignatures.matches(
+                "An existing connection was forcibly closed"
+                + " by the remote host"));
+    }
+
+    @Test
+    void windowsRussianAborted() {
+        // Locale-specific form actually emitted by Windows ru-RU
+        // (programma na vashem khost-kompyutere razorvala
+        // ustanovlennoe podklyuchenie).
+        assertTrue(DisconnectSignatures.matches(
+                "Программа на вашем хост-компьютере"
+                + " разорвала установленное подключение"));
+    }
+
+    @Test
+    void windowsRussianTerminatedByHost() {
+        assertTrue(DisconnectSignatures.matches(
+                "Удалённое подключение было разорвано"));
+    }
+
+    @Test
+    void windowsRussianTerminated() {
+        assertTrue(DisconnectSignatures.matches(
+                "Подключение прервано"));
+    }
+
+    @Test
+    void windowsGermanAborted() {
+        assertTrue(DisconnectSignatures.matches(
+                "Eine vorhandene Verbindung wurde vom"
+                + " Remotehost abgebrochen"));
+    }
+
+    @Test
+    void windowsGermanExisting() {
+        assertTrue(DisconnectSignatures.matches(
+                "Eine bestehende Verbindung wurde getrennt"));
+    }
+
+    @Test
+    void windowsFrenchInterrupted() {
+        assertTrue(DisconnectSignatures.matches(
+                "Une connexion existante a dû être"
+                + " interrompue par l'hôte distant"));
+    }
+
+    @Test
+    void windowsFrenchAbandoned() {
+        assertTrue(DisconnectSignatures.matches(
+                "Une connexion a été abandonnée par"
+                + " votre logiciel hôte"));
+    }
+
+    @Test
+    void windowsSpanish() {
+        assertTrue(DisconnectSignatures.matches(
+                "Una conexión existente fue cerrada"
+                + " forzosamente por el host remoto"));
+    }
+
+    @Test
+    void unrelatedMessageDoesNotMatch() {
+        assertFalse(DisconnectSignatures.matches(
+                "java.lang.NullPointerException: foo"));
+        assertFalse(DisconnectSignatures.matches(
+                "Permission denied"));
+        assertFalse(DisconnectSignatures.matches(""));
+    }
+
+    @Test
+    void partialPhraseDoesNotMatch() {
+        // Each multi-word locale signature requires both parts
+        // to be present — partial keyword match must NOT trip.
+        assertFalse(DisconnectSignatures.matches(
+                "Verbindung wurde aufgebaut"),
+                "German 'Verbindung wurde' alone (no abgebrochen)"
+                + " is not a disconnect");
+        assertFalse(DisconnectSignatures.matches(
+                "connexion existante a été établie"),
+                "French 'connexion existante a' alone (no"
+                + " interrompue) is not a disconnect");
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ReferenceCollectorTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ReferenceCollectorTest.java
@@ -218,4 +218,49 @@ public class ReferenceCollectorTest {
             }
         }
     }
+
+    @Nested
+    class PureHelpers {
+
+        @Test
+        void stripGenericsRemovesEverythingFromAngle() {
+            assertEquals("List",
+                    ReferenceCollector.stripGenerics(
+                            "List<String>"));
+            assertEquals("java.util.Map",
+                    ReferenceCollector.stripGenerics(
+                            "java.util.Map<K,V>"));
+        }
+
+        @Test
+        void stripGenericsPassesThroughWhenNoAngle() {
+            assertEquals("plain.Class",
+                    ReferenceCollector.stripGenerics(
+                            "plain.Class"));
+            assertEquals("",
+                    ReferenceCollector.stripGenerics(""));
+        }
+
+        @Test
+        void paramSigEmptyForNoArgs() throws Exception {
+            IType type = JdtUtils.findType(
+                    "test.model.Animal");
+            IMethod method = JdtUtils.findMethod(
+                    type, "name", null);
+            assertNotNull(method);
+            assertEquals("",
+                    ReferenceCollector.paramSig(method));
+        }
+
+        @Test
+        void paramSigPrimitivePair() throws Exception {
+            IType type = JdtUtils.findType(
+                    "test.edge.Calculator");
+            IMethod method = JdtUtils.findMethod(
+                    type, "add", "int,int");
+            assertNotNull(method);
+            assertEquals("int,int",
+                    ReferenceCollector.paramSig(method));
+        }
+    }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/DisconnectSignatures.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/DisconnectSignatures.java
@@ -1,0 +1,49 @@
+package io.github.kaluchi.jdtbridge;
+
+/**
+ * Detect remote-disconnect signatures inside wrapped exception
+ * messages. The JVM doesn't report a single canonical SocketException
+ * for client-disconnect across platforms — Linux says "Broken pipe",
+ * macOS "Connection reset", Windows surfaces a localized message
+ * from the OS, and we see them all flowing through wrapper layers
+ * (HTTP server, IO streams, executor reject) by message-substring.
+ *
+ * <p>Extracted out of {@link HttpServer} so the locale list has a
+ * single home and is unit-testable without the server lifecycle.
+ */
+final class DisconnectSignatures {
+
+    private DisconnectSignatures() { }
+
+    /**
+     * @return {@code true} if {@code msg} carries any known
+     *         remote-disconnect signature.
+     */
+    static boolean matches(String msg) {
+        // POSIX / generic
+        if (msg.contains("Broken pipe")) return true;
+        if (msg.contains("Connection reset")) return true;
+        // Windows English — WSAECONNABORTED
+        if (msg.contains("connection was aborted")) return true;
+        if (msg.contains("established connection was aborted"))
+            return true;
+        if (msg.contains("existing connection was forcibly closed"))
+            return true;
+        // Windows Russian (ru_RU)
+        if (msg.contains("разорвала")) return true;
+        if (msg.contains("разорвано")) return true;
+        if (msg.contains("прервано")) return true;
+        // Windows German (de_DE)
+        if (msg.contains("Verbindung wurde")
+                && msg.contains("abgebrochen")) return true;
+        if (msg.contains("bestehende Verbindung wurde")) return true;
+        // Windows French (fr_FR)
+        if (msg.contains("connexion existante a")
+                && msg.contains("interrompue")) return true;
+        if (msg.contains("connexion a été abandonnée")) return true;
+        // Windows Spanish (es_ES)
+        if (msg.contains("conexión existente")
+                && msg.contains("forzosamente")) return true;
+        return false;
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -352,39 +352,10 @@ public class HttpServer {
                 return true;
             }
             String msg = cursor.getMessage();
-            if (msg != null && containsDisconnectSignature(msg)) {
+            if (msg != null && DisconnectSignatures.matches(msg)) {
                 return true;
             }
         }
-        return false;
-    }
-
-    /** Message-substring match for wrapped disconnects. */
-    private static boolean containsDisconnectSignature(String msg) {
-        // POSIX / generic
-        if (msg.contains("Broken pipe")) return true;
-        if (msg.contains("Connection reset")) return true;
-        // Windows English — WSAECONNABORTED
-        if (msg.contains("connection was aborted")) return true;
-        if (msg.contains("established connection was aborted"))
-            return true;
-        if (msg.contains("existing connection was forcibly closed"))
-            return true;
-        // Windows Russian (ru_RU locale)
-        if (msg.contains("разорвала")) return true;
-        if (msg.contains("разорвано")) return true;
-        if (msg.contains("прервано")) return true;
-        // Windows German (de_DE)
-        if (msg.contains("Verbindung wurde")
-                && msg.contains("abgebrochen")) return true;
-        if (msg.contains("bestehende Verbindung wurde")) return true;
-        // Windows French (fr_FR)
-        if (msg.contains("connexion existante a")
-                && msg.contains("interrompue")) return true;
-        if (msg.contains("connexion a été abandonnée")) return true;
-        // Windows Spanish (es_ES)
-        if (msg.contains("conexión existente")
-                && msg.contains("forzosamente")) return true;
         return false;
     }
 


### PR DESCRIPTION
Two pure-logic extractions tied to coverage gaps in big handlers.

ReferenceCollector PureHelpers
- stripGenerics(String) and paramSig(IMethod) were package-private but only exercised incidentally through CollectFromMethod / CollectFromType. Add a PureHelpers nested class with four direct cases (stripGenerics generic / no-generic, paramSig no-arg / primitive pair).

HttpServer DisconnectSignatures
- 28-line locale-by-locale disconnect message matcher (Linux / macOS / Windows en/ru/de/fr/es) was a private static inside HttpServer. Pure logic with single responsibility (i18n disconnect detection) — extract to its own DisconnectSignatures class.
- DisconnectSignaturesTest covers each locale (11 positive cases) + negative cases (unrelated NPE, empty, partial-phrase guards for the multi-keyword `&&` shape).

Test plan
- [x] 713/713 plugin tests (was 695; +4 ReferenceCollector PureHelpers, +14 DisconnectSignaturesTest)
- [x] Live verify: fresh plugin installed in Eclipse, jdt test run on LaunchHandlerTest passes 43/43 with summary line in -f
- [x] CI Plugin build + CLI tests