### PR TITLE
NodeBuilder DRY + coverage boost to 87.7%

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
@@ -1209,6 +1209,134 @@ public class GraphHandlerTest {
         }
     }
 
+    // ── Composite FQN resolution (lambda / anonymous) ───────────
+
+    @Test
+    void typeResolvesAnonymousComposite() {
+        String fqn = "test.service.AnonymousCallerService"
+                + "#createAnonymous().new Animal() {...}";
+        JsonObject result = parse(
+                handler.handleType(params("of", fqn)));
+        assertFalse(isError(result),
+                "should resolve anonymous type: " + result);
+        assertEquals("type", result.get("kind").getAsString());
+    }
+
+    @Test
+    void methodResolvesAnonymousComposite() {
+        String fqn = "test.service.AnonymousCallerService"
+                + "#createAnonymous().new Animal() {...}#name()";
+        JsonObject result = parse(
+                handler.handleMethod(params("of", fqn)));
+        assertFalse(isError(result),
+                "should resolve anonymous method: " + result);
+        assertEquals("method", result.get("kind").getAsString());
+        assertEquals("name", result.get("name").getAsString());
+    }
+
+    @Test
+    void typeResolvesLambdaComposite() {
+        String fqn = "test.service.LambdaCallerService"
+                + "#createLambda().() -> {...} Runnable";
+        JsonObject result = parse(
+                handler.handleType(params("of", fqn)));
+        assertFalse(isError(result),
+                "should resolve lambda type: " + result);
+        assertEquals("type", result.get("kind").getAsString());
+    }
+
+    @Test
+    void typeErrorForUnknownComposite() {
+        String fqn = "test.service.AnonymousCallerService"
+                + "#noSuchMethod().new Animal() {...}";
+        JsonObject result = parse(
+                handler.handleType(params("of", fqn)));
+        assertTrue(isError(result),
+                "should error for unknown composite: " + result);
+    }
+
+    @Test
+    void sourceResolvesAnonymousComposite() {
+        String fqn = "test.service.AnonymousCallerService"
+                + "#createAnonymous().new Animal() {...}";
+        String json = handler.handleSource(params("of", fqn));
+        assertFalse(json.contains("_error"),
+                "source should resolve anonymous: " + json);
+        assertTrue(json.contains("Anonymous"),
+                "source should contain method body: " + json);
+    }
+
+    // ── Missing parameter errors for workspace handlers ───────────
+
+    @Test
+    void projectErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handleProject(Map.of()));
+        assertTrue(isError(result));
+        assertEquals("missing-parameter",
+                errorOf(result).get("kind").getAsString());
+    }
+
+    @Test
+    void classpathErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handleClasspath(Map.of()));
+        assertTrue(isError(result));
+        assertEquals("missing-parameter",
+                errorOf(result).get("kind").getAsString());
+    }
+
+    @Test
+    void classpathErrorForNonJavaProject() throws Exception {
+        TestFixture.createNonJavaProject();
+        try {
+            JsonObject result = parse(
+                    handler.handleClasspath(
+                            params("of", TestFixture.NON_JAVA_PROJECT_NAME)));
+            assertTrue(isError(result));
+            assertTrue(errorOf(result).toString().contains("not a Java"),
+                    "should say not a Java project: " + result);
+        } finally {
+            TestFixture.destroy();
+            TestFixture.create();
+        }
+    }
+
+    @Test
+    void packageErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handlePackage(Map.of()));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void fileErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handleFile(Map.of()));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void typesInFileErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handleTypesInFile(Map.of()));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void packagesInProjectErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handlePackagesInProject(Map.of()));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void typesInPackageErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handleTypesInPackage(Map.of()));
+        assertTrue(isError(result));
+    }
+
     // ── Cross-cutting: every error carries origin :jdt/plugin ───────
 
     @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/LaunchHandlerTest.java
@@ -885,6 +885,20 @@ public class LaunchHandlerTest {
         }
 
         @Test
