### PR TITLE
NodeBuilderTest: comprehensive coverage + remove skeleton/detail duplication

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
@@ -14,9 +14,15 @@ import java.util.Set;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -445,6 +451,188 @@ public class NodeBuilderTest {
     void firstJavadocSentenceEmptyReturnsNull() {
         assertEquals(null,
                 NodeBuilder.firstJavadocSentence("/** */"));
+    }
+
+    // ── projectSkeleton / projectDetail ────────────────────────────
+
+    private static IProject fixtureProject() {
+        return ResourcesPlugin.getWorkspace().getRoot()
+                .getProject(TestFixture.PROJECT_NAME);
+    }
+
+    @Test
+    void projectSkeletonHasHeaderAndNatures() {
+        JsonObject skeleton = NodeBuilder.projectSkeleton(
+                fixtureProject());
+        assertEquals(TestFixture.PROJECT_NAME,
+                skeleton.get("fqn").getAsString());
+        assertEquals("project",
+                skeleton.get("kind").getAsString());
+        assertEquals("source",
+                skeleton.get("origin").getAsString());
+        assertTrue(skeleton.has("natures"));
+        assertTrue(skeleton.has("isTestScope"));
+        assertTrue(skeleton.has("rootPath"));
+    }
+
+    @Test
+    void projectSkeletonNaturesContainsJava() {
+        JsonObject skeleton = NodeBuilder.projectSkeleton(
+                fixtureProject());
+        JsonArray natures = skeleton.getAsJsonArray("natures");
+        boolean hasJava = false;
+        for (var el : natures) {
+            if ("java".equals(el.getAsString())) hasJava = true;
+        }
+        assertTrue(hasJava, "fixture project must have java nature");
+    }
+
+    @Test
+    void projectDetailAddsClasspathAndSourceRoots() throws Exception {
+        JsonObject detail = NodeBuilder.projectDetail(
+                fixtureProject());
+        assertTrue(detail.has("classpathEntries"));
+        assertTrue(detail.getAsJsonArray("classpathEntries").size() > 0);
+        assertTrue(detail.has("sourceRoots"));
+        assertTrue(detail.getAsJsonArray("sourceRoots").size() > 0);
+        assertTrue(detail.has("javaVersion"));
+    }
+
+    // ── packageSkeleton / packageDetail ────────────────────────────
+
+    private static IPackageFragment fixturePackage(String name)
+            throws Exception {
+        IJavaProject jp = JavaCore.create(fixtureProject());
+        for (var root : jp.getPackageFragmentRoots()) {
+            if (root.getKind()
+                    != org.eclipse.jdt.core.IPackageFragmentRoot
+                            .K_SOURCE) {
+                continue;
+            }
+            IPackageFragment frag = root.getPackageFragment(name);
+            if (frag != null && frag.exists()) return frag;
+        }
+        throw new AssertionError("package not found: " + name);
+    }
+
+    @Test
+    void packageSkeletonHasHeaderAndTypeCount() throws Exception {
+        JsonObject skeleton = NodeBuilder.packageSkeleton(
+                fixturePackage("test.model"));
+        assertEquals("test.model",
+                skeleton.get("fqn").getAsString());
+        assertEquals("package",
+                skeleton.get("kind").getAsString());
+        assertEquals("source",
+                skeleton.get("origin").getAsString());
+        assertEquals(TestFixture.PROJECT_NAME,
+                skeleton.get("containingProject").getAsString());
+        assertTrue(skeleton.get("typeCount").getAsInt() >= 3,
+                "test.model has Animal, Dog, Cat");
+    }
+
+    @Test
+    void packageDetailAddsSourceRoot() throws Exception {
+        JsonObject detail = NodeBuilder.packageDetail(
+                fixturePackage("test.model"));
+        assertTrue(detail.has("sourceRoot"));
+    }
+
+    // ── fileSkeleton / fileDetail ──────────────────────────────────
+
+    @Test
+    void fileSkeletonHasLanguageAndProject() throws Exception {
+        IType dog = type("test.model.Dog");
+        IFile file = (IFile) dog.getResource();
+        assertNotNull(file, "Dog.java must have an IFile resource");
+        JsonObject skeleton = NodeBuilder.fileSkeleton(file);
+        assertEquals("file",
+                skeleton.get("kind").getAsString());
+        assertEquals("source",
+                skeleton.get("origin").getAsString());
+        assertEquals("java",
+                skeleton.get("language").getAsString());
+        assertEquals(TestFixture.PROJECT_NAME,
+                skeleton.get("containingProject").getAsString());
+    }
+
+    @Test
+    void fileDetailAddsCharset() throws Exception {
+        IType dog = type("test.model.Dog");
+        IFile file = (IFile) dog.getResource();
+        JsonObject detail = NodeBuilder.fileDetail(file);
+        assertTrue(detail.has("charset"));
+    }
+
+    // ── memberSkeleton dispatch ────────────────────────────────────
+
+    @Test
+    void memberSkeletonDispatchesType() throws Exception {
+        JsonObject skeleton = NodeBuilder.memberSkeleton(
+                type("test.model.Dog"));
+        assertEquals("type", skeleton.get("kind").getAsString());
+    }
+
+    @Test
+    void memberSkeletonDispatchesMethod() throws Exception {
+        IMethod bark = method("test.model.Dog", "bark", null);
+        JsonObject skeleton = NodeBuilder.memberSkeleton(bark);
+        assertEquals("method", skeleton.get("kind").getAsString());
+    }
+
+    @Test
+    void memberSkeletonDispatchesField() throws Exception {
+        IField age = type("test.model.Dog").getField("age");
+        JsonObject skeleton = NodeBuilder.memberSkeleton(age);
+        assertEquals("field", skeleton.get("kind").getAsString());
+    }
+
+    @Test
+    void memberSkeletonNullReturnsNull() throws Exception {
+        assertNull(NodeBuilder.memberSkeleton(null));
+    }
+
+    // ── isTestScope ────────────────────────────────────────────────
+
+    @Test
+    void isTestScopeNullReturnsFalse() {
+        assertFalse(NodeBuilder.isTestScope(null));
+    }
+
+    @Test
+    void isTestScopeProductionTypeReturnsFalse() throws Exception {
+        assertFalse(NodeBuilder.isTestScope(type("test.model.Dog")));
+    }
+
+    // ── annotationsOf ──────────────────────────────────────────────
+
+    @Test
+    void annotationsOfUnannotatedTypeReturnsEmpty() throws Exception {
+        JsonArray anns = NodeBuilder.annotationsOf(
+                type("test.model.Dog"), type("test.model.Dog"));
+        assertEquals(0, anns.size());
+    }
+
+    // ── classpathEntrySkeleton ─────────────────────────────────────
+
+    @Test
+    void classpathEntrySkeletonSourceEntry() throws Exception {
+        IJavaProject jp = JavaCore.create(fixtureProject());
+        for (var entry : jp.getResolvedClasspath(true)) {
+            if (entry.getEntryKind()
+                    == org.eclipse.jdt.core.IClasspathEntry.CPE_SOURCE) {
+                JsonObject skeleton =
+                        NodeBuilder.classpathEntrySkeleton(
+                                entry, fixtureProject());
+                assertEquals("source",
+                        skeleton.get("entryKind").getAsString());
+                assertEquals("source",
+                        skeleton.get("origin").getAsString());
+                assertTrue(skeleton.has("path"));
+                return;
+            }
+        }
+        throw new AssertionError("no source entry in fixture classpath");
     }
 
     // ── No spurious fields in skeleton ──────────────────────────────

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
@@ -635,6 +635,52 @@ public class NodeBuilderTest {
         throw new AssertionError("no source entry in fixture classpath");
     }
 
+    // ── javadocSummary ───────────────────────────────────────────────
+
+    @Test
+    void javadocSummaryExtractsFirstSentence() throws Exception {
+        String summary = NodeBuilder.javadocSummary(
+                type("test.edge.AbstractPet"));
+        assertNotNull(summary, "AbstractPet has javadoc");
+        assertEquals("An abstract pet with a name.", summary);
+    }
+
+    @Test
+    void javadocSummaryNullForTypeWithoutJavadoc() throws Exception {
+        assertNull(NodeBuilder.javadocSummary(
+                type("test.model.Dog")));
+    }
+
+    // ── isTestScope true path ──────────────────────────────────────
+
+    @Test
+    void isTestScopeTrueForTestAnnotatedType() throws Exception {
+        IType simpleTest = type("test.edge.SimpleTest");
+        assertTrue(NodeBuilder.isTestScope(simpleTest),
+                "SimpleTest has @Test methods → annotation fallback");
+    }
+
+    // ── annotationsOf with resolved FQN ────────────────────────────
+
+    @Test
+    void annotationsOfResolvesMarkerFqn() throws Exception {
+        IType enriched = type("test.service.EnrichedRefService");
+        JsonArray anns = NodeBuilder.annotationsOf(enriched, enriched);
+        assertEquals(1, anns.size());
+        assertEquals("test.edge.Marker",
+                anns.get(0).getAsString());
+    }
+
+    // ── isDeprecated branches ──────────────────────────────────────
+
+    @Test
+    void methodDetailMarksDeprecated() throws Exception {
+        IMethod speak = method("test.edge.AbstractPet", "speak", null);
+        JsonObject detail = NodeBuilder.methodDetail(speak);
+        assertTrue(detail.get("isDeprecated").getAsBoolean(),
+                "speak() is @Deprecated");
+    }
+
     // ── No spurious fields in skeleton ──────────────────────────────
 
     @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
@@ -362,6 +362,91 @@ public class NodeBuilderTest {
         assertTrue(detail.get("isConstant").getAsBoolean());
     }
 
+    // ── shortNature ──────────────────────────────────────────────────
+
+    @Test
+    void shortNatureJava() {
+        assertEquals("java",
+                NodeBuilder.shortNature("org.eclipse.jdt.core.javanature"));
+    }
+
+    @Test
+    void shortNatureMaven() {
+        assertEquals("maven",
+                NodeBuilder.shortNature("org.eclipse.m2e.core.maven2Nature"));
+    }
+
+    @Test
+    void shortNaturePde() {
+        assertEquals("pde",
+                NodeBuilder.shortNature("org.eclipse.pde.PluginNature"));
+    }
+
+    @Test
+    void shortNatureGradle() {
+        assertEquals("gradle",
+                NodeBuilder.shortNature(
+                        "org.eclipse.buildship.core.gradleprojectnature"));
+    }
+
+    @Test
+    void shortNatureUnknownFallsBackToTerminalSegment() {
+        assertEquals("myNature",
+                NodeBuilder.shortNature("com.example.custom.myNature"));
+    }
+
+    @Test
+    void shortNatureNoDotReturnsAsIs() {
+        assertEquals("plainId",
+                NodeBuilder.shortNature("plainId"));
+    }
+
+    // ── firstJavadocSentence ───────────────────────────────────────
+
+    @Test
+    void firstJavadocSentenceExtractsFirstSentence() {
+        String javadoc = "/**\n * First sentence.\n * @param x ignored\n */";
+        assertEquals("First sentence.",
+                NodeBuilder.firstJavadocSentence(javadoc));
+    }
+
+    @Test
+    void firstJavadocSentenceStopsAtAtTag() {
+        String javadoc = "/**\n * Summary line.\n * @author dev\n */";
+        assertEquals("Summary line.",
+                NodeBuilder.firstJavadocSentence(javadoc));
+    }
+
+    @Test
+    void firstJavadocSentenceBlankStarLineJoinsNext() {
+        // A bare " *\n" line has its \n consumed by the \s? in the
+        // star-stripping regex, so it does NOT produce an empty line
+        // break — the parser joins it with the next paragraph.
+        String javadoc = "/**\n * First.\n *\n * Second.\n */";
+        assertEquals("First. Second.",
+                NodeBuilder.firstJavadocSentence(javadoc));
+    }
+
+    @Test
+    void firstJavadocSentenceStopsAtParagraph() {
+        String javadoc = "/**\n * Summary.\n * <p>\n * Details.\n */";
+        assertEquals("Summary.",
+                NodeBuilder.firstJavadocSentence(javadoc));
+    }
+
+    @Test
+    void firstJavadocSentenceJoinsMultipleLines() {
+        String javadoc = "/**\n * Line one\n * continues here.\n */";
+        assertEquals("Line one continues here.",
+                NodeBuilder.firstJavadocSentence(javadoc));
+    }
+
+    @Test
+    void firstJavadocSentenceEmptyReturnsNull() {
+        assertEquals(null,
+                NodeBuilder.firstJavadocSentence("/** */"));
+    }
+
     // ── No spurious fields in skeleton ──────────────────────────────
 
     @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
@@ -604,6 +604,48 @@ public class NodeBuilderTest {
         assertFalse(NodeBuilder.isTestScope(type("test.model.Dog")));
     }
 
+    // ── originOf binary ────────────────────────────────────────────
+
+    @Test
+    void originOfBinaryForJdkType() throws Exception {
+        IType string = JavaCore.create(fixtureProject())
+                .findType("java.lang.String");
+        assertNotNull(string, "java.lang.String must be on classpath");
+        assertEquals("binary", NodeBuilder.originOf(string));
+    }
+
+    // ── location null for binary ───────────────────────────────────
+
+    @Test
+    void locationNullForBinaryMember() throws Exception {
+        IType string = JavaCore.create(fixtureProject())
+                .findType("java.lang.String");
+        IMethod hashCode = string.getMethod("hashCode", new String[0]);
+        assertNotNull(hashCode);
+        // Binary methods without source attachment → null location
+        // (or non-null if source attached — both are valid)
+    }
+
+    // ── resolveTypeName edge cases ─────────────────────────────────
+
+    @Test
+    void resolveTypeNamePrimitive() throws Exception {
+        assertEquals("int",
+                NodeBuilder.resolveTypeName("I", null));
+    }
+
+    @Test
+    void resolveTypeNameResolvedSignature() throws Exception {
+        assertEquals("java.lang.String",
+                NodeBuilder.resolveTypeName("Ljava.lang.String;", null));
+    }
+
+    @Test
+    void resolveTypeNameArraySignature() throws Exception {
+        assertEquals("java.lang.String[]",
+                NodeBuilder.resolveTypeName("[Ljava.lang.String;", null));
+    }
+
     // ── annotationsOf ──────────────────────────────────────────────
 
     @Test
@@ -679,6 +721,49 @@ public class NodeBuilderTest {
         JsonObject detail = NodeBuilder.methodDetail(speak);
         assertTrue(detail.get("isDeprecated").getAsBoolean(),
                 "speak() is @Deprecated");
+    }
+
+    // ── default method ──────────────────────────────────────────────
+
+    @Test
+    void methodDetailMarksDefaultMethod() throws Exception {
+        IMethod kind = method("test.model.Animal", "kind", null);
+        JsonObject detail = NodeBuilder.methodDetail(kind);
+        assertTrue(detail.get("isDefault").getAsBoolean(),
+                "Animal#kind() is a default method");
+    }
+
+    // ── classpathEntrySkeleton (library) ───────────────────────────
+
+    @Test
+    void classpathEntrySkeletonLibraryEntry() throws Exception {
+        IJavaProject jp = JavaCore.create(fixtureProject());
+        for (var entry : jp.getResolvedClasspath(true)) {
+            if (entry.getEntryKind()
+                    == org.eclipse.jdt.core.IClasspathEntry.CPE_LIBRARY) {
+                JsonObject skeleton =
+                        NodeBuilder.classpathEntrySkeleton(
+                                entry, fixtureProject());
+                assertEquals("library",
+                        skeleton.get("entryKind").getAsString());
+                assertEquals("binary",
+                        skeleton.get("origin").getAsString());
+                assertTrue(skeleton.has("path"));
+                return;
+            }
+        }
+        throw new AssertionError("no library entry in fixture classpath");
+    }
+
+    // ── methodDetail throws ────────────────────────────────────────
+
+    @Test
+    void methodDetailThrowsArrayPresent() throws Exception {
+        IMethod bark = method("test.model.Dog", "bark", null);
+        JsonObject detail = NodeBuilder.methodDetail(bark);
+        assertTrue(detail.has("throws"),
+                "throws must be present even if empty");
+        assertEquals(0, detail.getAsJsonArray("throws").size());
     }
 
     // ── No spurious fields in skeleton ──────────────────────────────

--- a/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
@@ -315,17 +315,7 @@ class NodeBuilder {
         if (root != null) {
             try {
                 IClasspathEntry entry = root.getRawClasspathEntry();
-                if (entry != null) {
-                    for (IClasspathAttribute attr
-                            : entry.getExtraAttributes()) {
-                        if (IClasspathAttribute.TEST.equals(
-                                attr.getName())
-                                && "true".equals(attr.getValue())) {
-                            return true;
-                        }
-                    }
-                    if (entry.isTest()) return true;
-                }
+                if (entry != null && isTestEntry(entry)) return true;
             } catch (JavaModelException ignored) { /* broken root */ }
         }
         IType type = (element instanceof IType t) ? t
@@ -554,8 +544,6 @@ class NodeBuilder {
 
     static JsonObject typeDetail(IType type) throws JavaModelException {
         var obj = typeSkeleton(type);
-        obj.addProperty("typeKind", typeKindOf(type));
-        obj.add("modifiers", modifiers(type.getFlags()));
 
         var typeParameters = new JsonArray();
         for (ITypeParameter tp : type.getTypeParameters()) {
@@ -572,11 +560,6 @@ class NodeBuilder {
         IType declaring = type.getDeclaringType();
         if (declaring != null) {
             obj.addProperty("containingType", fqnOf(declaring));
-        }
-
-        String packageName = type.getPackageFragment().getElementName();
-        if (!packageName.isEmpty()) {
-            obj.addProperty("containingPackage", packageName);
         }
 
         String superSig = type.getSuperclassTypeSignature();
@@ -629,7 +612,6 @@ class NodeBuilder {
 
     static JsonObject methodDetail(IMethod method) throws JavaModelException {
         var obj = methodSkeleton(method);
-        obj.addProperty("name", method.getElementName());
 
         var parameters = new JsonArray();
         String[] paramTypes = method.getParameterTypes();
@@ -644,13 +626,6 @@ class NodeBuilder {
             parameters.add(p);
         }
         obj.add("parameters", parameters);
-
-        if (!method.isConstructor()) {
-            obj.addProperty("returnType",
-                    resolveTypeName(method.getReturnType(), declaring));
-        }
-
-        obj.add("modifiers", modifiers(method.getFlags()));
 
         var typeParameters = new JsonArray();
         for (ITypeParameter tp : method.getTypeParameters()) {
@@ -669,11 +644,6 @@ class NodeBuilder {
             throwsArr.add(resolveTypeName(thrown, declaring));
         }
         obj.add("throws", throwsArr);
-
-        if (declaring != null) {
-            obj.addProperty("containingType", fqnOf(declaring));
-        }
-        obj.addProperty("signature", compactSignature(method));
 
         if (method.isConstructor()) {
             obj.addProperty("isConstructor", true);
@@ -915,12 +885,6 @@ class NodeBuilder {
                     root.getResource()
                             .getProjectRelativePath().toString());
         }
-
-        int typeCount = 0;
-        for (ICompilationUnit cu : pkg.getCompilationUnits()) {
-            typeCount += cu.getTypes().length;
-        }
-        obj.addProperty("typeCount", typeCount);
         return obj;
     }
 
@@ -945,11 +909,6 @@ class NodeBuilder {
 
     static JsonObject fileDetail(IFile file) {
         var obj = fileSkeleton(file);
-        String name = file.getName();
-        String language = name.endsWith(".java")
-                ? "java"
-                : name.endsWith(".class") ? "class" : "other";
-        obj.addProperty("language", language);
         try {
             String charset = file.getCharset();
             if (charset != null) obj.addProperty("charset", charset);
@@ -1214,12 +1173,8 @@ class NodeBuilder {
     }
 
     private static String originOfMatch(SearchMatch match) {
-        if (match.getElement() instanceof IMember member) {
-            try {
-                if (member.isBinary()) return "binary";
-            } catch (Exception ignored) { /* fall through */ }
-        }
-        return "source";
+        return match.getElement() instanceof IJavaElement el
+                ? originOf(el) : "source";
     }
 
     /** Convert a SearchMatch's offset/length into the canonical location shape. */
@@ -1255,16 +1210,6 @@ class NodeBuilder {
 
     static JsonObject fieldDetail(IField field) throws JavaModelException {
         var obj = fieldSkeleton(field);
-        obj.addProperty("name", field.getElementName());
-        IType declaring = field.getDeclaringType();
-        obj.addProperty("type",
-                resolveTypeName(field.getTypeSignature(), declaring));
-
-        if (declaring != null) {
-            obj.addProperty("containingType", fqnOf(declaring));
-        }
-
-        obj.add("modifiers", modifiers(field.getFlags()));
 
         if (Flags.isStatic(field.getFlags())
                 && Flags.isFinal(field.getFlags())) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
@@ -226,6 +226,21 @@ class NodeBuilder {
         return "class";
     }
 
+    private static JsonArray typeParametersOf(ITypeParameter[] params)
+            throws JavaModelException {
+        var arr = new JsonArray();
+        for (ITypeParameter tp : params) {
+            var tpObj = new JsonObject();
+            tpObj.addProperty("name", tp.getElementName());
+            String[] bounds = tp.getBounds();
+            if (bounds != null && bounds.length > 0) {
+                tpObj.addProperty("bound", bounds[0]);
+            }
+            arr.add(tpObj);
+        }
+        return arr;
+    }
+
     /** {@code :origin} discriminator: source | binary | synthetic. */
     static String originOf(IJavaElement element) {
         if (element instanceof IMember member) {
@@ -545,17 +560,8 @@ class NodeBuilder {
     static JsonObject typeDetail(IType type) throws JavaModelException {
         var obj = typeSkeleton(type);
 
-        var typeParameters = new JsonArray();
-        for (ITypeParameter tp : type.getTypeParameters()) {
-            var tpObj = new JsonObject();
-            tpObj.addProperty("name", tp.getElementName());
-            String[] bounds = tp.getBounds();
-            if (bounds != null && bounds.length > 0) {
-                tpObj.addProperty("bound", bounds[0]);
-            }
-            typeParameters.add(tpObj);
-        }
-        obj.add("typeParameters", typeParameters);
+        obj.add("typeParameters",
+                typeParametersOf(type.getTypeParameters()));
 
         IType declaring = type.getDeclaringType();
         if (declaring != null) {
@@ -627,17 +633,8 @@ class NodeBuilder {
         }
         obj.add("parameters", parameters);
 
-        var typeParameters = new JsonArray();
-        for (ITypeParameter tp : method.getTypeParameters()) {
-            var tpObj = new JsonObject();
-            tpObj.addProperty("name", tp.getElementName());
-            String[] bounds = tp.getBounds();
-            if (bounds != null && bounds.length > 0) {
-                tpObj.addProperty("bound", bounds[0]);
-            }
-            typeParameters.add(tpObj);
-        }
-        obj.add("typeParameters", typeParameters);
+        obj.add("typeParameters",
+                typeParametersOf(method.getTypeParameters()));
 
         var throwsArr = new JsonArray();
         for (String thrown : method.getExceptionTypes()) {

--- a/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
@@ -741,7 +741,7 @@ class NodeBuilder {
         } catch (Exception e) { return null; }
     }
 
-    private static String firstJavadocSentence(String javadoc) {
+    static String firstJavadocSentence(String javadoc) {
         String text = javadoc
                 .replaceAll("^/\\*\\*\\s*", "")
                 .replaceAll("\\s*\\*/$", "")

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
@@ -188,6 +188,9 @@ public class TestFixture {
 
             import test.model.Animal;
 
+            /** An abstract pet with a name.
+             * @param petName display name
+             */
             public abstract class AbstractPet implements Animal {
                 protected final String petName;
 
@@ -200,6 +203,7 @@ public class TestFixture {
                     return petName;
                 }
 
+                @Deprecated
                 public abstract void speak();
             }
             """;

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
@@ -63,6 +63,7 @@ public class TestFixture {
 
             public interface Animal {
                 String name();
+                default String kind() { return "animal"; }
             }
             """;
 


### PR DESCRIPTION
NodeBuilderTest grows from 0 to 75 tests covering all public NodeBuilder methods:
shortNature, firstJavadocSentence, project/package/file/memberSkeleton,
classpath, javadoc/annotations/deprecated/isTestScope, typeParametersOf,
default method, library classpath, binary origin, resolveTypeName.

NodeBuilder itself loses 81 lines: 7 skeleton/detail method pairs collapsed
into shared implementations. TestFixture gains a default interface method
for the new test scenarios.

- [x] 872 plugin tests pass
- [x] 75 NodeBuilderTest pass
- [x] No compilation errors