### PR TITLE
GraphHandler DRY + dedup + coverage boost for TestSession/Test/LaunchHandler

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
@@ -174,12 +174,15 @@ public class GraphHandlerTest {
     }
 
     @Test
-    void methodRejectsMissingHash() {
+    void methodRejectsTypeSubject() {
         JsonObject result = parse(handler.handleMethod(
                 params("of", "test.model.Dog")));
         assertTrue(isError(result));
-        assertEquals("invalid-fqn",
+        assertEquals("wrong-subject-kind",
                 errorOf(result).get("kind").getAsString());
+        assertEquals("method",
+                errorOf(result).getAsJsonObject("context")
+                .get("expected").getAsString());
     }
 
     @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
@@ -217,6 +217,18 @@ public class GraphHandlerTest {
     }
 
     @Test
+    void fieldRejectsMethodFqn() {
+        JsonObject result = parse(handler.handleField(
+                params("of", "test.model.Dog#bark")));
+        assertTrue(isError(result));
+        assertEquals("wrong-subject-kind",
+                errorOf(result).get("kind").getAsString());
+        assertEquals("field",
+                errorOf(result).getAsJsonObject("context")
+                .get("expected").getAsString());
+    }
+
+    @Test
     void fieldRejectsParensInName() {
         JsonObject result = parse(handler.handleField(
                 params("of", "test.model.Dog#age()")));
@@ -975,6 +987,59 @@ public class GraphHandlerTest {
         assertTrue(names.contains("test.service"));
         assertTrue(names.contains("test.edge"));
         assertTrue(names.contains("test.refactor"));
+    }
+
+    // ── /file ────────────────────────────────────────────────────────
+
+    @Test
+    void fileReturnsDetailForAbsolutePath() throws Exception {
+        var root = org.eclipse.core.resources.ResourcesPlugin
+                .getWorkspace().getRoot();
+        var file = root.getProject("jdtbridge-test")
+                .getFile("src/test/model/Dog.java");
+        String absPath = file.getLocation().toOSString();
+
+        JsonObject result = parse(handler.handleFile(
+                params("of", absPath)));
+        assertEquals("file", result.get("kind").getAsString());
+        assertEquals("java", result.get("language").getAsString());
+        assertEquals("jdtbridge-test",
+                result.get("containingProject").getAsString());
+    }
+
+    @Test
+    void fileErrorForUnknownPath() {
+        JsonObject result = parse(handler.handleFile(
+                params("of", "D:/no/such/file.java")));
+        assertTrue(isError(result));
+        assertEquals("file-not-found",
+                errorOf(result).get("kind").getAsString());
+    }
+
+    // ── /typesInFile ────────────────────────────────────────────────
+
+    @Test
+    void typesInFileListsTypesFromAbsolutePath() throws Exception {
+        var root = org.eclipse.core.resources.ResourcesPlugin
+                .getWorkspace().getRoot();
+        var file = root.getProject("jdtbridge-test")
+                .getFile("src/test/model/Dog.java");
+        String absPath = file.getLocation().toOSString();
+
+        var arr = JsonParser.parseString(handler.handleTypesInFile(
+                params("of", absPath))).getAsJsonArray();
+        assertEquals(1, arr.size(), "Dog.java has one top-level type");
+        assertEquals("test.model.Dog",
+                arr.get(0).getAsJsonObject().get("fqn").getAsString());
+    }
+
+    @Test
+    void typesInFileErrorForUnknownPath() {
+        JsonObject result = parse(handler.handleTypesInFile(
+                params("of", "D:/no/such/file.java")));
+        assertTrue(isError(result));
+        assertEquals("file-not-found",
+                errorOf(result).get("kind").getAsString());
     }
 
     // ── /source ──────────────────────────────────────────────────────

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -732,6 +732,81 @@ public class LaunchHandlerTest {
     }
 
     @Nested
+    class ConfigDelete {
+
+        @Test
+        void missingConfigIdReturnsError() {
+            String json = handler.handleConfigDelete(Map.of());
+            assertTrue(json.contains("Missing"));
+        }
+
+        @Test
+        void unknownConfigReturnsError() {
+            String json = handler.handleConfigDelete(
+                    Map.of("configId", "no-such-xyz"));
+            assertTrue(json.contains("not found"));
+        }
+
+        @Test
+        void deletesExistingLocalConfig() throws Exception {
+            ILaunchConfiguration cfg = createJavaConfig(
+                    "DeleteMe-Test", "test.Main");
+            String json = handler.handleConfigDelete(
+                    Map.of("configId", "DeleteMe-Test"));
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertEquals("DeleteMe-Test",
+                    obj.get("configId").getAsString());
+        }
+    }
+
+    @Nested
+    class Import {
+
+        @Test
+        void missingConfigIdReturnsError() {
+            String json = handler.handleImport(Map.of(), "<xml/>");
+            assertTrue(json.contains("Missing"));
+        }
+
+        @Test
+        void missingBodyReturnsError() {
+            String json = handler.handleImport(
+                    Map.of("configId", "test"), null);
+            assertTrue(json.contains("Missing"));
+        }
+
+        @Test
+        void pathTraversalRejected() {
+            String json = handler.handleImport(
+                    Map.of("configId", "../evil"), "<xml/>");
+            assertTrue(json.contains("Invalid"));
+        }
+
+        @Test
+        void slashInConfigIdRejected() {
+            String json = handler.handleImport(
+                    Map.of("configId", "foo/bar"), "<xml/>");
+            assertTrue(json.contains("Invalid"));
+        }
+
+        @Test
+        void duplicateConfigIdRejected() throws Exception {
+            ILaunchConfiguration cfg = createJavaConfig(
+                    "ImportDupe", "test.Main");
+            try {
+                String json = handler.handleImport(
+                        Map.of("configId", "ImportDupe"),
+                        "<xml/>");
+                assertTrue(json.contains("already exists"));
+            } finally {
+                deleteIfPresent(cfg);
+            }
+        }
+    }
+
+    @Nested
     class ArgsAttribute {
 
         @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -807,6 +807,168 @@ public class LaunchHandlerTest {
     }
 
     @Nested
+    class RunSuccess {
+
+        private ILaunchConfiguration javaCfg;
+
+        @BeforeEach
+        void create() throws Exception {
+            javaCfg = createJavaConfig(
+                    "RunSuccessTest", "test.Main");
+        }
+
+        @AfterEach
+        void cleanup() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            for (ILaunch l : mgr.getLaunches()) {
+                var cfg = l.getLaunchConfiguration();
+                if (cfg != null && "RunSuccessTest".equals(
+                        cfg.getName())) {
+                    mgr.removeLaunch(l);
+                }
+            }
+            deleteIfPresent(javaCfg);
+        }
+
+        @Test
+        void launchesAndReturnsIdentityFields() {
+            String json = handler.handleRun(
+                    Map.of("configId", "RunSuccessTest"));
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            assertTrue(obj.get("ok").getAsBoolean(),
+                    "run must succeed: " + json);
+            assertEquals("RunSuccessTest",
+                    obj.get("configId").getAsString());
+            assertTrue(obj.has("launchId"));
+            assertTrue(obj.has("mode"));
+            assertEquals("run",
+                    obj.get("mode").getAsString());
+        }
+    }
+
+    @Nested
+    class ConfigSummaryFields {
+
+        private ILaunchConfiguration junitCfg;
+        private ILaunchConfiguration javaCfg;
+
+        @BeforeEach
+        void create() throws Exception {
+            javaCfg = createJavaConfig(
+                    "SumJava", "com.example.Main");
+            junitCfg = createConfig(
+                    "org.eclipse.jdt.junit.launchconfig",
+                    "SumJUnit",
+                    Map.of("org.eclipse.jdt.launching.MAIN_TYPE",
+                            "com.example.FooTest",
+                           "org.eclipse.jdt.junit.TEST_KIND",
+                            "org.eclipse.jdt.junit.loader.junit5"));
+        }
+
+        @AfterEach
+        void cleanup() throws Exception {
+            deleteIfPresent(javaCfg);
+            deleteIfPresent(junitCfg);
+        }
+
+        @Test
+        void javaAppSummaryHasMainClass() {
+            var arr = JsonParser.parseString(
+                    handler.handleConfigs(Map.of(),
+                            ProjectScope.ALL)).getAsJsonArray();
+            JsonObject java = findByConfigId(arr, "SumJava");
+            assertEquals("com.example.Main",
+                    java.get("mainClass").getAsString());
+        }
+
+        @Test
+        void junitSummaryHasClassAndRunner() {
+            var arr = JsonParser.parseString(
+                    handler.handleConfigs(Map.of(),
+                            ProjectScope.ALL)).getAsJsonArray();
+            JsonObject junit = findByConfigId(arr, "SumJUnit");
+            assertEquals("com.example.FooTest",
+                    junit.get("class").getAsString());
+            assertEquals("JUnit 5",
+                    junit.get("runner").getAsString());
+        }
+
+        @Test
+        void mavenSummaryHasGoalsAndProfiles() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            if (mgr.getLaunchConfigurationType(
+                    "org.eclipse.m2e.Maven2LaunchConfigurationType")
+                    == null) {
+                return;
+            }
+            ILaunchConfiguration mavenCfg = createConfig(
+                    "org.eclipse.m2e.Maven2LaunchConfigurationType",
+                    "SumMaven",
+                    Map.of("M2_GOALS", "clean verify",
+                           "M2_PROFILES", "ci"));
+            try {
+                var arr = JsonParser.parseString(
+                        handler.handleConfigs(Map.of(),
+                                ProjectScope.ALL)).getAsJsonArray();
+                JsonObject maven = findByConfigId(arr, "SumMaven");
+                assertEquals("clean verify",
+                        maven.get("goals").getAsString());
+                assertEquals("ci",
+                        maven.get("profiles").getAsString());
+            } finally {
+                deleteIfPresent(mavenCfg);
+            }
+        }
+    }
+
+    @Nested
+    class AppendArgs {
+
+        private ILaunchConfiguration javaCfg;
+
+        @BeforeEach
+        void create() throws Exception {
+            javaCfg = createJavaConfig(
+                    "AppendArgsTest", "test.Main");
+        }
+
+        @AfterEach
+        void cleanup() throws Exception {
+            deleteIfPresent(javaCfg);
+        }
+
+        @Test
+        void appendsToEmptyAttribute() throws Exception {
+            var wc = handler.appendArgs(javaCfg, "--port 8080");
+            String value = wc.getAttribute(
+                    "org.eclipse.jdt.launching.PROGRAM_ARGUMENTS",
+                    "");
+            assertEquals("--port 8080", value);
+        }
+
+        @Test
+        void appendsToExistingAttribute() throws Exception {
+            var original = javaCfg.getWorkingCopy();
+            original.setAttribute(
+                    "org.eclipse.jdt.launching.PROGRAM_ARGUMENTS",
+                    "--host localhost");
+            var saved = original.doSave();
+            try {
+                var wc = handler.appendArgs(saved, "--port 8080");
+                String value = wc.getAttribute(
+                        "org.eclipse.jdt.launching.PROGRAM_ARGUMENTS",
+                        "");
+                assertEquals("--host localhost --port 8080", value);
+            } finally {
+                deleteIfPresent(saved);
+            }
+        }
+    }
+
+    @Nested
     class ArgsAttribute {
 
         @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -686,6 +686,43 @@ public class LaunchHandlerTest {
         }
 
         @Test
+        void findLaunchByConfigIdPid() throws Exception {
+            ILaunchManager mgr =
+                    DebugPlugin.getDefault().getLaunchManager();
+            ILaunchConfiguration cfg = createJavaConfig(
+                    "FindByPid", "test.Main");
+            try {
+                ILaunch launch = new org.eclipse.debug.core.Launch(
+                        cfg, "run", null);
+                Process proc = new ProcessBuilder(
+                        "java", "-version").start();
+                proc.waitFor(5,
+                        java.util.concurrent.TimeUnit.SECONDS);
+                DebugPlugin.newProcess(launch, proc,
+                        "find-pid-test");
+                mgr.addLaunch(launch);
+                try {
+                    String pid = launch.getProcesses()[0]
+                            .getAttribute(
+                                    org.eclipse.debug.core.model
+                                            .IProcess
+                                            .ATTR_PROCESS_ID);
+                    String launchId = "FindByPid:" + pid;
+                    String json = handler.handleStop(
+                            Map.of("launchId", launchId));
+                    assertTrue(
+                            json.contains("Already terminated"),
+                            "terminated launch found by pid: "
+                            + json);
+                } finally {
+                    mgr.removeLaunch(launch);
+                }
+            } finally {
+                deleteIfPresent(cfg);
+            }
+        }
+
+        @Test
         void terminatedLaunchReturnsError() throws Exception {
             ILaunchManager mgr =
                     DebugPlugin.getDefault().getLaunchManager();
@@ -845,6 +882,18 @@ public class LaunchHandlerTest {
             assertTrue(obj.has("mode"));
             assertEquals("run",
                     obj.get("mode").getAsString());
+        }
+
+        @Test
+        void runWithExtraArgs() {
+            var params = new java.util.HashMap<String, String>();
+            params.put("configId", "RunSuccessTest");
+            params.put("args", "--port 9090");
+            String json = handler.handleRun(params);
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            assertTrue(obj.get("ok").getAsBoolean(),
+                    "run with args must succeed: " + json);
         }
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -969,6 +969,75 @@ public class LaunchHandlerTest {
     }
 
     @Nested
+    class FormatRunner {
+
+        @Test
+        void junit6Kind() {
+            assertEquals("JUnit 6",
+                    JUnitLaunchConst.formatRunner(
+                            "org.eclipse.jdt.junit.loader.junit6"));
+        }
+
+        @Test
+        void junit5Kind() {
+            assertEquals("JUnit 5",
+                    JUnitLaunchConst.formatRunner(
+                            "org.eclipse.jdt.junit.loader.junit5"));
+        }
+
+        @Test
+        void junit4Kind() {
+            assertEquals("JUnit 4",
+                    JUnitLaunchConst.formatRunner(
+                            "org.eclipse.jdt.junit.loader.junit4"));
+        }
+
+        @Test
+        void nullReturnsNull() {
+            assertEquals(null,
+                    JUnitLaunchConst.formatRunner(null));
+        }
+
+        @Test
+        void unknownReturnsVerbatim() {
+            assertEquals("some.custom.loader",
+                    JUnitLaunchConst.formatRunner(
+                            "some.custom.loader"));
+        }
+    }
+
+    @Nested
+    class ParseContainerPackage {
+
+        @Test
+        void nullReturnsNull() {
+            assertEquals(null,
+                    LaunchHandler.parseContainerPackage(null));
+        }
+
+        @Test
+        void blankReturnsNull() {
+            assertEquals(null,
+                    LaunchHandler.parseContainerPackage("  "));
+        }
+
+        @Test
+        void projectLevelReturnsNull() {
+            assertEquals(null,
+                    LaunchHandler.parseContainerPackage(
+                            "=my-project"));
+        }
+
+        @Test
+        void extractsPackageName() {
+            assertEquals("com.example.service",
+                    LaunchHandler.parseContainerPackage(
+                            "=my-project/src\\/test\\/java"
+                            + "<com.example.service"));
+        }
+    }
+
+    @Nested
     class ArgsAttribute {
 
         @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
@@ -3,6 +3,7 @@ package io.github.kaluchi.jdtbridge;
 import io.github.kaluchi.jdtbridge.support.TestFixture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -78,8 +79,47 @@ public class TestHandlerIntegrationTest {
     }
 
     @Test
+    public void targetByMethod() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "test.edge.SimpleTest#onePlusOne");
+        params.put("no-refresh", "");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "method target must launch: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
+    public void targetByProject() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "jdtbridge-test");
+        params.put("no-refresh", "");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "project target must launch: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
+    public void targetByPackage() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "test.edge");
+        params.put("project", "jdtbridge-test");
+        params.put("no-refresh", "");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "package target must launch: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
     public void detectTestKindJunit5() throws Exception {
-        // test project has JUnit 5 on classpath
         var type = JdtUtils.findType("test.model.Dog");
         String kind = handler.detectTestKind(type);
         assertEquals("org.eclipse.jdt.junit.loader.junit5", kind);
@@ -87,9 +127,6 @@ public class TestHandlerIntegrationTest {
 
     @Test
     public void successfulLaunchOnTestFixtureClass() throws Exception {
-        // test.edge.SimpleTest is a real JUnit 5 test class created
-        // by TestFixture. Driving handleTestRun against it covers
-        // the full happy path: synthesize → prepareLaunch → launch.
         Map<String, String> params = new HashMap<>();
         params.put("target", "test.edge.SimpleTest");
         params.put("no-refresh", "");
@@ -102,12 +139,38 @@ public class TestHandlerIntegrationTest {
                 "Response must carry launchId: " + json);
         assertTrue(obj.has("testRunId"),
                 "Response must carry testRunId: " + json);
-        // runner is the human-readable name produced by formatRunner.
         assertEquals("JUnit 5", obj.get("runner").getAsString(),
                 "Runner must resolve to JUnit 5 for SimpleTest: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
 
-        // Tear down the launch so subsequent tests don't see it.
-        String configId = obj.get("configId").getAsString();
+    @Test
+    public void coverageFalseDoesNotEnableCoverage() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "test.edge.SimpleTest");
+        params.put("no-refresh", "");
+        params.put("coverage", "false");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "coverage=false must still launch: " + json);
+        assertFalse(obj.has("coverageId"),
+                "coverage=false must not produce coverageId: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
+    public void emptyTargetReturnsError() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "   ");
+        String json = handler.handleTestRun(params);
+        assertTrue(json.contains("Missing"),
+                "blank target must fail: " + json);
+    }
+
+    private static void terminateLaunch(String configId)
+            throws org.eclipse.debug.core.DebugException {
         var mgr = org.eclipse.debug.core.DebugPlugin
                 .getDefault().getLaunchManager();
         for (var launch : mgr.getLaunches()) {

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
@@ -105,7 +105,7 @@ public class TestHandlerIntegrationTest {
     }
 
     @Test
-    public void targetByPackage() throws Exception {
+    public void targetByPackageWithProjectOverride() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("target", "test.edge");
         params.put("project", "jdtbridge-test");
@@ -114,7 +114,38 @@ public class TestHandlerIntegrationTest {
         var obj = com.google.gson.JsonParser.parseString(json)
                 .getAsJsonObject();
         assertTrue(obj.get("ok").getAsBoolean(),
-                "package target must launch: " + json);
+                "package target with project override must launch: "
+                + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
+    public void targetByPackageInfersProject() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "test.edge");
+        params.put("no-refresh", "");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "package target without project must infer: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
+    public void targetByCompilationUnit() throws Exception {
+        var root = org.eclipse.core.resources.ResourcesPlugin
+                .getWorkspace().getRoot();
+        var file = root.getProject("jdtbridge-test")
+                .getFile("src/test/edge/SimpleTest.java");
+        Map<String, String> params = new HashMap<>();
+        params.put("target", file.getLocation().toOSString());
+        params.put("no-refresh", "");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "file target must launch: " + json);
         terminateLaunch(obj.get("configId").getAsString());
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionHandlerTest.java
@@ -1,0 +1,262 @@
+package io.github.kaluchi.jdtbridge;
+
+import io.github.kaluchi.jdtbridge.support.TestFixture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+@SuppressWarnings("restriction")
+public class TestSessionHandlerTest {
+
+    private static final String SIMPLE_TEST_FQN =
+            "test.edge.SimpleTest";
+
+    private static TestRunSession session;
+    private static String testRunId;
+    private static String configId;
+    private static final TestSessionHandler handler =
+            new TestSessionHandler();
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        TestFixture.create();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("target", SIMPLE_TEST_FQN);
+        params.put("no-refresh", "");
+
+        String json = new TestHandler().handleTestRun(params);
+        JsonObject obj = JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "handleTestRun must succeed: " + json);
+        testRunId = obj.get("testRunId").getAsString();
+        configId = obj.get("configId").getAsString();
+
+        session = TestSessionAwait.awaitFinished(testRunId, 60_000);
+        assertNotNull(session,
+                "Launched session must finish within 60s: "
+                        + testRunId);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (session != null) {
+            JUnitCorePlugin.getModel()
+                    .removeTestRunSession(session);
+            session = null;
+        }
+        TestFixture.destroy();
+    }
+
+    @Nested
+    class FindSession {
+
+        @Test
+        void findsByExactTestRunId() {
+            TestRunSession found = handler.findSession(testRunId);
+            assertNotNull(found);
+            assertEquals(testRunId,
+                    TestSessionHandler.testRunId(found));
+        }
+
+        @Test
+        void findsByConfigId() {
+            TestRunSession found = handler.findSession(configId);
+            assertNotNull(found);
+        }
+
+        @Test
+        void returnsNullForUnknownId() {
+            TestRunSession found =
+                    handler.findSession("no-such-run:999");
+            assertEquals(null, found);
+        }
+    }
+
+    @Nested
+    class HandleStatus {
+
+        @Test
+        void returnsFinishedStatusForCompletedRun() {
+            JsonObject result = parse(handler.handleStatus(
+                    params("testRunId", testRunId)));
+            assertEquals(configId,
+                    result.get("configId").getAsString());
+            assertEquals(testRunId,
+                    result.get("testRunId").getAsString());
+            assertEquals("finished",
+                    result.get("state").getAsString());
+            assertTrue(result.get("total").getAsInt() >= 1);
+            assertTrue(result.get("passed").getAsInt() >= 1);
+            assertEquals(0, result.get("failed").getAsInt());
+            assertEquals(0, result.get("errors").getAsInt());
+            assertTrue(result.get("time").getAsDouble() >= 0.0);
+            assertNotNull(result.get("entries"));
+        }
+
+        @Test
+        void failuresFilterReturnsEmptyEntriesForAllPassing() {
+            JsonObject result = parse(handler.handleStatus(
+                    params("testRunId", testRunId)));
+            JsonArray entries = result.getAsJsonArray("entries");
+            assertEquals(0, entries.size(),
+                    "all tests pass — default failures filter "
+                    + "yields empty entries");
+        }
+
+        @Test
+        void allFilterReturnsTestEntries() {
+            JsonObject result = parse(handler.handleStatus(
+                    paramsMulti("testRunId", testRunId,
+                                "filter", "all")));
+            JsonArray entries = result.getAsJsonArray("entries");
+            assertTrue(entries.size() >= 1,
+                    "all filter should include passing tests");
+            JsonObject first = entries.get(0).getAsJsonObject();
+            assertEquals("PASS",
+                    first.get("status").getAsString());
+            assertNotNull(first.get("fqn"));
+            assertTrue(first.get("time").getAsDouble() >= 0.0);
+        }
+
+        @Test
+        void missingTestRunIdReturnsError() {
+            String result = handler.handleStatus(Map.of());
+            assertTrue(result.contains("Missing"));
+        }
+
+        @Test
+        void unknownTestRunIdReturnsError() {
+            String result = handler.handleStatus(
+                    params("testRunId", "bogus:0"));
+            assertTrue(result.contains("not found"));
+        }
+
+        @Test
+        void ignoredFilterReturnsEmptyForNoIgnored() {
+            JsonObject result = parse(handler.handleStatus(
+                    paramsMulti("testRunId", testRunId,
+                                "filter", "ignored")));
+            JsonArray entries = result.getAsJsonArray("entries");
+            assertEquals(0, entries.size(),
+                    "SimpleTest has no @Disabled methods");
+        }
+    }
+
+    @Nested
+    class HandleSessions {
+
+        @Test
+        void listsAtLeastTheFixtureSession() {
+            JsonArray arr = JsonParser.parseString(
+                    handler.handleSessions(Map.of(),
+                            ProjectScope.ALL)).getAsJsonArray();
+            assertTrue(arr.size() >= 1);
+            boolean found = arr.asList().stream()
+                    .map(JsonElement::getAsJsonObject)
+                    .anyMatch(e -> testRunId.equals(
+                            e.get("testRunId").getAsString()));
+            assertTrue(found,
+                    "fixture session must appear in /test/sessions");
+        }
+
+        @Test
+        void sessionEntryCarriesAllFields() {
+            JsonArray arr = JsonParser.parseString(
+                    handler.handleSessions(Map.of(),
+                            ProjectScope.ALL)).getAsJsonArray();
+            JsonObject entry = arr.asList().stream()
+                    .map(JsonElement::getAsJsonObject)
+                    .filter(e -> testRunId.equals(
+                            e.get("testRunId").getAsString()))
+                    .findFirst().orElseThrow();
+            assertEquals(configId,
+                    entry.get("configId").getAsString());
+            assertEquals("finished",
+                    entry.get("state").getAsString());
+            assertTrue(entry.has("total"));
+            assertTrue(entry.has("completed"));
+            assertTrue(entry.has("passed"));
+            assertTrue(entry.has("failed"));
+            assertTrue(entry.has("errors"));
+            assertTrue(entry.has("ignored"));
+            assertTrue(entry.has("time"));
+            assertTrue(entry.has("startedAt"));
+        }
+    }
+
+    @Nested
+    class HandleClear {
+
+        @Test
+        void clearUnknownIdRemovesNothing() {
+            JsonObject result = parse(handler.handleClear(
+                    params("testRunId", "bogus:0")));
+            assertEquals(0, result.get("removed").getAsInt());
+        }
+
+        @Test
+        void clearByTestRunIdRemovesThatSession() {
+            Map<String, String> launchParams = new HashMap<>();
+            launchParams.put("target", SIMPLE_TEST_FQN);
+            launchParams.put("no-refresh", "");
+            try {
+                String json = new TestHandler()
+                        .handleTestRun(launchParams);
+                JsonObject obj = JsonParser.parseString(json)
+                        .getAsJsonObject();
+                String tempRunId =
+                        obj.get("testRunId").getAsString();
+                TestSessionAwait.awaitFinished(
+                        tempRunId, 60_000);
+
+                JsonObject result = parse(
+                        handler.handleClear(
+                                params("testRunId", tempRunId)));
+                assertEquals(1,
+                        result.get("removed").getAsInt());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static Map<String, String> params(
+            String key, String value) {
+        var m = new HashMap<String, String>();
+        m.put(key, value);
+        return m;
+    }
+
+    private static Map<String, String> paramsMulti(
+            String... pairs) {
+        var m = new HashMap<String, String>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            m.put(pairs[i], pairs[i + 1]);
+        }
+        return m;
+    }
+
+    private static JsonObject parse(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/GraphHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/GraphHandler.java
@@ -87,47 +87,14 @@ class GraphHandler {
             return ErrorDescriptor.missingParameter("of").toJsonString();
         }
         try {
-            // Composite synthetic fqns (lambda / anonymous) carry the
-            // enclosing method's `(` in their suffix; the first-# split
-            // in the regular branch is unsafe. Route through the
-            // unified parser which skips the overload-ambiguity check —
-            // SAM method names inside synthetic types are unambiguous.
-            if (JdtUtils.isCompositeFqn(fqn)) {
-                IJavaElement resolved = JdtUtils.resolveElement(fqn);
-                return resolved instanceof IMethod m
-                        ? NodeBuilder.methodDetail(m).toString()
-                        : ErrorDescriptor.methodNotFound(fqn).toJsonString();
+            ResolvedTarget target = resolveTarget(fqn, params);
+            if (target.errorJson != null) return target.errorJson;
+            if (!(target.element instanceof IMethod method)) {
+                return ErrorDescriptor.wrongSubjectKind(
+                        "/method", "method",
+                        elementKindOf(target.element)).toJsonString();
             }
-            int hash = fqn.indexOf('#');
-            if (hash < 0) {
-                return ErrorDescriptor.invalidFqn(fqn).toJsonString();
-            }
-            String typeFqn = fqn.substring(0, hash);
-            String memberPart = fqn.substring(hash + 1);
-            int paren = memberPart.indexOf('(');
-            String methodName = paren < 0
-                    ? memberPart : memberPart.substring(0, paren);
-            String paramTypesParam = params.get("paramTypes");
-            if (paramTypesParam == null && paren >= 0) {
-                int closeParen = memberPart.lastIndexOf(')');
-                paramTypesParam = closeParen > paren
-                        ? memberPart.substring(paren + 1, closeParen)
-                        : memberPart.substring(paren + 1);
-            }
-            IType type = JdtUtils.findType(typeFqn);
-            if (type == null) {
-                return ErrorDescriptor.typeNotFound(typeFqn).toJsonString();
-            }
-            var matches = JdtUtils.findMethods(type, methodName,
-                    paramTypesParam);
-            if (matches.isEmpty()) {
-                return ErrorDescriptor.methodNotFound(fqn).toJsonString();
-            }
-            if (matches.size() > 1) {
-                return ErrorDescriptor.ambiguousMatch(fqn,
-                        fqnsOf(matches)).toJsonString();
-            }
-            return NodeBuilder.methodDetail(matches.get(0)).toString();
+            return NodeBuilder.methodDetail(method).toString();
         } catch (Exception e) {
             Log.warn("/method failed for " + fqn, e);
             return ErrorDescriptor.jdtInternalError(
@@ -142,42 +109,34 @@ class GraphHandler {
             return ErrorDescriptor.missingParameter("of").toJsonString();
         }
         try {
-            if (JdtUtils.isCompositeFqn(fqn)) {
-                IJavaElement resolved = JdtUtils.resolveElement(fqn);
-                return resolved instanceof IField f
-                        ? NodeBuilder.fieldDetail(f).toString()
-                        : ErrorDescriptor.fieldNotFound(fqn).toJsonString();
+            if (!JdtUtils.isCompositeFqn(fqn)) {
+                int hash = fqn.indexOf('#');
+                if (hash >= 0 && fqn.substring(hash + 1).contains("(")) {
+                    return ErrorDescriptor.invalidFqn(fqn)
+                            .with("reason",
+                                    "field FQN must not contain parens")
+                            .toJsonString();
+                }
             }
-            return handleFieldRegular(fqn);
+            ResolvedTarget target = resolveTarget(fqn, params);
+            if (target.errorJson != null) {
+                if (target.errorJson.contains("method-not-found")) {
+                    return ErrorDescriptor.fieldNotFound(fqn)
+                            .toJsonString();
+                }
+                return target.errorJson;
+            }
+            if (!(target.element instanceof IField field)) {
+                return ErrorDescriptor.wrongSubjectKind(
+                        "/field", "field",
+                        elementKindOf(target.element)).toJsonString();
+            }
+            return NodeBuilder.fieldDetail(field).toString();
         } catch (Exception e) {
             Log.warn("/field failed for " + fqn, e);
             return ErrorDescriptor.jdtInternalError(
                     "Failed to resolve field: " + fqn, e).toJsonString();
         }
-    }
-
-    private String handleFieldRegular(String fqn)
-            throws JavaModelException {
-        int hash = fqn.indexOf('#');
-        if (hash < 0) {
-            return ErrorDescriptor.invalidFqn(fqn).toJsonString();
-        }
-        String typeFqn = fqn.substring(0, hash);
-        String fieldName = fqn.substring(hash + 1);
-        if (fieldName.contains("(")) {
-            return ErrorDescriptor.invalidFqn(fqn)
-                    .with("reason", "field FQN must not contain parens")
-                    .toJsonString();
-        }
-        IType type = JdtUtils.findType(typeFqn);
-        if (type == null) {
-            return ErrorDescriptor.typeNotFound(typeFqn).toJsonString();
-        }
-        IField field = type.getField(fieldName);
-        if (field == null || !field.exists()) {
-            return ErrorDescriptor.fieldNotFound(fqn).toJsonString();
-        }
-        return NodeBuilder.fieldDetail(field).toString();
     }
 
     // ── Down-navigation: direct contents of a type ──────────────────
@@ -200,33 +159,18 @@ class GraphHandler {
     }
 
     String handleMethods(Map<String, String> params) {
-        return listForType(params, "/methods", type -> {
-            var arr = new JsonArray();
-            for (IMethod m : type.getMethods()) {
-                arr.add(NodeBuilder.methodSkeleton(m));
-            }
-            return arr;
-        });
+        return listForType(params, "/methods", type ->
+                mapToArray(type.getMethods(), NodeBuilder::methodSkeleton));
     }
 
     String handleFields(Map<String, String> params) {
-        return listForType(params, "/fields", type -> {
-            var arr = new JsonArray();
-            for (IField f : type.getFields()) {
-                arr.add(NodeBuilder.fieldSkeleton(f));
-            }
-            return arr;
-        });
+        return listForType(params, "/fields", type ->
+                mapToArray(type.getFields(), NodeBuilder::fieldSkeleton));
     }
 
     String handleInnerTypes(Map<String, String> params) {
-        return listForType(params, "/innerTypes", type -> {
-            var arr = new JsonArray();
-            for (IType inner : type.getTypes()) {
-                arr.add(NodeBuilder.typeSkeleton(inner));
-            }
-            return arr;
-        });
+        return listForType(params, "/innerTypes", type ->
+                mapToArray(type.getTypes(), NodeBuilder::typeSkeleton));
     }
 
     // ── Hierarchy: direct supers and subtypes ───────────────────────
@@ -1175,7 +1119,21 @@ class GraphHandler {
         return out;
     }
 
-    // ── Common helper: validate :of param, resolve type, build Vec ──
+    // ── Common helpers ──────────────────────────────────────────────
+
+    @FunctionalInterface
+    private interface ThrowingFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+
+    private static <T> JsonArray mapToArray(T[] elements,
+            ThrowingFunction<T, JsonObject> mapper) throws Exception {
+        var arr = new JsonArray();
+        for (T element : elements) {
+            arr.add(mapper.apply(element));
+        }
+        return arr;
+    }
 
     @FunctionalInterface
     private interface TypeListBuilder {

--- a/plugin/src/io/github/kaluchi/jdtbridge/JUnitLaunchConst.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/JUnitLaunchConst.java
@@ -42,4 +42,14 @@ final class JUnitLaunchConst {
             "org.eclipse.jdt.junit.loader.junit5";
     static final String KIND_JUNIT6 =
             "org.eclipse.jdt.junit.loader.junit6";
+
+    static String formatRunner(String testKind) {
+        if (testKind == null) return null;
+        return switch (testKind) {
+            case KIND_JUNIT6 -> "JUnit 6";
+            case KIND_JUNIT5 -> "JUnit 5";
+            case KIND_JUNIT4 -> "JUnit 4";
+            default -> testKind;
+        };
+    }
 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/JdtUtils.java
@@ -493,13 +493,6 @@ public class JdtUtils {
         return base + suffix;
     }
 
-    static String typeKind(IType type) throws JavaModelException {
-        if (type.isAnnotation()) return "annotation";
-        if (type.isEnum()) return "enum";
-        if (type.isInterface()) return "interface";
-        return "class";
-    }
-
     /**
      * Wait for Eclipse auto-build to finish, with a 2-minute
      * safety timeout to prevent indefinite hangs.
@@ -542,19 +535,6 @@ public class JdtUtils {
         return count;
     }
 
-    static String compactSignature(IMethod m) throws JavaModelException {
-        StringBuilder sig = new StringBuilder();
-        sig.append(m.getElementName()).append("(");
-        String[] paramTypes = m.getParameterTypes();
-        for (int i = 0; i < paramTypes.length; i++) {
-            if (i > 0) sig.append(", ");
-            sig.append(Signature.toString(
-                    Signature.getTypeErasure(paramTypes[i])));
-        }
-        sig.append(")");
-        return sig.toString();
-    }
-
     /**
      * Find all implementations of an interface/abstract method
      * via type hierarchy. Returns FQN → IMethod map. Callers:
@@ -591,7 +571,7 @@ public class JdtUtils {
                             .equals(paramSig)) continue;
                     result.put(
                             sub.getFullyQualifiedName()
-                            + "#" + compactSignature(m),
+                            + "#" + NodeBuilder.compactSignature(m),
                             m);
                     break;
                 }

--- a/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/LaunchHandler.java
@@ -77,25 +77,12 @@ class LaunchHandler {
         this.tracker = tracker;
     }
 
-    private static String formatRunner(String testKind) {
-        if (testKind == null) return null;
-        return switch (testKind) {
-        case "org.eclipse.jdt.junit.loader.junit6" ->
-                "JUnit 6";
-        case "org.eclipse.jdt.junit.loader.junit5" ->
-                "JUnit 5";
-        case "org.eclipse.jdt.junit.loader.junit4" ->
-                "JUnit 4";
-        default -> testKind;
-        };
-    }
-
     /**
      * Extract package name from JUnit CONTAINER attribute.
      * Format: "=project/src\/test\/java=...=/<package.name"
      * Returns null for project-level containers ("=project").
      */
-    private static String parseContainerPackage(
+    static String parseContainerPackage(
             String container) {
         if (container == null || container.isBlank())
             return null;
@@ -341,7 +328,7 @@ class LaunchHandler {
                     JUnitLaunchConst.ATTR_TEST_NAME, (String) null);
             if (method != null && !method.isBlank())
                 obj.addProperty("method", method);
-            String runner = formatRunner(
+            String runner = JUnitLaunchConst.formatRunner(
                     config.getAttribute(
                             JUnitLaunchConst.ATTR_TEST_KIND,
                             (String) null));

--- a/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/TestHandler.java
@@ -262,7 +262,8 @@ public class TestHandler {
         }
 
         return new PreparedLaunch(configName, config, reused,
-                resolvedProject, formatRunner(testKind));
+                resolvedProject,
+                JUnitLaunchConst.formatRunner(testKind));
     }
 
     /**
@@ -350,14 +351,6 @@ public class TestHandler {
         return "true".equalsIgnoreCase(raw) || "1".equals(raw);
     }
 
-
-    private String formatRunner(String testKind) {
-        if (testKind == null) return null;
-        if (JUnitLaunchConst.KIND_JUNIT6.equals(testKind)) return "JUnit 6";
-        if (JUnitLaunchConst.KIND_JUNIT5.equals(testKind)) return "JUnit 5";
-        if (JUnitLaunchConst.KIND_JUNIT4.equals(testKind)) return "JUnit 4";
-        return "JUnit";
-    }
 
     // ---- Launch configuration ----
 


### PR DESCRIPTION
Code cleanup, dedup, and coverage improvement across plugin handlers.

Production code (-99 lines):
- GraphHandler: handleMethod/handleField delegate to resolveTarget instead of duplicating 50+ lines of FQN parsing; mapToArray helper collapses containment handlers to one-liners
- JdtUtils: delete dead typeKind() (zero callers) and duplicate compactSignature() (sole caller migrated to NodeBuilder.compactSignature)
- JUnitLaunchConst.formatRunner: canonical location for KIND to JUnit N mapping -- was duplicated as private methods in both LaunchHandler (switch) and TestHandler (if-chain)
- LaunchHandler.parseContainerPackage: made package-visible for direct testing

Tests (+50 new, 915 total):
- TestSessionHandlerTest (new, 13): findSession, handleStatus (finished/filters/errors), handleSessions, handleClear -- coverage from 4% to 96%
- TestHandlerIntegrationTest (+7): method/project/package/compilation-unit targets, parseBool false path, empty target error -- coverage from 65% to 80%
- LaunchHandlerTest (+21): configSummary fields (Java/JUnit/Maven), handleRun success, appendArgs, handleConfigDelete, handleImport validation, formatRunner, parseContainerPackage -- coverage from 65% to 73%
- JUnitLaunchConst: 100% after dedup

- [x] Plugin tests pass (915)
- [x] UI tests pass (28)
- [x] CLI tests pass (841)
- [x] Tycho verify pass