### PR TITLE
Bump qlang to 0.5.0

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kaluchi/qlang-cli": "^0.4.0",
-        "@kaluchi/qlang-core": "^0.4.0",
+        "@kaluchi/qlang-cli": "^0.5.0",
+        "@kaluchi/qlang-core": "^0.5.0",
         "picocolors": "^1.1.0",
         "tree-kill": "^1.2.2"
       },
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@kaluchi/qlang-cli": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-cli/-/qlang-cli-0.4.0.tgz",
-      "integrity": "sha512-JPocuOrp0I8qX30zYcVPQM423I2KZeuT4DXMmx9v9oa4ih/Fj6e7ZlWxDYfcYm+gw5uR2C822/T29WWFBJDxIA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-cli/-/qlang-cli-0.5.0.tgz",
+      "integrity": "sha512-YCTUsaupyCHVtNu/hHeC6WLa3rkpwPW5j6YB+47BJolIbCuSoPXjunrFQsA2pvcXWUKZnuHA6jvov6lHmMh1ZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kaluchi/qlang-core": "*"
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@kaluchi/qlang-core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-core/-/qlang-core-0.4.0.tgz",
-      "integrity": "sha512-btN3caEEttkP/mDGx7PSvk/W2OQAVYGAELW4VA5VfBH43nMuH49Oft9b1pCA8qVofwyoHnrvAaoU3BmWGJeEcQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-core/-/qlang-core-0.5.0.tgz",
+      "integrity": "sha512-2URL+u1UaWWI+khav6YQ3khq8lXud3AmAGbJvFQ28wx4YNrG0K+vF90JhdbfbYn17lh3L/HF+khcGbHYmcI19Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/cli/package.json
+++ b/cli/package.json
@@ -44,8 +44,8 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "@kaluchi/qlang-core": "^0.4.0",
-    "@kaluchi/qlang-cli": "^0.4.0",
+    "@kaluchi/qlang-core": "^0.5.0",
+    "@kaluchi/qlang-cli": "^0.5.0",
     "picocolors": "^1.1.0",
     "tree-kill": "^1.2.2"
   }


### PR DESCRIPTION
## Summary

- Bump @kaluchi/qlang-core and @kaluchi/qlang-cli from 0.4.0 to 0.5.0
- New in 0.5.0: :fault error descriptor, :combinator in trail entries, REPL trail materialization

## Test plan

- [x] 841 CLI tests pass
- [ ] CI checks pass