### PR TITLE
Plugin coverage: refreshProject + CoverageHandler cleanup (82.9%)

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/TestHandlerIntegrationTest.java
@@ -192,6 +192,18 @@ public class TestHandlerIntegrationTest {
     }
 
     @Test
+    public void launchWithRefreshProject() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "test.edge.SimpleTest");
+        String json = handler.handleTestRun(params);
+        var obj = com.google.gson.JsonParser.parseString(json)
+                .getAsJsonObject();
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "handleTestRun without no-refresh: " + json);
+        terminateLaunch(obj.get("configId").getAsString());
+    }
+
+    @Test
     public void emptyTargetReturnsError() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("target", "   ");

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
@@ -10,8 +10,9 @@ import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.eclemma.core.CoverageTools;
-import org.eclipse.eclemma.core.IExecutionDataSource;
 import org.eclipse.eclemma.core.ISessionImporter;
+
+import io.github.kaluchi.jdtbridge.support.TestCoverageStubs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -288,7 +289,8 @@ public class CoverageHandlerTest {
 		ISessionImporter importer = CoverageTools.getImporter();
         importer.setDescription(description);
         importer.setScope(Set.of());
-        importer.setExecutionDataSource(emptyDataSource());
+        importer.setExecutionDataSource(
+                TestCoverageStubs.emptyDataSource());
         importer.setCopy(false);
         importer.importSession(new NullProgressMonitor());
         Job.getJobManager().join(
@@ -298,12 +300,5 @@ public class CoverageHandlerTest {
                 .map(r -> r.coverageId)
                 .findFirst()
                 .orElseThrow();
-    }
-
-    @SuppressWarnings("restriction")
-	private static IExecutionDataSource emptyDataSource() {
-        return (execVisitor, sessionInfoVisitor) -> {
-            // Intentionally empty.
-        };
     }
 }


### PR DESCRIPTION
## Summary

- Add TestHandler integration test without no-refresh to exercise refreshProject path (+43 instructions)
- Replace inline emptyDataSource in CoverageHandlerTest with TestCoverageStubs

Headless: 1093 tests, 82.9% instruction coverage

## Test plan

- [x] 1093 headless + 35 UI tests pass
- [x] Tycho verify green
- [ ] CI checks pass