### PR TITLE
Plugin coverage: dispatch routes + handleNode scoped tests (81.3% → 82.7%)

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpServerDispatchTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/HttpServerDispatchTest.java
@@ -149,9 +149,89 @@ public class HttpServerDispatchTest {
         }
 
         @Test
+        void overloadsRouteReturnsJson() {
+            var resp = server.dispatch("/overloads",
+                    Map.of("of", "test.edge.Calculator#add(int,int)"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
         void packageRouteReturnsJson() {
             var resp = server.dispatch("/package",
                     Map.of("of", "test.model"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void methodRouteReturnsJson() {
+            var resp = server.dispatch("/method",
+                    Map.of("of", "test.model.Dog#name()"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void fieldRouteReturnsJson() {
+            var resp = server.dispatch("/field",
+                    Map.of("of", "test.model.Dog#age"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void outgoingRefsRouteReturnsJson() {
+            var resp = server.dispatch("/outgoingRefs",
+                    Map.of("of", "test.model.Dog#name()"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void projectRouteReturnsJson() {
+            var resp = server.dispatch("/project",
+                    Map.of("of", TestFixture.PROJECT_NAME),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void classpathRouteReturnsJson() {
+            var resp = server.dispatch("/classpath",
+                    Map.of("of", TestFixture.PROJECT_NAME),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void fileRouteReturnsJson() {
+            var resp = server.dispatch("/file",
+                    Map.of("of", "test.model.Dog"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void typesInPackageRouteReturnsJson() {
+            var resp = server.dispatch("/typesInPackage",
+                    Map.of("of", "test.model"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void typesInFileRouteReturnsJson() {
+            var resp = server.dispatch("/typesInFile",
+                    Map.of("of", "test.model.Dog"),
+                    null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void packagesInProjectRouteReturnsJson() {
+            var resp = server.dispatch("/packagesInProject",
+                    Map.of("of", TestFixture.PROJECT_NAME),
                     null, ProjectScope.ALL);
             assertEquals("application/json", resp.contentType());
         }
@@ -193,6 +273,27 @@ public class HttpServerDispatchTest {
             var resp = server.dispatch("/test/sessions",
                     Map.of(), null, ProjectScope.ALL);
             assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void testStatusMissingIdErrors() {
+            var resp = server.dispatch("/test/status",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void testClearReturnsJson() {
+            var resp = server.dispatch("/test/clear",
+                    Map.of(), null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void testRunMissingClassErrors() {
+            var resp = server.dispatch("/test/run",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
         }
     }
 
@@ -246,8 +347,15 @@ public class HttpServerDispatchTest {
         }
 
         @Test
-        void coverageRouteReturnsJson() {
-            var resp = server.dispatch("/coverage/runs",
+        void refreshRouteReturnsJson() {
+            var resp = server.dispatch("/refresh",
+                    Map.of(), null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void mavenUpdateRouteReturnsJson() {
+            var resp = server.dispatch("/maven/update",
                     Map.of(), null, ProjectScope.ALL);
             assertEquals("application/json", resp.contentType());
         }
@@ -257,6 +365,133 @@ public class HttpServerDispatchTest {
             var resp = server.dispatch("/no-such-path",
                     Map.of(), null, ProjectScope.ALL);
             assertTrue(resp.body().contains("Unknown path"));
+        }
+    }
+
+    @Nested
+    class CoverageRoutes {
+
+        @Test
+        void coverageRunsReturnsJson() {
+            var resp = server.dispatch("/coverage/runs",
+                    Map.of(), null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void coverageActiveReturnsJson() {
+            var resp = server.dispatch("/coverage/active",
+                    Map.of(), null, ProjectScope.ALL);
+            assertEquals("application/json", resp.contentType());
+        }
+
+        @Test
+        void coverageSessionMissingIdErrors() {
+            var resp = server.dispatch("/coverage/session",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("coverage-not-found"));
+        }
+
+        @Test
+        void coverageNodeMissingIdErrors() {
+            var resp = server.dispatch("/coverage/node",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("coverage-not-found"));
+        }
+
+        @Test
+        void coverageRunMissingConfigErrors() {
+            var resp = server.dispatch("/coverage/run",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void coverageDumpMissingBodyErrors() {
+            var resp = server.dispatch("/coverage/dump",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void coverageRefreshNoActiveErrors() {
+            var resp = server.dispatch("/coverage/refresh",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void coverageRelaunchNoActiveErrors() {
+            var resp = server.dispatch("/coverage/relaunch",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void coverageActivateMissingBodyErrors() {
+            var resp = server.dispatch("/coverage/activate",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void coverageMergeMissingBodyErrors() {
+            var resp = server.dispatch("/coverage/merge",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void coverageRemoveNoActiveErrors() {
+            var resp = server.dispatch("/coverage/remove",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+    }
+
+    @Nested
+    class AdditionalLaunchRoutes {
+
+        @Test
+        void launchConsoleMissingIdErrors() {
+            var resp = server.dispatch("/launch/console",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void launchRunMissingIdErrors() {
+            var resp = server.dispatch("/launch/run",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void launchStopMissingIdErrors() {
+            var resp = server.dispatch("/launch/stop",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void launchConfigMissingIdErrors() {
+            var resp = server.dispatch("/launch/config",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("error"));
+        }
+
+        @Test
+        void launchConfigDeleteMissingIdErrors() {
+            var resp = server.dispatch("/launch/config/delete",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("Missing"));
+        }
+
+        @Test
+        void launchImportMissingIdErrors() {
+            var resp = server.dispatch("/launch/import",
+                    Map.of(), null, ProjectScope.ALL);
+            assertTrue(resp.body().contains("Missing"));
         }
     }
 

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -322,6 +322,48 @@ public class CoverageSessionHandlerTest {
             assertEquals("coverage-dump-not-found",
                     obj.get("error").getAsString());
         }
+
+        @Test
+        void resolvableFqnInScopeReturnsCountersAndLines()
+                throws Exception {
+            var root = org.eclipse.core.resources.ResourcesPlugin
+                    .getWorkspace().getRoot();
+            var project = org.eclipse.jdt.core.JavaCore.create(
+                    root.getProject(TestFixture.PROJECT_NAME));
+            var srcRoot = project.getPackageFragmentRoot(
+                    root.getProject(TestFixture.PROJECT_NAME)
+                            .getFolder("src"));
+
+            ISessionImporter importer = CoverageTools.getImporter();
+            importer.setDescription("node-with-scope");
+            importer.setScope(Set.of(srcRoot));
+            importer.setExecutionDataSource(
+                    TestCoverageStubs.emptyDataSource());
+            importer.setCopy(false);
+            importer.importSession(
+                    new org.eclipse.core.runtime
+                            .NullProgressMonitor());
+            org.eclipse.core.runtime.jobs.Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+            String coverageId = tracker.snapshot().values().stream()
+                    .filter(r -> "node-with-scope"
+                            .equals(r.description))
+                    .map(r -> r.coverageId)
+                    .findFirst()
+                    .orElseThrow();
+
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", coverageId,
+                    "fqn", "test.model.Dog")));
+            assertNotNull(obj.get("counters"),
+                    "Should have counters: " + obj);
+            assertNotNull(obj.get("lines"),
+                    "Should have lines block: " + obj);
+            assertEquals("test.model.Dog",
+                    obj.get("fqn").getAsString());
+            assertEquals("type",
+                    obj.get("elementKind").getAsString());
+        }
     }
 
     @Nested

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -324,34 +324,9 @@ public class CoverageSessionHandlerTest {
         }
 
         @Test
-        void resolvableFqnInScopeReturnsCountersAndLines()
+        void typeInScopeReturnsCountersAndLines()
                 throws Exception {
-            var root = org.eclipse.core.resources.ResourcesPlugin
-                    .getWorkspace().getRoot();
-            var project = org.eclipse.jdt.core.JavaCore.create(
-                    root.getProject(TestFixture.PROJECT_NAME));
-            var srcRoot = project.getPackageFragmentRoot(
-                    root.getProject(TestFixture.PROJECT_NAME)
-                            .getFolder("src"));
-
-            ISessionImporter importer = CoverageTools.getImporter();
-            importer.setDescription("node-with-scope");
-            importer.setScope(Set.of(srcRoot));
-            importer.setExecutionDataSource(
-                    TestCoverageStubs.emptyDataSource());
-            importer.setCopy(false);
-            importer.importSession(
-                    new org.eclipse.core.runtime
-                            .NullProgressMonitor());
-            org.eclipse.core.runtime.jobs.Job.getJobManager().join(
-                    CoverageTracker.CLASSIFY_FAMILY, null);
-            String coverageId = tracker.snapshot().values().stream()
-                    .filter(r -> "node-with-scope"
-                            .equals(r.description))
-                    .map(r -> r.coverageId)
-                    .findFirst()
-                    .orElseThrow();
-
+            String coverageId = importWithScope("node-type");
             JsonObject obj = parseObj(handler.handleNode(Map.of(
                     "coverageId", coverageId,
                     "fqn", "test.model.Dog")));
@@ -363,6 +338,55 @@ public class CoverageSessionHandlerTest {
                     obj.get("fqn").getAsString());
             assertEquals("type",
                     obj.get("elementKind").getAsString());
+        }
+
+        @Test
+        void methodInScopeReturnsCounters() throws Exception {
+            String coverageId = importWithScope("node-method");
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", coverageId,
+                    "fqn", "test.model.Dog#name()")));
+            assertNotNull(obj.get("counters"),
+                    "Should have counters: " + obj);
+            assertEquals("method",
+                    obj.get("elementKind").getAsString());
+        }
+
+        @Test
+        void fieldReturnsNoDataForElement() throws Exception {
+            String coverageId = importWithScope("node-field");
+            JsonObject obj = parseObj(handler.handleNode(Map.of(
+                    "coverageId", coverageId,
+                    "fqn", "test.model.Dog#age")));
+            assertEquals("coverage-no-data-for-element",
+                    obj.get("error").getAsString());
+        }
+
+        private String importWithScope(String desc)
+                throws Exception {
+            var root = org.eclipse.core.resources.ResourcesPlugin
+                    .getWorkspace().getRoot();
+            var project = org.eclipse.jdt.core.JavaCore.create(
+                    root.getProject(TestFixture.PROJECT_NAME));
+            var srcRoot = project.getPackageFragmentRoot(
+                    root.getProject(TestFixture.PROJECT_NAME)
+                            .getFolder("src"));
+            ISessionImporter importer = CoverageTools.getImporter();
+            importer.setDescription(desc);
+            importer.setScope(Set.of(srcRoot));
+            importer.setExecutionDataSource(
+                    TestCoverageStubs.emptyDataSource());
+            importer.setCopy(false);
+            importer.importSession(
+                    new org.eclipse.core.runtime
+                            .NullProgressMonitor());
+            org.eclipse.core.runtime.jobs.Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+            return tracker.snapshot().values().stream()
+                    .filter(r -> desc.equals(r.description))
+                    .map(r -> r.coverageId)
+                    .findFirst()
+                    .orElseThrow();
         }
     }
 


### PR DESCRIPTION
## Summary

- Add 31 dispatch route tests covering every switch arm in HttpServer.dispatch
- Add handleNode success-path tests with scoped imported sessions -- exercises linesJson, elementKind switch, counters response
- Extract importWithScope helper for coverage tests needing real scope

Headless suite: 1092 tests, 82.7% instruction coverage (was 81.3%)
Combined headless+UI: ~84% (EditorHandler covered by UI suite)

## Test plan

- [x] 1092 headless tests pass
- [x] 35 UI tests pass
- [x] Tycho verify green
- [x] CI checks pass