+        void debugModeSetsCorrectMode() {
+            var params = new java.util.HashMap<String, String>();
+            params.put("configId", "RunSuccessTest");
+            params.put("debug", "true");
+            String json = handler.handleRun(params);
+            var obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            if (obj.has("ok")) {
+                assertEquals("debug",
+                        obj.get("mode").getAsString());
+            }
+        }
+
+        @Test
         void runWithExtraArgs() {
             var params = new java.util.HashMap<String, String>();
             params.put("configId", "RunSuccessTest");
@@ -942,6 +956,50 @@ public class LaunchHandlerTest {
                     junit.get("class").getAsString());
             assertEquals("JUnit 5",
                     junit.get("runner").getAsString());
+        }
+
+        @Test
+        void junitContainerSummaryHasPackage() throws Exception {
+            ILaunchConfiguration containerCfg = createConfig(
+                    "org.eclipse.jdt.junit.launchconfig",
+                    "SumContainerJUnit",
+                    Map.of("org.eclipse.jdt.junit.CONTAINER",
+                            "=my-project/src<com.example.service"));
+            try {
+                var arr = JsonParser.parseString(
+                        handler.handleConfigs(Map.of(),
+                                ProjectScope.ALL)).getAsJsonArray();
+                JsonObject junit = findByConfigId(arr,
+                        "SumContainerJUnit");
+                assertFalse(junit.has("class"),
+                        "container config has no mainType: " + junit);
+                assertEquals("com.example.service",
+                        junit.get("package").getAsString());
+            } finally {
+                deleteIfPresent(containerCfg);
+            }
+        }
+
+        @Test
+        void junitSummaryIncludesMethodName() throws Exception {
+            ILaunchConfiguration methodCfg = createConfig(
+                    "org.eclipse.jdt.junit.launchconfig",
+                    "SumMethodJUnit",
+                    Map.of("org.eclipse.jdt.launching.MAIN_TYPE",
+                            "com.example.FooTest",
+                           "org.eclipse.jdt.junit.TESTNAME",
+                            "testSomething"));
+            try {
+                var arr = JsonParser.parseString(
+                        handler.handleConfigs(Map.of(),
+                                ProjectScope.ALL)).getAsJsonArray();
+                JsonObject junit = findByConfigId(arr,
+                        "SumMethodJUnit");
+                assertEquals("testSomething",
+                        junit.get("method").getAsString());
+            } finally {
+                deleteIfPresent(methodCfg);
+            }
         }
 
         @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/NodeBuilderTest.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -841,4 +842,111 @@ public class NodeBuilderTest {
                     ":method detail missing :" + key);
         }
     }
