### PR TITLE
Replace stub classes with Proxy + remove try-catch wrapper (-22 missed)

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestSessionHandlerTest.java
@@ -211,28 +211,25 @@ public class TestSessionHandlerTest {
         }
 
         @Test
-        void clearByTestRunIdRemovesThatSession() {
+        void clearByTestRunIdRemovesThatSession()
+                throws Exception {
             Map<String, String> launchParams = new HashMap<>();
             launchParams.put("target", SIMPLE_TEST_FQN);
             launchParams.put("no-refresh", "");
-            try {
-                String json = new TestHandler()
-                        .handleTestRun(launchParams);
-                JsonObject obj = JsonParser.parseString(json)
-                        .getAsJsonObject();
-                String tempRunId =
-                        obj.get("testRunId").getAsString();
-                TestSessionAwait.awaitFinished(
-                        tempRunId, 60_000);
+            String json = new TestHandler()
+                    .handleTestRun(launchParams);
+            JsonObject obj = JsonParser.parseString(json)
+                    .getAsJsonObject();
+            String tempRunId =
+                    obj.get("testRunId").getAsString();
+            TestSessionAwait.awaitFinished(
+                    tempRunId, 60_000);
 
-                JsonObject result = parse(
-                        handler.handleClear(
-                                params("testRunId", tempRunId)));
-                assertEquals(1,
-                        result.get("removed").getAsInt());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            JsonObject result = parse(
+                    handler.handleClear(
+                            params("testRunId", tempRunId)));
+            assertEquals(1,
+                    result.get("removed").getAsInt());
         }
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageAnalyzerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageAnalyzerTest.java
@@ -110,7 +110,7 @@ public class CoverageAnalyzerTest {
         @Test
         void invalidateUnknownIsNoop() {
             // Should not throw on a session never analyzed.
-            ICoverageSession fake = new TestSessionStub();
+            ICoverageSession fake = stubSession();
             analyzer.invalidate(fake);
             assertEquals(0, analyzer.cacheSize());
         }
@@ -161,22 +161,12 @@ public class CoverageAnalyzerTest {
         };
     }
 
-    /** Bare stub used only for {@link
-     *  Invalidation#invalidateUnknownIsNoop} where we need an
-     *  ICoverageSession instance that isn't from EclEmma. */
-    private static final class TestSessionStub
-            implements ICoverageSession {
-        @Override public String getDescription() { return "stub"; }
-        @Override public Set<org.eclipse.jdt.core.IPackageFragmentRoot>
-                getScope() { return Set.of(); }
-        @Override public org.eclipse.debug.core.ILaunchConfiguration
-                getLaunchConfiguration() { return null; }
-        @Override public void accept(
-                org.jacoco.core.data.IExecutionDataVisitor execVisitor,
-                org.jacoco.core.data.ISessionInfoVisitor
-                        sessionInfoVisitor) { }
-        @Override public <T> T getAdapter(Class<T> adapter) {
-            return null;
-        }
+    @SuppressWarnings("restriction")
+    private static ICoverageSession stubSession() {
+        return (ICoverageSession) java.lang.reflect.Proxy
+                .newProxyInstance(
+                        ICoverageSession.class.getClassLoader(),
+                        new Class<?>[] { ICoverageSession.class },
+                        (p, m, a) -> null);
     }
 }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageRunTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageRunTest.java
@@ -176,7 +176,7 @@ public class CoverageRunTest {
                     null, new Launch(null, "coverage", null), 1L,
                     Set.of());
             for (int i = 0; i < n; i++) {
-                run.sessions.add(new FakeSession("dump-" + i));
+                run.sessions.add(fakeSession("dump-" + i));
                 run.dumpedAt.add((long) i);
             }
             return run;
@@ -226,44 +226,14 @@ public class CoverageRunTest {
         }
     }
 
-    /** Bare-bones {@link ICoverageSession} stub for resolve tests —
-     *  only {@code getDescription()} is queried. */
-    @SuppressWarnings("restriction")
-	private static final class FakeSession
-            implements ICoverageSession {
-        private final String desc;
-
-        FakeSession(String desc) {
-            this.desc = desc;
-        }
-
-        @Override
-        public String getDescription() {
-            return desc;
-        }
-
-        @Override
-        public Set<org.eclipse.jdt.core.IPackageFragmentRoot>
-                getScope() {
-            return Set.of();
-        }
-
-        @Override
-        public org.eclipse.debug.core.ILaunchConfiguration
-                getLaunchConfiguration() {
-            return null;
-        }
-
-        @Override
-        public void accept(
-                org.jacoco.core.data.IExecutionDataVisitor execVisitor,
-                org.jacoco.core.data.ISessionInfoVisitor
-                        sessionInfoVisitor) {
-        }
-
-        @Override
-        public <T> T getAdapter(Class<T> adapter) {
-            return null;
-        }
+    @SuppressWarnings({"restriction", "unchecked"})
+    private static ICoverageSession fakeSession(String desc) {
+        return (ICoverageSession) java.lang.reflect.Proxy
+                .newProxyInstance(
+                        ICoverageSession.class.getClassLoader(),
+                        new Class<?>[] { ICoverageSession.class },
+                        (p, m, a) -> java.util.Map.of(
+                                "getDescription", (Object) desc)
+                                .getOrDefault(m.getName(), null));
     }
 }


### PR DESCRIPTION
## Summary

- CoverageAnalyzerTest: replace TestSessionStub class with Proxy (9 to 0 missed)
- CoverageRunTest: replace FakeSession class with Proxy factory (7 to 0 missed)
- TestSessionHandlerTest.HandleClear: remove try-catch, add throws Exception (6 to 0 missed)

All three patterns had uncalled interface method bodies or catch blocks that bytecode-branched but never executed.

## Test plan

- [x] 1058 plugin tests pass
- [x] CoverageAnalyzerTest 8/8
- [x] CoverageRunTest 19/19
- [x] TestSessionHandlerTest 13/13