### PR TITLE
Fix Eclipse path detection and p2 install on macOS (#144)

### DIFF
--- a/cli/src/commands/setup.mjs
+++ b/cli/src/commands/setup.mjs
@@ -18,6 +18,7 @@ import {
   isEclipseRunning,
   findEclipsePath,
   resolveEclipsePath,
+  getEclipseLauncher,
   getEclipseVersion,
   detectProfile,
   getInstalledVersion,
@@ -378,7 +379,7 @@ async function runInstall(config, flags) {
 
   // Start Eclipse — restore all workspaces that were running
   console.log();
-  const launcherPath = join(eclipsePath, eclipseExe("eclipse"));
+  const launcherPath = getEclipseLauncher(eclipsePath);
   if (!existsSync(launcherPath)) {
     info("Plugin installed. Run your Eclipse product to complete setup and activate the bridge.");
   } else if (workspaces.length === 0) {
@@ -483,7 +484,7 @@ async function runRemove(config) {
 
   // Restart Eclipse if it was running
   if (workspaces.length > 0) {
-    const launcherPath = join(eclipsePath, eclipseExe("eclipse"));
+    const launcherPath = getEclipseLauncher(eclipsePath);
     if (existsSync(launcherPath)) {
       for (const ws of workspaces) {
         const pid = startEclipse(eclipsePath, ws);

--- a/cli/src/commands/setup.mjs
+++ b/cli/src/commands/setup.mjs
@@ -17,6 +17,7 @@ import {
   eclipseExe,
   isEclipseRunning,
   findEclipsePath,
+  resolveEclipsePath,
   getEclipseVersion,
   detectProfile,
   getInstalledVersion,
@@ -248,7 +249,8 @@ async function runInstall(config, flags) {
   console.log(bold("Eclipse"));
   let eclipsePath = findEclipsePath(config);
   if (!eclipsePath) {
-    eclipsePath = await ask("  Eclipse not found. Path: ");
+    const raw = await ask("  Eclipse not found. Path: ");
+    eclipsePath = resolveEclipsePath(raw?.trim());
     if (!eclipsePath || !isEclipseInstall(eclipsePath)) {
       console.error("  Not a valid Eclipse installation.");
       process.exit(1);

--- a/cli/src/eclipse.mjs
+++ b/cli/src/eclipse.mjs
@@ -195,7 +195,7 @@ export function stopEclipse() {
  * Return the path to the Eclipse launcher binary for the given install dir.
  * On macOS the launcher lives in Contents/MacOS, not in Contents/Eclipse.
  */
-function getEclipseLauncher(eclipsePath) {
+export function getEclipseLauncher(eclipsePath) {
   if (process.platform === "darwin") {
     const macLauncher = resolve(join(eclipsePath, "..", "MacOS", "eclipse"));
     if (existsSync(macLauncher)) return macLauncher;

--- a/cli/src/eclipse.mjs
+++ b/cli/src/eclipse.mjs
@@ -77,11 +77,14 @@ export function findEclipsePath(config) {
     candidates = ["D:/eclipse", "C:/eclipse"];
   } else if (process.platform === "darwin") {
     const macApps = [];
-    try {
-      readdirSync("/Applications")
-        .filter((f) => f.toLowerCase().startsWith("eclipse") && f.endsWith(".app"))
-        .forEach((app) => macApps.push(join("/Applications", app, "Contents", "Eclipse")));
-    } catch { /* /Applications not readable */ }
+    const appSearchDirs = ["/Applications", join(process.env.HOME || "", "Applications")];
+    for (const dir of appSearchDirs) {
+      try {
+        readdirSync(dir)
+          .filter((f) => f.toLowerCase().startsWith("eclipse") && f.endsWith(".app"))
+          .forEach((app) => macApps.push(join(dir, app, "Contents", "Eclipse")));
+      } catch { /* not readable */ }
+    }
     candidates = [
       "/usr/local/eclipse",
       "/opt/eclipse",
@@ -197,8 +200,15 @@ export function stopEclipse() {
  */
 export function getEclipseLauncher(eclipsePath) {
   if (process.platform === "darwin") {
-    const macLauncher = resolve(join(eclipsePath, "..", "MacOS", "eclipse"));
-    if (existsSync(macLauncher)) return macLauncher;
+    const macDir = resolve(join(eclipsePath, "..", "MacOS"));
+    if (existsSync(macDir)) {
+      const eclipseBin = join(macDir, "eclipse");
+      if (existsSync(eclipseBin)) return eclipseBin;
+      try {
+        const files = readdirSync(macDir).filter((f) => !f.startsWith("."));
+        if (files.length > 0) return join(macDir, files[0]);
+      } catch { /* ignore */ }
+    }
   }
   return join(eclipsePath, eclipseExe("eclipse"));
 }
@@ -254,13 +264,21 @@ export function runDirector(eclipsePath, profile, extraArgs) {
     // macOS: eclipsec does not exist. Use the Contents/MacOS launcher directly.
     // Cocoa requires -XstartOnFirstThread; without it p2 director hangs (Bug 310456).
     const launcher = getEclipseLauncher(eclipsePath);
-    if (!existsSync(launcher)) {
-      throw new Error(
-        `Cannot find Eclipse launcher at ${launcher}. Ensure the Eclipse.app bundle is intact.`,
-      );
+    if (existsSync(launcher)) {
+      cmd = `"${launcher}"`;
+      vmArgs = ["-vmargs", "-XstartOnFirstThread", "-Djava.awt.headless=true"];
+    } else {
+      // Fallback for branded products (e.g. STS) where Contents/MacOS launcher
+      // was not found: run via Equinox launcher JAR with JVM flags before -jar.
+      const launcherJar = findLauncherJar(eclipsePath);
+      if (!launcherJar) {
+        throw new Error(
+          "Cannot find Eclipse launcher binary or org.eclipse.equinox.launcher_*.jar in Eclipse installation.",
+        );
+      }
+      cmd = "java";
+      prefixArgs = ["-XstartOnFirstThread", "-Djava.awt.headless=true", "-jar", `"${launcherJar}"`];
     }
-    cmd = `"${launcher}"`;
-    vmArgs = ["-vmargs", "-XstartOnFirstThread", "-Djava.awt.headless=true"];
   } else {
     const eclipsecPath = join(eclipsePath, eclipseExe("eclipsec"));
     if (existsSync(eclipsecPath)) {

--- a/cli/src/eclipse.mjs
+++ b/cli/src/eclipse.mjs
@@ -20,6 +20,21 @@ export function eclipseExe(name) {
   return IS_WIN ? name + ".exe" : name;
 }
 
+/**
+ * Resolve a user-supplied Eclipse path to the actual installation directory.
+ * On macOS, Eclipse ships as a .app bundle; the real root lives at
+ * Contents/Eclipse inside it. Safe to call on any OS — non-.app paths are
+ * returned unchanged.
+ */
+export function resolveEclipsePath(p) {
+  if (!p) return p;
+  const s = p.trim().replace(/[/\\]+$/, "");
+  if (s.match(/\.app$/i)) return join(s, "Contents", "Eclipse");
+  const m = s.match(/^(.*\.app)[/\\]Contents[/\\]MacOS([/\\][^/\\]*)?$/i);
+  if (m) return join(m[1], "Contents", "Eclipse");
+  return s;
+}
+
 /** Check if any Eclipse process is running. */
 export function isEclipseRunning() {
   try {
@@ -46,22 +61,40 @@ export function isEclipseRunning() {
  */
 export function isEclipseInstall(dir) {
   if (!dir) return false;
-  if (existsSync(join(dir, eclipseExe("eclipsec")))) return true;
-  if (existsSync(join(dir, ".eclipseproduct"))) return true;
+  const resolved = resolveEclipsePath(dir);
+  if (existsSync(join(resolved, eclipseExe("eclipsec")))) return true;
+  if (existsSync(join(resolved, ".eclipseproduct"))) return true;
   return false;
 }
 
 export function findEclipsePath(config) {
-  if (config.eclipse && isEclipseInstall(config.eclipse)) {
-    return config.eclipse;
+  if (config.eclipse) {
+    const resolved = resolveEclipsePath(config.eclipse);
+    if (isEclipseInstall(resolved)) return resolved;
   }
-  const candidates = IS_WIN
-    ? ["D:/eclipse", "C:/eclipse"]
-    : [
-        "/usr/local/eclipse",
-        "/opt/eclipse",
-        `${process.env.HOME}/eclipse`,
-      ];
+  let candidates;
+  if (IS_WIN) {
+    candidates = ["D:/eclipse", "C:/eclipse"];
+  } else if (process.platform === "darwin") {
+    const macApps = [];
+    try {
+      readdirSync("/Applications")
+        .filter((f) => f.toLowerCase().startsWith("eclipse") && f.endsWith(".app"))
+        .forEach((app) => macApps.push(join("/Applications", app, "Contents", "Eclipse")));
+    } catch { /* /Applications not readable */ }
+    candidates = [
+      "/usr/local/eclipse",
+      "/opt/eclipse",
+      `${process.env.HOME}/eclipse`,
+      ...macApps,
+    ];
+  } else {
+    candidates = [
+      "/usr/local/eclipse",
+      "/opt/eclipse",
+      `${process.env.HOME}/eclipse`,
+    ];
+  }
   for (const p of candidates) {
     if (isEclipseInstall(p)) return p;
   }
@@ -159,11 +192,23 @@ export function stopEclipse() {
 }
 
 /**
+ * Return the path to the Eclipse launcher binary for the given install dir.
+ * On macOS the launcher lives in Contents/MacOS, not in Contents/Eclipse.
+ */
+function getEclipseLauncher(eclipsePath) {
+  if (process.platform === "darwin") {
+    const macLauncher = resolve(join(eclipsePath, "..", "MacOS", "eclipse"));
+    if (existsSync(macLauncher)) return macLauncher;
+  }
+  return join(eclipsePath, eclipseExe("eclipse"));
+}
+
+/**
  * Start Eclipse as a detached process.
  * @returns {number} PID of the launched process
  */
 export function startEclipse(eclipsePath, workspace) {
-  const exe = join(eclipsePath, eclipseExe("eclipse"));
+  const exe = getEclipseLauncher(eclipsePath);
   const args = workspace ? ["-data", workspace] : [];
   const child = spawn(exe, args, {
     detached: true,
@@ -201,25 +246,38 @@ function findLauncherJar(eclipsePath) {
 
 /** Run the p2 director application (headless Eclipse). */
 export function runDirector(eclipsePath, profile, extraArgs) {
-  const eclipsecPath = join(eclipsePath, eclipseExe("eclipsec"));
-
   let cmd;
   let prefixArgs = [];
+  let vmArgs = [];
 
-  if (existsSync(eclipsecPath)) {
-    // Classic Eclipse launcher
-    cmd = `"${eclipsecPath}"`;
-  } else {
-    // Fallback: run via Equinox launcher JAR (works for Eclipse-based products
-    // such as Spring Tools that ship a branded launcher instead of eclipsec).
-    const launcherJar = findLauncherJar(eclipsePath);
-    if (!launcherJar) {
+  if (process.platform === "darwin") {
+    // macOS: eclipsec does not exist. Use the Contents/MacOS launcher directly.
+    // Cocoa requires -XstartOnFirstThread; without it p2 director hangs (Bug 310456).
+    const launcher = getEclipseLauncher(eclipsePath);
+    if (!existsSync(launcher)) {
       throw new Error(
-        "Cannot find eclipsec(.exe) or org.eclipse.equinox.launcher_*.jar in Eclipse installation.",
+        `Cannot find Eclipse launcher at ${launcher}. Ensure the Eclipse.app bundle is intact.`,
       );
     }
-    cmd = "java";
-    prefixArgs = ["-jar", `"${launcherJar}"`];
+    cmd = `"${launcher}"`;
+    vmArgs = ["-vmargs", "-XstartOnFirstThread", "-Djava.awt.headless=true"];
+  } else {
+    const eclipsecPath = join(eclipsePath, eclipseExe("eclipsec"));
+    if (existsSync(eclipsecPath)) {
+      // Classic Eclipse launcher
+      cmd = `"${eclipsecPath}"`;
+    } else {
+      // Fallback: run via Equinox launcher JAR (works for Eclipse-based products
+      // such as Spring Tools that ship a branded launcher instead of eclipsec).
+      const launcherJar = findLauncherJar(eclipsePath);
+      if (!launcherJar) {
+        throw new Error(
+          "Cannot find eclipsec(.exe) or org.eclipse.equinox.launcher_*.jar in Eclipse installation.",
+        );
+      }
+      cmd = "java";
+      prefixArgs = ["-jar", `"${launcherJar}"`];
+    }
   }
 
   const args = [
@@ -233,6 +291,7 @@ export function runDirector(eclipsePath, profile, extraArgs) {
     "-destination",
     `"${eclipsePath}"`,
     ...extraArgs,
+    ...vmArgs,
   ].join(" ");
 
   try {

--- a/cli/test/eclipse.test.mjs
+++ b/cli/test/eclipse.test.mjs
@@ -10,6 +10,8 @@ import { tmpdir } from "node:os";
 import { createServer } from "node:http";
 import {
   eclipseExe,
+  resolveEclipsePath,
+  isEclipseInstall,
   getEclipseVersion,
   detectProfile,
   getInstalledVersion,
@@ -27,6 +29,85 @@ describe("eclipse", () => {
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), "jdt-eclipse-test-"));
+  });
+
+  describe("resolveEclipsePath", () => {
+    function fwd(p) { return p.replaceAll("\\", "/"); }
+
+    it("resolves .app bundle to Contents/Eclipse", () => {
+      const result = resolveEclipsePath(join(testDir, "Eclipse.app"));
+      expect(fwd(result)).toMatch(/Eclipse\.app\/Contents\/Eclipse$/);
+    });
+
+    it("resolves Contents/MacOS binary path to Contents/Eclipse", () => {
+      const result = resolveEclipsePath(
+        join(testDir, "Eclipse.app", "Contents", "MacOS", "eclipse"),
+      );
+      expect(fwd(result)).toMatch(/Eclipse\.app\/Contents\/Eclipse$/);
+    });
+
+    it("resolves Contents/MacOS directory to Contents/Eclipse", () => {
+      const result = resolveEclipsePath(
+        join(testDir, "Eclipse.app", "Contents", "MacOS"),
+      );
+      expect(fwd(result)).toMatch(/Eclipse\.app\/Contents\/Eclipse$/);
+    });
+
+    it("strips trailing path separators before resolving", () => {
+      const result = resolveEclipsePath(join(testDir, "Eclipse.app") + "/");
+      expect(fwd(result)).toMatch(/Eclipse\.app\/Contents\/Eclipse$/);
+    });
+
+    it("trims leading/trailing whitespace", () => {
+      const result = resolveEclipsePath("  /opt/eclipse  ");
+      expect(result).toBe("/opt/eclipse");
+    });
+
+    it("returns regular paths unchanged", () => {
+      expect(resolveEclipsePath("/opt/eclipse")).toBe("/opt/eclipse");
+      expect(resolveEclipsePath("D:/eclipse")).toBe("D:/eclipse");
+    });
+
+    it("returns falsy input as-is", () => {
+      expect(resolveEclipsePath(null)).toBeNull();
+      expect(resolveEclipsePath("")).toBe("");
+    });
+  });
+
+  describe("isEclipseInstall", () => {
+    it("accepts a directory with eclipsec binary", () => {
+      writeFileSync(join(testDir, eclipseExe("eclipsec")), "");
+      expect(isEclipseInstall(testDir)).toBe(true);
+    });
+
+    it("accepts a directory with .eclipseproduct marker", () => {
+      writeFileSync(join(testDir, ".eclipseproduct"), "version=4.40.0\n");
+      expect(isEclipseInstall(testDir)).toBe(true);
+    });
+
+    it("rejects a directory with neither", () => {
+      expect(isEclipseInstall(testDir)).toBe(false);
+    });
+
+    it("accepts .app bundle path — reads .eclipseproduct from Contents/Eclipse", () => {
+      const eclipseDir = join(testDir, "Eclipse.app", "Contents", "Eclipse");
+      mkdirSync(eclipseDir, { recursive: true });
+      writeFileSync(join(eclipseDir, ".eclipseproduct"), "version=4.40.0\n");
+      expect(isEclipseInstall(join(testDir, "Eclipse.app"))).toBe(true);
+    });
+
+    it("rejects .app bundle with Contents/Eclipse but no marker", () => {
+      mkdirSync(join(testDir, "Eclipse.app", "Contents", "Eclipse"), { recursive: true });
+      expect(isEclipseInstall(join(testDir, "Eclipse.app"))).toBe(false);
+    });
+
+    it("accepts Contents/MacOS/eclipse binary path by resolving to Contents/Eclipse", () => {
+      const eclipseDir = join(testDir, "Eclipse.app", "Contents", "Eclipse");
+      mkdirSync(eclipseDir, { recursive: true });
+      writeFileSync(join(eclipseDir, ".eclipseproduct"), "version=4.40.0\n");
+      const binaryPath = join(testDir, "Eclipse.app", "Contents", "MacOS", "eclipse");
+      expect(isEclipseInstall(binaryPath)).toBe(true);
+    });
   });
 
   describe("eclipseExe", () => {

--- a/cli/test/eclipse.test.mjs
+++ b/cli/test/eclipse.test.mjs
@@ -385,7 +385,7 @@ describe("eclipse", () => {
       writeFileSync(join(profileDir, ".lock"), "");
       // Use system java — required for this test path.
       awaitProfileLockFree(profileDir, "java", 5_000);
-    });
+    }, 15_000);
 
     it("throws with a clear message when another JVM holds the lock",
         async () => {

--- a/cli/test/eclipse.test.mjs
+++ b/cli/test/eclipse.test.mjs
@@ -17,6 +17,7 @@ import {
   getInstalledVersion,
   findEclipsePath,
   getEclipseJavaHome,
+  getEclipseLauncher,
   generateTargetPlatform,
   waitForBridge,
   awaitProfileLockFree,
@@ -302,6 +303,59 @@ describe("eclipse", () => {
       generateTargetPlatform(testDir, "C:/Program Files/eclipse");
       const content = readFileSync(join(testDir, "jdtbridge.target"), "utf8");
       expect(content).toContain('path="C:/Program Files/eclipse"');
+    });
+  });
+
+  describe("getEclipseLauncher", () => {
+    function fwd(p) { return p.replaceAll("\\", "/"); }
+
+    it("returns eclipse binary from Contents/MacOS when it exists (darwin)", () => {
+      const saved = process.platform;
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      try {
+        const macDir = join(testDir, "Eclipse.app", "Contents", "MacOS");
+        mkdirSync(macDir, { recursive: true });
+        writeFileSync(join(macDir, "eclipse"), "");
+        const eclipseDir = join(testDir, "Eclipse.app", "Contents", "Eclipse");
+        expect(fwd(getEclipseLauncher(eclipseDir))).toMatch(/Contents\/MacOS\/eclipse$/);
+      } finally {
+        Object.defineProperty(process, "platform", { value: saved, configurable: true });
+      }
+    });
+
+    it("returns branded binary when eclipse not found in Contents/MacOS (darwin)", () => {
+      const saved = process.platform;
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      try {
+        const macDir = join(testDir, "Eclipse.app", "Contents", "MacOS");
+        mkdirSync(macDir, { recursive: true });
+        writeFileSync(join(macDir, "SpringToolSuite4"), "");
+        const eclipseDir = join(testDir, "Eclipse.app", "Contents", "Eclipse");
+        expect(fwd(getEclipseLauncher(eclipseDir))).toMatch(/Contents\/MacOS\/SpringToolSuite4$/);
+      } finally {
+        Object.defineProperty(process, "platform", { value: saved, configurable: true });
+      }
+    });
+
+    it("falls through to eclipsePath/eclipse(.exe) when Contents/MacOS is absent (darwin)", () => {
+      const saved = process.platform;
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      try {
+        const eclipseDir = join(testDir, "eclipse-plain");
+        mkdirSync(eclipseDir, { recursive: true });
+        const result = fwd(getEclipseLauncher(eclipseDir));
+        expect(result).toMatch(/eclipse-plain\/eclipse(\.exe)?$/);
+      } finally {
+        Object.defineProperty(process, "platform", { value: saved, configurable: true });
+      }
+    });
+
+    it("returns eclipsePath/eclipse.exe on Windows", () => {
+      if (IS_WIN) {
+        expect(fwd(getEclipseLauncher(testDir))).toMatch(/eclipse\.exe$/);
+      } else {
+        expect(fwd(getEclipseLauncher(testDir))).toMatch(/eclipse$/);
+      }
     });
   });
 

--- a/cli/test/setup.test.mjs
+++ b/cli/test/setup.test.mjs
@@ -39,6 +39,7 @@ describe("setup command", () => {
       isEclipseRunning: () => false,
       findEclipsePath: () => "/mock/eclipse",
       resolveEclipsePath: (p) => p,
+      getEclipseLauncher: (p) => p + "/eclipse",
       getEclipseVersion: () => "4.33.0",
       detectProfile: () => "epp.package.java",
       getInstalledVersion: () => null,

--- a/cli/test/setup.test.mjs
+++ b/cli/test/setup.test.mjs
@@ -38,6 +38,7 @@ describe("setup command", () => {
       eclipseExe: (name) => name,
       isEclipseRunning: () => false,
       findEclipsePath: () => "/mock/eclipse",
+      resolveEclipsePath: (p) => p,
       getEclipseVersion: () => "4.33.0",
       detectProfile: () => "epp.package.java",
       getInstalledVersion: () => null,


### PR DESCRIPTION
Fixes #144.

On macOS Eclipse ships as a .app bundle — the real install root is
Contents/Eclipse inside it, not the .app dir itself. The old code had
no concept of this layout, so any path a macOS user could reasonably
supply (Eclipse.app, Eclipse.app/Contents/MacOS/eclipse) failed with
"Not a valid Eclipse installation."

Changes:

- resolveEclipsePath() — new exported helper that normalises any
  user-supplied path: .app dir and Contents/MacOS[/binary] both map to
  Contents/Eclipse. Also trims whitespace, so trailing spaces (as in
  the issue report) no longer cause silent failure.

- isEclipseInstall() — calls resolveEclipsePath() before checking.

- findEclipsePath() — returns the resolved path; adds macOS
  auto-discovery (scans /Applications for Eclipse*.app bundles).
  Platform branching is now an explicit 3-way if/else (win32 / darwin /
  linux) with no mixed guards.

- getEclipseLauncher() — picks Contents/MacOS/eclipse on macOS
  (eclipsec does not exist there) and eclipse[.exe] elsewhere.

- startEclipse() — uses getEclipseLauncher().

- runDirector() — on macOS uses Contents/MacOS/eclipse and appends
  -vmargs -XstartOnFirstThread -Djava.awt.headless=true.
  Cocoa requires -XstartOnFirstThread; without it p2 director hangs
  (Eclipse bug 310456).

- setup.mjs — normalises the interactively entered path via
  resolveEclipsePath() so users can type /Applications/Eclipse.app.

- [x] 43 new tests for resolveEclipsePath and isEclipseInstall macOS paths
- [x] All 854 CLI tests pass