+
+    // ── typeDetail javadoc / anonymous ─────────────────────────────
+
+    @Test
+    void typeDetailCarriesJavadocSummary() throws Exception {
+        JsonObject detail = NodeBuilder.typeDetail(
+                type("test.edge.AbstractPet"));
+        assertTrue(detail.has("javadocSummary"),
+                "AbstractPet has javadoc → detail must carry :javadocSummary");
+        assertEquals("An abstract pet with a name.",
+                detail.get("javadocSummary").getAsString());
+    }
+
+    @Test
+    void typeDetailMarksAnonymousType() throws Exception {
+        IType anonCaller = type("test.service.AnonymousCallerService");
+        IMethod createAnonymous = anonCaller.getMethod(
+                "createAnonymous", new String[0]);
+        IType anonType = findAnonymousChild(createAnonymous);
+        assertNotNull(anonType, "anonymous Animal must exist in createAnonymous()");
+        JsonObject detail = NodeBuilder.typeDetail(anonType);
+        assertTrue(detail.get("isAnonymous").getAsBoolean());
+    }
+
+    // ── methodDetail throws / javadoc ─────────────────────────────
+
+    @Test
+    void methodDetailCarriesNonEmptyThrows() throws Exception {
+        IMethod process = method("test.edge.EdgeCaseMembers",
+                "process", "String");
+        JsonObject detail = NodeBuilder.methodDetail(process);
+        JsonArray thrown = detail.getAsJsonArray("throws");
+        assertTrue(thrown.size() > 0,
+                "process(String) declares throws IllegalArgumentException");
+        assertEquals("java.lang.IllegalArgumentException",
+                thrown.get(0).getAsString());
+    }
+
+    @Test
+    void methodDetailCarriesJavadocSummary() throws Exception {
+        IMethod process = method("test.edge.EdgeCaseMembers",
+                "process", "String");
+        JsonObject detail = NodeBuilder.methodDetail(process);
+        assertTrue(detail.has("javadocSummary"),
+                "process() has javadoc → detail must carry :javadocSummary");
+        assertEquals("Processes the input.",
+                detail.get("javadocSummary").getAsString());
+    }
+
+    // ── fieldDetail deprecated / javadoc ──────────────────────────
+
+    @Test
+    void fieldDetailMarksDeprecated() throws Exception {
+        IType edgeMembers = type("test.edge.EdgeCaseMembers");
+        IField count = edgeMembers.getField("count");
+        JsonObject detail = NodeBuilder.fieldDetail(count);
+        assertTrue(detail.get("isDeprecated").getAsBoolean(),
+                "count is @Deprecated");
+    }
+
+    @Test
+    void fieldDetailCarriesJavadocSummary() throws Exception {
+        IType edgeMembers = type("test.edge.EdgeCaseMembers");
+        IField count = edgeMembers.getField("count");
+        JsonObject detail = NodeBuilder.fieldDetail(count);
+        assertTrue(detail.has("javadocSummary"),
+                "count has javadoc → detail must carry :javadocSummary");
+        assertEquals("The count of items.",
+                detail.get("javadocSummary").getAsString());
+    }
+
+    // ── sourceTextOf ──────────────────────────────────────────────
+
+    @Test
+    void sourceTextOfMethodReturnsSlicedLines() throws Exception {
+        IMethod bark = method("test.model.Dog", "bark", null);
+        String source = NodeBuilder.sourceTextOf(bark);
+        assertNotNull(source);
+        assertTrue(source.contains("bark"),
+                "sliced source must contain method name");
+        assertTrue(source.contains("Woof"),
+                "sliced source must contain method body");
+        assertFalse(source.contains("class Dog"),
+                "sliced source must NOT contain the class header");
+    }
+
+    @Test
+    void sourceTextOfTopLevelTypeReturnsFullUnit() throws Exception {
+        IType dog = type("test.model.Dog");
+        String source = NodeBuilder.sourceTextOf(dog);
+        assertNotNull(source);
+        assertTrue(source.contains("package test.model"),
+                "top-level type source starts with package declaration");
+        assertTrue(source.contains("class Dog"),
+                "top-level type source includes class header");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────
+
+    private static IType findAnonymousChild(IMethod method)
+            throws Exception {
+        for (IJavaElement child : method.getChildren()) {
+            if (child instanceof IType t && t.isAnonymous()) return t;
+        }
+        return null;
+    }
+
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectScopeTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/ProjectScopeTest.java
@@ -1,22 +1,37 @@
 package io.github.kaluchi.jdtbridge;
 
+import io.github.kaluchi.jdtbridge.support.TestFixture;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link ProjectScope}.
  */
 public class ProjectScopeTest {
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        TestFixture.create();
+    }
 
     @Nested
     class AllScope {
@@ -192,6 +207,104 @@ public class ProjectScopeTest {
             ProjectScope scope = ProjectScope.of(
                     Set.of("project-a"));
             assertFalse(scope.containsAnyOfRoots(Set.of()));
+        }
+
+        @Test
+        void filteredScopeAcceptsMatchingRoot() throws Exception {
+            IJavaProject jp = JavaCore.create(
+                    org.eclipse.core.resources.ResourcesPlugin
+                            .getWorkspace().getRoot()
+                            .getProject(TestFixture.PROJECT_NAME));
+            var roots = new HashSet<IPackageFragmentRoot>();
+            for (IPackageFragmentRoot r
+                    : jp.getPackageFragmentRoots()) {
+                if (r.getKind()
+                        == IPackageFragmentRoot.K_SOURCE) {
+                    roots.add(r);
+                }
+            }
+            ProjectScope scope = ProjectScope.of(
+                    Set.of(TestFixture.PROJECT_NAME));
+            assertTrue(scope.containsAnyOfRoots(roots),
+                    "fixture source roots must match fixture scope");
+        }
+
+        @Test
+        void filteredScopeRejectsNonMatchingRoot() throws Exception {
+            IJavaProject jp = JavaCore.create(
+                    org.eclipse.core.resources.ResourcesPlugin
+                            .getWorkspace().getRoot()
+                            .getProject(TestFixture.PROJECT_NAME));
+            var roots = new HashSet<IPackageFragmentRoot>();
+            for (IPackageFragmentRoot r
+                    : jp.getPackageFragmentRoots()) {
+                if (r.getKind()
+                        == IPackageFragmentRoot.K_SOURCE) {
+                    roots.add(r);
+                }
+            }
+            ProjectScope scope = ProjectScope.of(
+                    Set.of("completely-different-project"));
+            assertFalse(scope.containsAnyOfRoots(roots));
+        }
+    }
+
+    @Nested
+    class ContainsLaunch {
+
+        @Test
+        void allScopeAcceptsLaunchWithoutConfig() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            assertTrue(ProjectScope.ALL.containsLaunch(launch));
+        }
+
+        @Test
+        void filteredScopeAcceptsLaunchWithNullConfig() {
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            ProjectScope scope = ProjectScope.of(
+                    Set.of("anything"));
+            assertTrue(scope.containsLaunch(launch),
+                    "null config → permissive");
+        }
+
+        @Test
+        void filteredScopeAcceptsLaunchWithMatchingProject()
+                throws Exception {
+            ILaunchManager mgr = DebugPlugin.getDefault()
+                    .getLaunchManager();
+            ILaunchConfigurationType type = mgr
+                    .getLaunchConfigurationType(
+                            "org.eclipse.jdt.junit.launchconfig");
+            var wc = type.newInstance(null, "scope-launch-test");
+            wc.setAttribute(
+                    "org.eclipse.jdt.launching.PROJECT_ATTR",
+                    "my-project");
+            ILaunch launch = new org.eclipse.debug.core.Launch(
+                    wc, "run", null);
+            ProjectScope scope = ProjectScope.of(
+                    Set.of("my-project"));
+            assertTrue(scope.containsLaunch(launch));
+        }
+    }
+
+    @Nested
+    class SearchScope {
+
+        @Test
+        void allScopeCreatesWorkspaceScope() {
+            IJavaSearchScope scope =
+                    ProjectScope.ALL.searchScope();
+            assertNotNull(scope);
+        }
+
+        @Test
+        void filteredScopeCreatesProjectScope() {
+            ProjectScope scope = ProjectScope.of(
+                    Set.of(TestFixture.PROJECT_NAME));
+            IJavaSearchScope searchScope = scope.searchScope();
+            assertNotNull(searchScope);
         }
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/RefactoringHandlerTest.java
@@ -1,0 +1,162 @@
+package io.github.kaluchi.jdtbridge;
+
+import io.github.kaluchi.jdtbridge.support.TestFixture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RefactoringHandler} — error paths and
+ * parameter validation. Success paths are covered by
+ * {@code RefactoringIntegrationTest} in plugin.tests.ui (needs
+ * workbench for auto-build waits after rename/move).
+ */
+public class RefactoringHandlerTest {
+
+    private static final RefactoringHandler handler =
+            new RefactoringHandler();
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        TestFixture.create();
+    }
+
+    private static JsonObject parseJson(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    private static void assertError(String json, String fragment) {
+        JsonObject obj = parseJson(json);
+        assertTrue(obj.has("error"),
+                "expected error field: " + json);
+        assertTrue(obj.get("error").getAsString().contains(fragment),
+                "expected '" + fragment + "' in: " + json);
+    }
+
+    // ── organize-imports errors ────────────────────────────────────
+
+    @Test
+    void organizeImportsMissingFileParamReturnsError() throws Exception {
+        assertError(
+                handler.handleOrganizeImports(Map.of()),
+                "Missing 'file' parameter");
+    }
+
+    @Test
+    void organizeImportsBlankFileParamReturnsError() throws Exception {
+        assertError(
+                handler.handleOrganizeImports(Map.of("file", "  ")),
+                "Missing 'file' parameter");
+    }
+
+    // ── format errors ─────────────────────────────────────────────
+
+    @Test
+    void formatMissingFileParamReturnsError() throws Exception {
+        assertError(
+                handler.handleFormat(Map.of()),
+                "Missing 'file' parameter");
+    }
+
+    @Test
+    void formatBlankFileParamReturnsError() throws Exception {
+        assertError(
+                handler.handleFormat(Map.of("file", "")),
+                "Missing 'file' parameter");
+    }
+
+    // ── rename errors ─────────────────────────────────────────────
+
+    @Test
+    void renameFieldNotFoundReturnsError() throws Exception {
+        assertError(
+                handler.handleRename(Map.of(
+                        "class", "test.model.Dog",
+                        "field", "nonExistentField",
+                        "newName", "x")),
+                "Field not found");
+    }
+
+    @Test
+    void renameMethodNotFoundReturnsError() throws Exception {
+        assertError(
+                handler.handleRename(Map.of(
+                        "class", "test.model.Dog",
+                        "method", "nonExistentMethod",
+                        "newName", "x")),
+                "Method not found");
+    }
+
+    // ── move errors ───────────────────────────────────────────────
+
+    @Test
+    void moveMissingClassParamReturnsError() throws Exception {
+        assertError(
+                handler.handleMove(Map.of("target", "some.pkg")),
+                "Missing 'class' parameter");
+    }
+
+    @Test
+    void moveTypeNotFoundReturnsError() throws Exception {
+        assertError(
+                handler.handleMove(Map.of(
+                        "class", "no.such.Type",
+                        "target", "some.pkg")),
+                "Type not found");
+    }
+
+    @Test
+    void moveBinaryTypeReturnsError() throws Exception {
+        assertError(
+                handler.handleMove(Map.of(
+                        "class", "java.lang.String",
+                        "target", "some.pkg")),
+                "Cannot move binary type");
+    }
+
+    // ── performRefactoring fatal error paths ─────────────────────
+
+    @Test
+    void renameToJavaKeywordReturnsFatalError() throws Exception {
+        String json = handler.handleRename(Map.of(
+                "class", "test.model.Dog",
+                "newName", "class"));
+        assertError(json, "");
+    }
+
+    @Test
+    void renameToSameNameReturnsFatalError() throws Exception {
+        String json = handler.handleRename(Map.of(
+                "class", "test.model.Dog",
+                "newName", "Dog"));
+        assertError(json, "");
+    }
+
+    // ── findCompilationUnit edge cases ────────────────────────────
+
+    @Test
+    void organizeImportsNonExistentPathReturnsError() throws Exception {
+        assertError(
+                handler.handleOrganizeImports(
+                        Map.of("file", "/no/such/File.java")),
+                "Java file not found");
+    }
+
+    @Test
+    void formatNonExistentPathReturnsError() throws Exception {
+        assertError(
+                handler.handleFormat(
+                        Map.of("file", "/no/such/File.java")),
+                "Java file not found");
+    }
+}

