### PR TITLE
Test smell cleanup + DRY helpers (review followups #11/#12/#14/#16/#22)

### DIFF
--- a/plugin.tests.ui/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
+++ b/plugin.tests.ui/src/io/github/kaluchi/jdtbridge/RefactoringIntegrationTest.java
@@ -69,8 +69,7 @@ public class RefactoringIntegrationTest {
     public void a3_organizeImportsFileNotFound() throws Exception {
         String json = handler.handleOrganizeImports(
                 Map.of("file", "/no/such/File.java"));
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
+        assertJsonError(json, "Java file not found");
     }
 
     // ---- Format ----
@@ -100,8 +99,7 @@ public class RefactoringIntegrationTest {
     public void b3_formatFileNotFound() throws Exception {
         String json = handler.handleFormat(
                 Map.of("file", "/no/such/File.java"));
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
+        assertJsonError(json, "Java file not found");
     }
 
     // ---- Rename method ----
@@ -200,31 +198,41 @@ public class RefactoringIntegrationTest {
     public void e1_renameMissingClass() throws Exception {
         String json = handler.handleRename(
                 Map.of("newName", "Foo"));
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
+        assertJsonError(json, "Missing 'class' parameter");
     }
 
     @Test
     public void e2_renameMissingNewName() throws Exception {
         String json = handler.handleRename(
                 Map.of("class", "test.model.Dog"));
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
+        assertJsonError(json, "Missing 'newName' parameter");
     }
 
     @Test
     public void e3_renameTypeNotFound() throws Exception {
         String json = handler.handleRename(
                 Map.of("class", "no.such.Type", "newName", "X"));
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
+        assertJsonError(json, "Type not found");
     }
 
     @Test
     public void e4_moveMissingTarget() throws Exception {
         String json = handler.handleMove(
                 Map.of("class", "test.model.Dog"));
-        assertTrue(json.contains("error"),
-                "Should return error: " + json);
+        assertJsonError(json, "Missing 'target' parameter");
+    }
+
+    private static void assertJsonError(
+            String json, String expectedFragment) {
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        org.junit.jupiter.api.Assertions.assertTrue(
+                obj.has("error"),
+                "Expected error field: " + json);
+        String error = obj.get("error").getAsString();
+        org.junit.jupiter.api.Assertions.assertTrue(
+                error.contains(expectedFragment),
+                "Expected '" + expectedFragment + "' in error: "
+                        + error);
     }
 }

--- a/plugin.tests.ui/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageLiveTest.java
+++ b/plugin.tests.ui/src/io/github/kaluchi/jdtbridge/coverage/TestRunCoverageLiveTest.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import io.github.kaluchi.jdtbridge.TestHandler;
+import io.github.kaluchi.jdtbridge.support.TestAwait;
 import io.github.kaluchi.jdtbridge.support.TestFixture;
 
 /**
@@ -49,31 +50,24 @@ public class TestRunCoverageLiveTest {
         TestFixture.destroy();
     }
 
-    /** Each coverage test launches a child JVM via CoverageLauncher.
-     *  handleTestRun returns immediately (non-blocking) with the
-     *  testRunId; the child JVM keeps holding bin/*.class file
-     *  handles until it exits. Wait here so each @Test leaves no
-     *  leaked process — match the launch by ATTR_LAUNCH_TIMESTAMP
-     *  encoded as the suffix of testRunId
-     *  ({@code configId:timestamp}, see TestHandler.handleTestRun). */
-    private static void awaitLaunchTerminated(String testRunId)
-            throws Exception {
+    /** handleTestRun returns immediately with the testRunId; the
+     *  child JVM keeps holding jdtbridge-test/bin/*.class until it
+     *  exits. Match the launch by ATTR_LAUNCH_TIMESTAMP suffix of
+     *  testRunId ({@code configId:timestamp}, see TestHandler). */
+    private static void awaitLaunchTerminated(String testRunId) {
         String timestamp = testRunId.substring(
                 testRunId.indexOf(':') + 1);
         var mgr = DebugPlugin.getDefault().getLaunchManager();
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (System.currentTimeMillis() < deadline) {
+        TestAwait.pollUntil(30_000, () -> {
             for (ILaunch l : mgr.getLaunches()) {
                 if (timestamp.equals(l.getAttribute(
                         DebugPlugin.ATTR_LAUNCH_TIMESTAMP))
                         && l.isTerminated()) {
-                    return;
+                    return true;
                 }
             }
-            Thread.onSpinWait();
-        }
-        throw new AssertionError(
-                "Launch did not terminate within 30s: " + testRunId);
+            return false;
+        }, "Launch did not terminate within 30s: " + testRunId);
     }
 
     @AfterEach

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpIntegrationTest.java
@@ -206,12 +206,13 @@ public class HttpIntegrationTest {
         String response = rawRequest("GET " + path + " HTTP/1.1",
                 "Host: localhost",
                 "Authorization: Bearer " + TOKEN);
-        // Extract body (after blank line)
         int bodyStart = response.indexOf("\r\n\r\n");
-        if (bodyStart >= 0) {
-            return response.substring(bodyStart + 4);
+        if (bodyStart < 0) {
+            throw new AssertionError(
+                    "HTTP response missing header/body separator: "
+                            + response);
         }
-        return response;
+        return response.substring(bodyStart + 4);
     }
 
     // /editors requires Display thread — tested live, not in headless CI

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -272,13 +272,13 @@ public class LaunchHandlerTest {
 
     private static JsonObject findByConfigId(
             com.google.gson.JsonArray arr, String configId) {
-        for (var el : arr) {
-            var obj = el.getAsJsonObject();
-            if (configId.equals(obj.get("configId").getAsString())) {
-                return obj;
-            }
-        }
-        return null;
+        return java.util.stream.StreamSupport
+                .stream(arr.spliterator(), false)
+                .map(com.google.gson.JsonElement::getAsJsonObject)
+                .filter(o -> configId.equals(
+                        o.get("configId").getAsString()))
+                .findFirst()
+                .orElseThrow();
     }
 
     @Nested

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LogTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LogTest.java
@@ -107,10 +107,9 @@ public class LogTest {
     }
 
     private IStatus lastForLevel(int severity) {
-        for (int i = captured.size() - 1; i >= 0; i--) {
-            IStatus s = captured.get(i);
-            if (s.getSeverity() == severity) return s;
-        }
-        return null;
+        return captured.stream()
+                .filter(s -> s.getSeverity() == severity)
+                .reduce((a, b) -> b)
+                .orElseThrow();
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/MavenIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/MavenIntegrationTest.java
@@ -94,10 +94,6 @@ public class MavenIntegrationTest {
         IWorkspaceRoot root =
                 ResourcesPlugin.getWorkspace().getRoot();
         IProject project = root.getProject(name);
-        if (project.exists()) {
-            project.delete(true, true, null);
-        }
-
         project.create(null);
         project.open(null);
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerTest.java
@@ -219,6 +219,27 @@ public class TestHandlerTest {
         assertEquals(JUNIT4_KIND, handler.detectTestKind(project));
     }
 
+    // ---- Unparseable jar name → manifest + classpath fallback ----
+
+    @Test
+    public void jarWithoutVersionFallsThroughToClasspathCheck() {
+        // jar name has no parseable version (extractVersion → null).
+        // resolveJUnitMajor then calls readManifestVersion, which
+        // reflectively probes PACKAGE_FRAGMENT_ROOT.getManifest()
+        // — the mock has no such method, so the reflective lookup
+        // throws and the version stays null. detectTestKind falls
+        // back to the classpath-path exclusion check; the mock
+        // entry path "/libs/stripped.jar" matches none of
+        // JUnit 3/4/5 container paths, so JUnit 6 (newest) wins.
+        // This mirrors Eclipse CoreTestSearchEngine's "unknown
+        // version on a non-excluded classpath" handling.
+        IJavaProject project = fakeProjectWithMarker(
+                TESTABLE, "stripped.jar");
+
+        assertEquals(JUNIT6_KIND, handler.detectTestKind(project));
+    }
+
+
     // ---- parseTimeout ----
 
     @Test
@@ -348,8 +369,7 @@ public class TestHandlerTest {
                             if ("getPath".equals(method.getName())) {
                                 return rawClasspathPath;
                             }
-                            return defaultValue(
-                                    method.getReturnType());
+                            throw notMocked(method);
                         });
 
         IPackageFragmentRoot root = (IPackageFragmentRoot)
@@ -361,8 +381,7 @@ public class TestHandlerTest {
                                     method.getName())) {
                                 return entry;
                             }
-                            return defaultValue(
-                                    method.getReturnType());
+                            throw notMocked(method);
                         });
 
         IPath binaryPath = new Path("/repo/" + jarName);
@@ -386,8 +405,14 @@ public class TestHandlerTest {
                                     .equals(args[0])) {
                         return root;
                     }
-                    return defaultValue(method.getReturnType());
+                    throw notMocked(method);
                 });
+    }
+
+    private static UnsupportedOperationException notMocked(
+            java.lang.reflect.Method method) {
+        return new UnsupportedOperationException(
+                "method not mocked: " + method.getName());
     }
 
     private Object defaultValue(Class<?> returnType) {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestProgressStreamerTest.java
@@ -52,7 +52,7 @@ public class TestProgressStreamerTest {
                 "handleTestRun must succeed: " + json);
         String testRunId = obj.get("testRunId").getAsString();
 
-        session = awaitFinishedSession(testRunId, 60_000);
+        session = TestSessionAwait.awaitFinished(testRunId, 60_000);
         assertNotNull(session,
                 "Launched session must finish within 60s: "
                         + testRunId);
@@ -116,24 +116,4 @@ public class TestProgressStreamerTest {
         assertEquals("PASS", event.get("status").getAsString());
     }
 
-    /** Spin-poll JUnit's session model until the session whose
-     *  testRunId matches finishes (not running, not starting),
-     *  or the deadline expires. Returns the session or null on
-     *  timeout. */
-    private static TestRunSession awaitFinishedSession(
-            String testRunId, long maxMs) {
-        long deadline = System.currentTimeMillis() + maxMs;
-        while (System.currentTimeMillis() < deadline) {
-            for (TestRunSession s : JUnitCorePlugin.getModel()
-                    .getTestRunSessions()) {
-                if (testRunId.equals(
-                        TestSessionHandler.testRunId(s))
-                        && !s.isRunning() && !s.isStarting()) {
-                    return s;
-                }
-            }
-            Thread.onSpinWait();
-        }
-        return null;
-    }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionAwait.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionAwait.java
@@ -1,0 +1,46 @@
+package io.github.kaluchi.jdtbridge;
+
+import io.github.kaluchi.jdtbridge.support.TestAwait;
+
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+import org.eclipse.jdt.junit.model.ITestElement.Result;
+
+/**
+ * Locate a {@link TestRunSession} produced by
+ * {@link TestHandler#handleTestRun} and wait until per-case events
+ * have been applied to the model — package-private fragment-only
+ * helper because {@link TestSessionHandler#testRunId} is not
+ * exported.
+ */
+@SuppressWarnings("restriction")
+final class TestSessionAwait {
+
+    private TestSessionAwait() {
+    }
+
+    /** Lifecycle flags ({@code !isRunning && !isStarting}) flip
+     *  before the streamed PASS/FAIL events land — slower CI runners
+     *  observe status=UNKNOWN if we read at that moment.
+     *  {@link TestRunSession#getTestResult(boolean)} stays UNDEFINED
+     *  until every child case has been evaluated. */
+    static TestRunSession awaitFinished(String testRunId,
+            long timeoutMs) {
+        TestRunSession[] result = new TestRunSession[1];
+        TestAwait.pollUntil(timeoutMs, () -> {
+            for (TestRunSession s : JUnitCorePlugin.getModel()
+                    .getTestRunSessions()) {
+                if (testRunId.equals(
+                        TestSessionHandler.testRunId(s))
+                        && !s.isRunning() && !s.isStarting()
+                        && s.getTestResult(true) != Result.UNDEFINED) {
+                    result[0] = s;
+                    return true;
+                }
+            }
+            return false;
+        }, "Launched session did not finish within "
+                + timeoutMs + "ms: " + testRunId);
+        return result[0];
+    }
+}

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionFormatTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionFormatTest.java
@@ -56,11 +56,12 @@ public class TestSessionFormatTest {
         }
 
         @Test
-        void unknownFilterValueIncludesEverything() {
-            // Unrecognised filter falls through to "include" rather
-            // than rejecting all events — matches existing behaviour.
-            assertTrue(TestSessionFormat.streamerFilter("PASS", "garbage"));
-            assertTrue(TestSessionFormat.streamerFilter("FAIL", ""));
+        void unknownFilterValueExcludes() {
+            // fail-closed for typos — silent flood is worse than
+            // an empty stream the caller can spot immediately.
+            assertFalse(TestSessionFormat.streamerFilter("PASS", "garbage"));
+            assertFalse(TestSessionFormat.streamerFilter("FAIL", ""));
+            assertFalse(TestSessionFormat.streamerFilter("IGNORED", "skipped"));
         }
     }
 
@@ -161,11 +162,11 @@ public class TestSessionFormatTest {
         }
 
         @Test
-        void canGoNegative() {
-            // Bridge does not clamp — caller's responsibility
-            // when bookkeeping disagrees with started count.
-            assertEquals(-1,
+        void clampsAtZeroWhenBucketsExceedStarted() {
+            assertEquals(0,
                     TestSessionFormat.passedCount(0, 1, 0, 0));
+            assertEquals(0,
+                    TestSessionFormat.passedCount(2, 5, 0, 0));
         }
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionTrackerTest.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
 import org.eclipse.jdt.internal.junit.model.TestRunSession;
-import org.eclipse.jdt.junit.model.ITestElement.Result;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,30 +44,8 @@ public class TestSessionTrackerTest {
                 .getAsJsonObject();
         assertTrue(obj.get("ok").getAsBoolean(),
                 "handleTestRun must succeed: " + json);
-        String testRunId = obj.get("testRunId").getAsString();
-
-        // Lifecycle flags (!isRunning && !isStarting) flip before
-        // per-case PASS/FAIL events from the child JVM stream are
-        // applied to the model — observable on slower CI runners,
-        // where assertions then see status=UNKNOWN. Wait for the
-        // aggregated result to leave UNDEFINED.
-        long deadline = System.currentTimeMillis() + 60_000;
-        while (System.currentTimeMillis() < deadline) {
-            for (TestRunSession s : JUnitCorePlugin.getModel()
-                    .getTestRunSessions()) {
-                if (testRunId.equals(
-                        TestSessionHandler.testRunId(s))
-                        && !s.isRunning() && !s.isStarting()
-                        && s.getTestResult(true) != Result.UNDEFINED) {
-                    finishedSession = s;
-                    return;
-                }
-            }
-            Thread.onSpinWait();
-        }
-        throw new AssertionError(
-                "Launched session did not finish within 60s: "
-                        + testRunId);
+        finishedSession = TestSessionAwait.awaitFinished(
+                obj.get("testRunId").getAsString(), 60_000);
     }
 
     @AfterAll

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestSessionFormat.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestSessionFormat.java
@@ -33,10 +33,13 @@ final class TestSessionFormat {
     }
 
     /** Bridge-side {@code passed} count: started minus every
-     *  non-passing bucket (failures, errors, assumption failures). */
+     *  non-passing bucket (failures, errors, assumption failures).
+     *  Clamped at 0 — over-counting buckets must not surface a
+     *  negative wire field. */
     static int passedCount(int started, int failures, int errors,
             int assumptionFailures) {
-        return started - failures - errors - assumptionFailures;
+        return Math.max(0,
+                started - failures - errors - assumptionFailures);
     }
 
     /** Attach {@code trace}/{@code expected}/{@code actual} to
@@ -52,8 +55,9 @@ final class TestSessionFormat {
     }
 
     /** Streamer-side filter: null/"all" includes everything,
-     *  "failures" → only FAIL/ERROR, "ignored" → only IGNORED,
-     *  any other value falls back to "include". */
+     *  "failures" → only FAIL/ERROR, "ignored" → only IGNORED.
+     *  Unknown filter values are fail-closed (excluded) — fail-open
+     *  silently floods the stream when a typo reaches the bridge. */
     static boolean streamerFilter(String status, String filter) {
         if (filter == null || "all".equals(filter)) return true;
         if ("failures".equals(filter))
@@ -61,6 +65,6 @@ final class TestSessionFormat {
                     || "ERROR".equals(status);
         if ("ignored".equals(filter))
             return "IGNORED".equals(status);
-        return true;
+        return false;
     }
 }

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/TestAwait.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/TestAwait.java
@@ -1,0 +1,34 @@
+package io.github.kaluchi.jdtbridge.support;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Deadline-bounded poll for asynchronous Eclipse state — sessions
+ * landing in the model, launches terminating, jobs draining. The
+ * poll parks for 50 ms between checks so a hot CI runner does not
+ * burn a core on Thread.onSpinWait while waiting on I/O-paced
+ * events.
+ */
+public final class TestAwait {
+
+    private static final long PARK_NANOS =
+            TimeUnit.MILLISECONDS.toNanos(50);
+
+    private TestAwait() {
+    }
+
+    /** Park-poll {@code condition} every 50 ms until it returns
+     *  true or {@code timeoutMs} elapses. Throws AssertionError with
+     *  {@code timeoutMessage} on timeout — never returns false. */
+    public static void pollUntil(long timeoutMs,
+            BooleanSupplier condition, String timeoutMessage) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) return;
+            LockSupport.parkNanos(PARK_NANOS);
+        }
+        throw new AssertionError(timeoutMessage);
+    }
+}

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
@@ -365,8 +365,6 @@ public class TestFixture {
             }
             """;
 
-    // ---- Refactoring targets (separate classes that can be renamed/moved) ----
-
     // ---- Generic erasure testing ----
 
     private static final String GENERIC_CALLER_SRC = """


### PR DESCRIPTION
## Summary

Address remaining test-side smells from PR #123 review and start the test-coverage drill.

Behavioural fixes
- TestSessionFormat.passedCount: clamp at 0 (no more negative wire field on bucket over-count)
- TestSessionFormat.streamerFilter: fail-closed for unknown filter values (silent flood was worse than empty stream)

DRY
- tests.support/TestAwait.pollUntil — 50 ms parkNanos polling, single source of truth
- plugin.tests/TestSessionAwait.awaitFinished — domain helper that waits for !isRunning/isStarting AND getTestResult(true) != UNDEFINED. Replaces three hand-rolled Thread.onSpinWait spin-loops.

Smell cleanup
- RefactoringIntegrationTest: 6 weak `json.contains("error")` checks → exact-fragment assertions
- TestFixture: duplicate section header removed
- LogTest / LaunchHandlerTest helpers: `return null` defensive paths → stream/orElseThrow
- TestHandlerTest.fakeType: defensive `defaultValue(...)` returns → loud `throw notMocked(method)`; new test covers the previously-orphan readManifestVersion/getRawClasspathPath path
- MavenIntegrationTest, HttpIntegrationTest: dead defensive branches removed

## Test plan
- [x] mvn verify locally: 821 headless + 17 UI = 838 passed, 0 skipped
- [ ] CI passes