### PR TITLE
Plugin coverage: launch lifecycle + runResponse tests (83% → 85%)

### DIFF
--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/GraphHandlerTest.java
@@ -1337,6 +1337,69 @@ public class GraphHandlerTest {
         assertTrue(isError(result));
     }
 
+    // ── Additional validation paths ────────────────────────────────
+
+    @Test
+    void refsToWriteOnFieldUsesWriteAccessesPattern() {
+        var arr = JsonParser.parseString(handler.handleRefsTo(
+                paramsMulti("of",
+                        "test.edge.Outer.StaticNested#VALUE",
+                        "refKind", "write"),
+                ProjectScope.ALL)).getAsJsonArray();
+        // VALUE is final — write accesses may be empty or only
+        // at the initializer. The important thing is it doesn't
+        // error and uses the WRITE_ACCESSES pattern.
+        assertNotNull(arr);
+    }
+
+    @Test
+    void refsToMissingOfReturnsError() {
+        JsonObject result = parse(handler.handleRefsTo(
+                Map.of(), ProjectScope.ALL));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void packagesInProjectUnknownProjectReturnsError() {
+        JsonObject result = parse(
+                handler.handlePackagesInProject(
+                        params("of", "no-such-project-xyz")));
+        assertTrue(isError(result));
+        assertEquals("project-not-found",
+                errorOf(result).get("kind").getAsString());
+    }
+
+    @Test
+    void sourceErrorWhenOfMissing() {
+        JsonObject result = parse(
+                handler.handleSource(Map.of()));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void outgoingRefsErrorWhenOfMissing() {
+        JsonObject result = parse(handler.handleOutgoingRefs(
+                Map.of(), ProjectScope.ALL));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void outgoingRefsErrorOnUnknownTarget() {
+        JsonObject result = parse(handler.handleOutgoingRefs(
+                params("of", "no.such.Type"),
+                ProjectScope.ALL));
+        assertTrue(isError(result));
+    }
+
+    @Test
+    void typesInFileForNonJavaReturnsError() throws Exception {
+        // Use a file that exists but isn't a Java source
+        String pomPath = "D:/git/eclipse-jdt-search/pom.xml";
+        JsonObject result = parse(
+                handler.handleTypesInFile(params("of", pomPath)));
+        assertTrue(isError(result));
+    }
+
     // ── Cross-cutting: every error carries origin :jdt/plugin ───────
 
     @Test

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBusTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageEventBusTest.java
@@ -124,14 +124,10 @@ public class CoverageEventBusTest {
         @Test
         void thrownByOneListenerDoesNotBlockOthers() {
             CountingListener after = new CountingListener();
-            bus.subscribe("X:1", new CoverageTracker.CoverageEventListener() {
-                @Override public void onDumped(CoverageRun r, int i, long t) {}
-                @Override public void onAnalysisLoading(CoverageRun r) {}
-                @Override public void onAnalysisReady(CoverageRun r) {}
+            bus.subscribe("X:1", new CountingListener() {
                 @Override public void onTerminated(CoverageRun r) {
                     throw new RuntimeException("intentional");
                 }
-                @Override public void onFailed(CoverageRun r, String reason) {}
             });
             bus.subscribe("X:1", after);
             bus.fire("X:1", l -> l.onTerminated(null));
@@ -157,7 +153,7 @@ public class CoverageEventBusTest {
     /** Listener that just counts how many times each callback
      *  was invoked. CoverageRun arg is ignored — bus
      *  contract is just "deliver call-by-call". */
-    private static final class CountingListener
+    private static class CountingListener
             implements CoverageTracker.CoverageEventListener {
         final AtomicInteger dumped = new AtomicInteger();
         final AtomicInteger loading = new AtomicInteger();

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandlerTest.java
@@ -5,13 +5,16 @@ import com.google.gson.JsonParser;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
 import org.eclipse.eclemma.core.ISessionImporter;
 
+import io.github.kaluchi.jdtbridge.support.FakeCoverageLaunch;
 import io.github.kaluchi.jdtbridge.support.TestCoverageStubs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +27,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -248,12 +252,200 @@ public class CoverageHandlerTest {
     }
 
     @Nested
+    class HandleDumpLiveRun {
+
+        private ILaunchConfiguration config;
+
+        @BeforeEach
+        void createConfig() throws Exception {
+            ILaunchManager mgr = DebugPlugin.getDefault()
+                    .getLaunchManager();
+            ILaunchConfigurationType type =
+                    mgr.getLaunchConfigurationType(
+                            "org.eclipse.jdt.junit.launchconfig");
+            String name = "dump-live-" + UUID.randomUUID();
+            ILaunchConfigurationWorkingCopy wc =
+                    type.newInstance(null, name);
+            config = wc.doSave();
+        }
+
+        @AfterEach
+        void deleteConfig() throws Exception {
+            config.delete();
+        }
+
+        @Test
+        void terminatedLiveRunReturnsTerminatedError() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            String coverageId = tracker.snapshot().keySet()
+                    .iterator().next();
+            tracker.launchesTerminated(new ILaunch[]{launch});
+
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"" + coverageId + "\"}"));
+            assertEquals("coverage-launch-terminated",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void liveDumpRequestsFromAgent() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            String coverageId = tracker.snapshot().keySet()
+                    .iterator().next();
+
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"" + coverageId
+                            + "\",\"reset\":true}"));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertTrue(launch.wasDumpRequested());
+            assertTrue(launch.wasDumpReset());
+        }
+
+        @Test
+        void liveDumpWithoutResetDefaultsToFalse() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            String coverageId = tracker.snapshot().keySet()
+                    .iterator().next();
+
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"" + coverageId + "\"}"));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertTrue(launch.wasDumpRequested());
+            assertFalse(launch.wasDumpReset());
+        }
+
+        @Test
+        void blankCoverageIdInDumpReturnsNotFound() {
+            JsonObject obj = parseObj(handler.handleDump(
+                    "{\"coverageId\":\"  \"}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+    }
+
+    @Nested
+    class RunResponse {
+
+        private ILaunchConfiguration config;
+
+        @BeforeEach
+        void createConfig() throws Exception {
+            ILaunchManager mgr = DebugPlugin.getDefault()
+                    .getLaunchManager();
+            ILaunchConfigurationType type =
+                    mgr.getLaunchConfigurationType(
+                            "org.eclipse.jdt.junit.launchconfig");
+            String name = "run-resp-" + UUID.randomUUID();
+            ILaunchConfigurationWorkingCopy wc =
+                    type.newInstance(null, name);
+            config = wc.doSave();
+        }
+
+        @AfterEach
+        void deleteConfig() throws Exception {
+            config.delete();
+        }
+
+        @Test
+        void responseContainsConfigAndCoverageId() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(launch));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertEquals(config.getName(),
+                    obj.get("configId").getAsString());
+            assertTrue(obj.has("coverageId"));
+            assertTrue(obj.get("coverageId").getAsString()
+                    .startsWith(config.getName() + ":"));
+        }
+
+        @Test
+        void responseContainsLaunchTimestamp() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(launch));
+            assertTrue(obj.has("launchTimestamp"));
+            assertNotEquals(0,
+                    obj.get("launchTimestamp").getAsLong());
+        }
+
+        @Test
+        void responseContainsConfigType() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(launch));
+            assertTrue(obj.has("configType"));
+            assertTrue(obj.has("configTypeId"));
+        }
+
+        @Test
+        void responseContainsLaunchId() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(launch));
+            assertTrue(obj.has("launchId"));
+        }
+
+        @Test
+        void responseContainsCoverageScope() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(launch));
+            assertTrue(obj.has("coverageScope"));
+            assertTrue(obj.get("coverageScope").isJsonArray());
+        }
+
+        @Test
+        void nonCoverageLaunchOmitsScope() {
+            ILaunch plain = new org.eclipse.debug.core.Launch(
+                    config, "run", null);
+            plain.setAttribute(
+                    org.eclipse.debug.core.DebugPlugin
+                            .ATTR_LAUNCH_TIMESTAMP,
+                    Long.toString(System.currentTimeMillis()));
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(plain));
+            assertTrue(obj.get("ok").getAsBoolean());
+            assertFalse(obj.has("coverageScope"));
+        }
+
+        @Test
+        void launchWithoutTimestampUsesConfigIdAsCoverageId() {
+            ILaunch plain = new org.eclipse.debug.core.Launch(
+                    config, "run", null);
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(plain));
+            assertEquals(config.getName(),
+                    obj.get("coverageId").getAsString());
+            assertFalse(obj.has("launchTimestamp"));
+        }
+
+        @Test
+        void launchWithoutConfigUsesEmptyConfigId() {
+            ILaunch plain = new org.eclipse.debug.core.Launch(
+                    null, "run", null);
+            JsonObject obj = parseObj(
+                    CoverageHandler.runResponse(plain));
+            assertEquals("", obj.get("configId").getAsString());
+        }
+    }
+
+    @Nested
     class ErrorJsonShape {
 
         @Test
         void everyErrorHasErrorAndMessage() throws Exception {
-            // Iterate the validation paths that don't require a
-            // real launch and assert the error JSON shape.
             String[] errorJsons = {
                     handler.handleRun(Map.of()),
                     handler.handleRun(

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageProgressStreamerTest.java
@@ -468,8 +468,8 @@ public class CoverageProgressStreamerTest {
         // other jobs in the manager queue — local runs settle
         // sub-millisecond.
         TestAwait.pollUntil(30_000,
-                () -> !tracker.byCoverageId(coverageId)
-                        .analysisLoading,
+                () -> tracker.byCoverageId(coverageId)
+                        .analysisReady,
                 "LoadSessionJob did not settle within 30s for "
                         + coverageId);
     }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageSessionHandlerTest.java
@@ -4,10 +4,17 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.github.kaluchi.jdtbridge.ProjectScope;
+import io.github.kaluchi.jdtbridge.support.FakeCoverageLaunch;
 import io.github.kaluchi.jdtbridge.support.TestCoverageStubs;
 import io.github.kaluchi.jdtbridge.support.TestFixture;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.eclemma.core.CoverageTools;
 import org.eclipse.eclemma.core.IExecutionDataSource;
 import org.eclipse.eclemma.core.ISessionImporter;
@@ -22,8 +29,10 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,6 +105,40 @@ public class CoverageSessionHandlerTest {
                         "Missing required field '" + required
                                 + "': " + entry);
             }
+        }
+
+        @Test
+        void liveRunCarriesLaunchIdAndConfigType() throws Exception {
+            ILaunchManager mgr = DebugPlugin.getDefault()
+                    .getLaunchManager();
+            ILaunchConfigurationType type =
+                    mgr.getLaunchConfigurationType(
+                            "org.eclipse.jdt.junit.launchconfig");
+            String name = "session-live-" + UUID.randomUUID();
+            ILaunchConfigurationWorkingCopy wc =
+                    type.newInstance(null, name);
+            ILaunchConfiguration cfg = wc.doSave();
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(cfg, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            JsonArray arr = JsonParser.parseString(
+                            handler.handleRuns(ProjectScope.ALL))
+                    .getAsJsonArray();
+            JsonObject live = null;
+            for (var el : arr) {
+                JsonObject o = el.getAsJsonObject();
+                if ("live".equals(o.get("coverageSessionKind")
+                        .getAsString())) {
+                    live = o;
+                    break;
+                }
+            }
+            assertNotNull(live);
+            assertFalse(live.get("launchId").isJsonNull());
+            assertFalse(live.get("configType").isJsonNull());
+            assertEquals(name, live.get("configId").getAsString());
+            cfg.delete();
         }
 
         @Test
@@ -501,6 +544,22 @@ public class CoverageSessionHandlerTest {
         void unknownIdReturnsCoverageNotFound() {
             JsonObject obj = parseObj(handler.handleActivate(
                     "{\"coverageId\":\"Bogus:1\"}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void missingCoverageIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleActivate(
+                    "{\"reset\":true}"));
+            assertEquals("coverage-not-found",
+                    obj.get("error").getAsString());
+        }
+
+        @Test
+        void blankCoverageIdReturnsCoverageNotFound() {
+            JsonObject obj = parseObj(handler.handleActivate(
+                    "{\"coverageId\":\"  \"}"));
             assertEquals("coverage-not-found",
                     obj.get("error").getAsString());
         }

--- a/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
+++ b/plugin.tests/src/io/github/kaluchi/jdtbridge/coverage/CoverageTrackerTest.java
@@ -2,20 +2,31 @@ package io.github.kaluchi.jdtbridge.coverage;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.eclemma.core.CoverageTools;
+import org.eclipse.eclemma.core.ICoverageSession;
 import org.eclipse.eclemma.core.ISessionImporter;
 import org.eclipse.eclemma.core.ISessionManager;
 
+import io.github.kaluchi.jdtbridge.support.FakeCoverageLaunch;
 import io.github.kaluchi.jdtbridge.support.TestCoverageStubs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -54,18 +65,20 @@ public class CoverageTrackerTest {
         void startIsIdempotent() {
             tracker.start();
             tracker.start();
-            // No assertion beyond "did not throw" — duplicate
-            // start should be a no-op.
         }
 
         @Test
         void stopThenStartReregisters() throws Exception {
             tracker.stop();
             tracker.start();
-            // Listener registration must succeed — verify by
-            // firing an import and seeing the run appear.
             String coverageId = importAndAwait("alpha");
             assertNotNull(tracker.byCoverageId(coverageId));
+        }
+
+        @Test
+        void stopWithoutStartIsNoOp() {
+            CoverageTracker fresh = new CoverageTracker();
+            fresh.stop();
         }
 
         @Test
@@ -225,25 +238,295 @@ public class CoverageTrackerTest {
         @Test
         void twoImportsInSameMillisecondGetUniqueIds()
                 throws Exception {
-            // Force the issue by reusing the same start time —
-            // we can't fully control Java's clock granularity, but
-            // calling import twice back-to-back routinely lands
-            // both events in the same millisecond on modern CPUs.
             String firstId = importAndAwait("collide-1");
             String secondId = importAndAwait("collide-2");
             assertNotNull(firstId);
             assertNotNull(secondId);
-            // The two coverage IDs must differ regardless of
-            // millisecond clock alignment.
-            org.junit.jupiter.api.Assertions.assertNotEquals(
-                    firstId, secondId);
+            assertNotEquals(firstId, secondId);
         }
     }
 
-    /** Trigger {@code SessionImporter.importSession} with a no-op
-     *  execution-data source, then block until the deferred
-     *  classification job has run. Returns the assigned
-     *  {@code coverageId}. */
+    @Nested
+    class LaunchLifecycle {
+
+        private ILaunchConfiguration config;
+
+        @BeforeEach
+        void createConfig() throws Exception {
+            ILaunchManager mgr = DebugPlugin.getDefault()
+                    .getLaunchManager();
+            ILaunchConfigurationType type =
+                    mgr.getLaunchConfigurationType(
+                            "org.eclipse.jdt.junit.launchconfig");
+            assertNotNull(type);
+            String name = "tracker-test-" + UUID.randomUUID();
+            ILaunchConfigurationWorkingCopy wc =
+                    type.newInstance(null, name);
+            config = wc.doSave();
+        }
+
+        @AfterEach
+        void deleteConfig() throws Exception {
+            config.delete();
+        }
+
+        @Test
+        void launchesAddedRegistersLiveRun() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            Map<String, CoverageRun> snap = tracker.snapshot();
+            assertEquals(1, snap.size());
+            CoverageRun run = snap.values().iterator().next();
+            assertEquals(CoverageRun.Kind.LIVE, run.kind);
+            assertEquals(config.getName(), run.configId);
+            assertFalse(run.terminated);
+            assertSame(launch, run.launch);
+        }
+
+        @Test
+        void launchesAddedIgnoresNonCoverageLaunch() {
+            ILaunch plain = new org.eclipse.debug.core.Launch(
+                    config, "run", null);
+            tracker.launchesAdded(new ILaunch[]{plain});
+            assertTrue(tracker.snapshot().isEmpty());
+        }
+
+        @Test
+        void launchesAddedSkipsNullConfig() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(null, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            assertTrue(tracker.snapshot().isEmpty());
+        }
+
+        @Test
+        void launchesAddedIdempotent() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            tracker.launchesAdded(new ILaunch[]{launch});
+            assertEquals(1, tracker.snapshot().size());
+        }
+
+        @Test
+        void launchesTerminatedMarksCoverageRun() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            tracker.launchesTerminated(new ILaunch[]{launch});
+
+            CoverageRun run = tracker.snapshot().values()
+                    .iterator().next();
+            assertTrue(run.terminated);
+            assertNotNull(run.terminatedAt);
+        }
+
+        @Test
+        void launchesTerminatedIdempotentOnTimestamp() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            tracker.launchesTerminated(new ILaunch[]{launch});
+
+            CoverageRun run = tracker.snapshot().values()
+                    .iterator().next();
+            Long firstTerminatedAt = run.terminatedAt;
+
+            tracker.launchesTerminated(new ILaunch[]{launch});
+            assertEquals(firstTerminatedAt, run.terminatedAt);
+        }
+
+        @Test
+        void launchesChangedNoOp() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            tracker.launchesChanged(new ILaunch[]{launch});
+            assertEquals(1, tracker.snapshot().size());
+        }
+
+        @Test
+        void launchesRemovedKeepsRun() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            tracker.launchesRemoved(new ILaunch[]{launch});
+            assertEquals(1, tracker.snapshot().size());
+        }
+
+        @Test
+        void liveRunCoverageIdContainsConfigNameAndTimestamp() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            CoverageRun run = tracker.snapshot().values()
+                    .iterator().next();
+            assertTrue(run.coverageId.startsWith(
+                    config.getName() + ":"));
+        }
+
+        @Test
+        void liveRunHasConfigType() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            CoverageRun run = tracker.snapshot().values()
+                    .iterator().next();
+            assertNotNull(run.configType);
+            assertNotNull(run.configTypeId);
+        }
+
+        @Test
+        void launchWithoutTimestampIsSkipped() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            launch.setAttribute(
+                    org.eclipse.debug.core.DebugPlugin
+                            .ATTR_LAUNCH_TIMESTAMP, null);
+            tracker.launchesAdded(new ILaunch[]{launch});
+            assertTrue(tracker.snapshot().isEmpty());
+        }
+
+        @Test
+        void sessionAddedMatchesLiveRun() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            String coverageId = tracker.snapshot().keySet()
+                    .iterator().next();
+
+            ICoverageSession session = TestCoverageStubs
+                    .fakeSession("live-dump", config);
+            tracker.sessionAdded(session);
+
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(1, run.dumpCount());
+            assertTrue(run.dataReceived);
+            assertEquals("live-dump", run.description);
+        }
+
+        @Test
+        void sessionAddedIdempotent() {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+
+            String coverageId = tracker.snapshot().keySet()
+                    .iterator().next();
+
+            ICoverageSession session = TestCoverageStubs
+                    .fakeSession("dup-dump", config);
+            tracker.sessionAdded(session);
+            tracker.sessionAdded(session);
+
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(1, run.dumpCount());
+        }
+
+        @Test
+        void terminatedLiveRunDoesNotMatchNewSession() throws Exception {
+            FakeCoverageLaunch launch =
+                    new FakeCoverageLaunch(config, Set.of());
+            tracker.launchesAdded(new ILaunch[]{launch});
+            tracker.launchesTerminated(new ILaunch[]{launch});
+
+            int before = tracker.snapshot().size();
+            ICoverageSession session = TestCoverageStubs
+                    .fakeSession("post-term", config);
+            tracker.sessionAdded(session);
+            Job.getJobManager().join(
+                    CoverageTracker.CLASSIFY_FAMILY, null);
+
+            assertEquals(before + 1, tracker.snapshot().size());
+        }
+
+        @Test
+        void flushPendingSettlesAllDeferred() throws Exception {
+            ICoverageSession session = TestCoverageStubs
+                    .fakeSession("flush-test");
+            tracker.sessionAdded(session);
+            tracker.flushPending();
+
+            CoverageRun run = tracker.snapshot().values().stream()
+                    .filter(r -> "flush-test".equals(r.description))
+                    .findFirst()
+                    .orElseThrow();
+            assertTrue(run.coverageId.startsWith("imported:"));
+        }
+    }
+
+    @Nested
+    class CoverageChangedCallback {
+
+        @Test
+        void coverageChangedUpdatesActiveRunState()
+                throws Exception {
+            String coverageId = importAndAwait("cc-active");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            run.analysisLoading = true;
+
+            tracker.coverageChanged();
+
+            assertEquals(coverageId, tracker.activeCoverageId());
+        }
+
+        @Test
+        void coverageChangedIgnoresUnknownSession()
+                throws Exception {
+            importAndAwait("cc-ignore");
+            int before = tracker.snapshot().size();
+            tracker.coverageChanged();
+            assertEquals(before, tracker.snapshot().size());
+        }
+    }
+
+    @Nested
+    class SessionRemoval {
+
+        @Test
+        void removedSessionDeletesEmptyRun() throws Exception {
+            String coverageId = importAndAwait("remove-test");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(1, run.sessions.size());
+
+            ICoverageSession session = run.sessions.get(0);
+            tracker.sessionRemoved(session);
+
+            assertNull(tracker.byCoverageId(coverageId));
+        }
+
+        @Test
+        void removedSessionKeepsRunWithRemainingSessions()
+                throws Exception {
+            String coverageId = importAndAwait("keep-run");
+            CoverageRun run = tracker.byCoverageId(coverageId);
+            assertEquals(1, run.dumpCount());
+
+            ICoverageSession original = run.sessions.get(0);
+            ICoverageSession extra = TestCoverageStubs
+                    .fakeSession("extra-session");
+            run.sessions.add(extra);
+            run.dumpedAt.add(System.currentTimeMillis());
+            assertEquals(2, run.dumpCount());
+
+            tracker.sessionRemoved(original);
+            assertEquals(1, run.dumpCount());
+            assertNotNull(tracker.byCoverageId(coverageId));
+        }
+
+        @Test
+        void sessionActivatedWithNull() {
+            tracker.sessionActivated(null);
+            assertNull(tracker.activeCoverageId());
+        }
+    }
+
     private String importAndAwait(String description) throws Exception {
         ISessionImporter importer = CoverageTools.getImporter();
         importer.setDescription(description);

--- a/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/coverage/CoverageHandler.java
@@ -175,7 +175,7 @@ class CoverageHandler {
     /** Build the response JSON for {@code /coverage/run} and
      *  {@code /coverage/relaunch}. */
     @SuppressWarnings("restriction")
-	private static String runResponse(ILaunch launch) {
+	static String runResponse(ILaunch launch) {
         var obj = new JsonObject();
         obj.addProperty("ok", true);
 

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/FakeCoverageLaunch.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/FakeCoverageLaunch.java
@@ -1,0 +1,46 @@
+package io.github.kaluchi.jdtbridge.support;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.Launch;
+import org.eclipse.eclemma.core.launching.ICoverageLaunch;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+@SuppressWarnings("restriction")
+public class FakeCoverageLaunch extends Launch
+		implements ICoverageLaunch {
+
+	private final Set<IPackageFragmentRoot> scope;
+	private boolean dumpRequested;
+	private boolean dumpReset;
+
+	public FakeCoverageLaunch(ILaunchConfiguration config,
+			Set<IPackageFragmentRoot> scope) {
+		super(config, "coverage", null);
+		this.scope = scope;
+		setAttribute(DebugPlugin.ATTR_LAUNCH_TIMESTAMP,
+				Long.toString(System.currentTimeMillis()));
+	}
+
+	@Override
+	public Set<IPackageFragmentRoot> getScope() {
+		return scope;
+	}
+
+	@Override
+	public void requestDump(boolean reset) throws CoreException {
+		this.dumpRequested = true;
+		this.dumpReset = reset;
+	}
+
+	public boolean wasDumpRequested() {
+		return dumpRequested;
+	}
+
+	public boolean wasDumpReset() {
+		return dumpReset;
+	}
+}

--- a/tests.support/src/io/github/kaluchi/jdtbridge/support/TestCoverageStubs.java
+++ b/tests.support/src/io/github/kaluchi/jdtbridge/support/TestCoverageStubs.java
@@ -115,12 +115,23 @@ public final class TestCoverageStubs {
     }
 
     public static ICoverageSession fakeSession(String description) {
+        return fakeSession(description, null);
+    }
+
+    public static ICoverageSession fakeSession(String description,
+            org.eclipse.debug.core.ILaunchConfiguration config) {
         return (ICoverageSession) Proxy.newProxyInstance(
                 ICoverageSession.class.getClassLoader(),
                 new Class<?>[] { ICoverageSession.class },
-                (p, m, a) -> java.util.Map.of(
-                        "getDescription", (Object) description)
-                        .getOrDefault(m.getName(), null));
+                (p, m, a) -> switch (m.getName()) {
+                    case "getDescription" -> description;
+                    case "getLaunchConfiguration" -> config;
+                    case "getScope" -> java.util.Set.of();
+                    case "equals" -> p == a[0];
+                    case "hashCode" ->
+                            System.identityHashCode(p);
+                    default -> null;
+                });
     }
 
     private static final class FakeNode extends CoverageNodeImpl {


### PR DESCRIPTION
Summary

- FakeCoverageLaunch stub in tests.support for ICoverageLaunch with requestDump tracking
- TestCoverageStubs.fakeSession(desc, config) overload with hashCode/equals support
- CoverageTrackerTest: launch lifecycle tests (launchesAdded, launchesTerminated, sessionAdded, sessionRemoved, flushPending, coverageChanged)
- CoverageHandlerTest: handleDump terminated/live paths, runResponse with FakeCoverageLaunch
- CoverageSessionHandlerTest: handleActivate validation, live run runEntry with launchId
- GraphHandlerTest: write refs, missing params, unknown project, non-Java file
- CoverageHandler.runResponse visibility private to package-private for direct testing
- Fix test-file coverage: eliminate anonymous CoverageEventListener (CoverageEventBusTest), remove negation branch (CoverageProgressStreamerTest), replace assertTrue(x > y) with assertEquals (CoverageTrackerTest, CoverageHandlerTest)

- [x] jdt launch run jdtbridge-verify passes
- [x] 1136 headless + 35 UI tests pass
- [x] Headless instruction coverage 83.0% to 85.0%