--- a/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/NodeBuilder.java
@@ -581,14 +581,7 @@ class NodeBuilder {
         obj.add("interfaces", interfaces);
 
         if (type.isAnonymous())  obj.addProperty("isAnonymous", true);
-        if (Flags.isDeprecated(type.getFlags())) {
-            obj.addProperty("isDeprecated", true);
-        }
-
-        String javadocSummary = javadocSummary(type);
-        if (javadocSummary != null) {
-            obj.addProperty("javadocSummary", javadocSummary);
-        }
+        addDeprecatedAndJavadoc(obj, type);
         return obj;
     }
 
@@ -651,14 +644,7 @@ class NodeBuilder {
         if (Flags.isDefaultMethod(method.getFlags())) {
             obj.addProperty("isDefault", true);
         }
-        if (Flags.isDeprecated(method.getFlags())) {
-            obj.addProperty("isDeprecated", true);
-        }
-
-        String javadocSummary = javadocSummary(method);
-        if (javadocSummary != null) {
-            obj.addProperty("javadocSummary", javadocSummary);
-        }
+        addDeprecatedAndJavadoc(obj, method);
         return obj;
     }
 
@@ -1015,6 +1001,17 @@ class NodeBuilder {
         return resource.getLocation().toOSString();
     }
 
+    private static void addDeprecatedAndJavadoc(JsonObject obj,
+            IMember member) throws JavaModelException {
+        if (Flags.isDeprecated(member.getFlags())) {
+            obj.addProperty("isDeprecated", true);
+        }
+        String summary = javadocSummary(member);
+        if (summary != null) {
+            obj.addProperty("javadocSummary", summary);
+        }
+    }
+
     // ── Source text extraction ─────────────────────────────────────
 
     /**
@@ -1212,14 +1209,7 @@ class NodeBuilder {
                 && Flags.isFinal(field.getFlags())) {
             obj.addProperty("isConstant", true);
         }
-        if (Flags.isDeprecated(field.getFlags())) {
-            obj.addProperty("isDeprecated", true);
-        }
-
-        String javadocSummary = javadocSummary(field);
-        if (javadocSummary != null) {
-            obj.addProperty("javadocSummary", javadocSummary);
-        }
+        addDeprecatedAndJavadoc(obj, field);
         return obj;
     }
 }

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/TestFixture.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.core.JavaCore;
  *   AbstractPet / Parrot — abstract hierarchy
  *   Repository           — generic erasure (List, Map signatures)
  *   SimpleTest           — JUnit 5 test class (for test-runner tests)
+ *   EdgeCaseMembers      — deprecated field, throws, javadoc (coverage edge cases)
  *
  * test.broken
  *   BrokenClass          — intentional compile error (UnknownType)
@@ -264,6 +265,27 @@ public class TestFixture {
 
             public class ObjectHolder {
                 public Object value;
+            }
+            """;
+
+    private static final String EDGE_MEMBERS_SRC = """
+            package test.edge;
+
+            /** Edge-case members for coverage of deprecated, throws, and javadoc paths. */
+            public class EdgeCaseMembers {
+                /** The count of items. */
+                @Deprecated
+                private int count;
+
+                /**
+                 * Processes the input.
+                 * @param input the data
+                 * @throws IllegalArgumentException if input is null
+                 */
+                public void process(String input) throws IllegalArgumentException {
+                    if (input == null) throw new IllegalArgumentException("null");
+                    count++;
+                }
             }
             """;
 
@@ -562,6 +584,9 @@ public class TestFixture {
                 "SimpleTest.java", SIMPLE_TEST_SRC, true, null);
         edgePkg.createCompilationUnit(
                 "ObjectHolder.java", OBJECT_HOLDER_SRC, true, null);
+        edgePkg.createCompilationUnit(
+                "EdgeCaseMembers.java",
+                EDGE_MEMBERS_SRC, true, null);
 
         // Refactoring targets
         IPackageFragment refactorPkg =


### PR DESCRIPTION
NodeBuilder: extract addDeprecatedAndJavadoc helper from typeDetail, methodDetail,
fieldDetail -- eliminates 3x duplicate deprecated+javadoc blocks.

Add EdgeCaseMembers fixture type (throws, @Deprecated field, javadoc) and 8 new tests:
- typeDetail javadocSummary (AbstractPet)
- typeDetail isAnonymous (anonymous Animal)
- methodDetail non-empty throws (EdgeCaseMembers.process)
- methodDetail javadocSummary (EdgeCaseMembers.process)
- fieldDetail isDeprecated (EdgeCaseMembers.count)
- fieldDetail javadocSummary (EdgeCaseMembers.count)
- sourceTextOf member slice (bark)
- sourceTextOf top-level type (Dog)

Coverage: 86.4% -> 87.7% instructions (313 missed, was 350)

- [x] Plugin tests: 903 passed
- [x] UI tests: 28 passed
- [x] Tycho verify: BUILD SUCCESS