### PR TITLE
Add jdt open <path> and fix refresh path translation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,9 +254,30 @@ gh api repos/kaluchi/jdtbridge/issues/<N>/comments   # PR-level
 Every concrete bot finding must be resolved before merge — either
 fix it in a follow-up commit, or reply on the comment with a clear
 reason for rejection. Do not leave bot comments unanswered: the
-human reviewer expects each one closed by the time they look. Reply
-inline (`gh api ... -X POST -f in_reply_to=<comment-id>`) so the
-thread stays attached to the diff line.
+human reviewer expects each one closed by the time they look.
+
+After replying, also **mark the conversation resolved** so the PR
+page no longer shows it as outstanding. The REST comments API can
+post replies; resolving the conversation is GraphQL-only:
+
+```bash
+# Reply on the diff line
+gh api repos/kaluchi/jdtbridge/pulls/<N>/comments/<comment-id>/replies \
+  -X POST -f body="…"
+
+# Look up review-thread IDs (PRRT_*) for the PR
+gh api graphql -f query='query {
+  repository(owner: "kaluchi", name: "jdtbridge") {
+    pullRequest(number: <N>) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved
+          comments(first: 1) { nodes { databaseId path } } } } } } }'
+
+# Resolve a thread by its PRRT_* id
+gh api graphql -f query='mutation {
+  resolveReviewThread(input: {threadId: "PRRT_…"}) {
+    thread { id isResolved } } }'
+```
 
 ### Important details
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,26 @@ gh pr checks 55 --watch
 all checks complete, then exits with 0 (all pass) or 1 (failures).
 Never use `sleep` loops to poll CI status.
 
+**Bot review comments.** After CI, automated reviewers
+(`gemini-code-assist[bot]`, etc.) leave a review summary plus
+line-level comments. `gemini-code-assist` first puts an 👀 reaction
+on the PR description when it picks up the PR; the actual review
+lands ~1–2 min later. Watch for both signals:
+
+```bash
+gh api repos/kaluchi/jdtbridge/issues/<N>/reactions  # 👀 = bot reading
+gh api repos/kaluchi/jdtbridge/pulls/<N>/reviews
+gh api repos/kaluchi/jdtbridge/pulls/<N>/comments    # line-level
+gh api repos/kaluchi/jdtbridge/issues/<N>/comments   # PR-level
+```
+
+Every concrete bot finding must be resolved before merge — either
+fix it in a follow-up commit, or reply on the comment with a clear
+reason for rejection. Do not leave bot comments unanswered: the
+human reviewer expects each one closed by the time they look. Reply
+inline (`gh api ... -X POST -f in_reply_to=<comment-id>`) so the
+thread stays attached to the diff line.
+
 ### Important details
 
 - **Clean build after branch switch or merge.** `git checkout`, `git pull`,
@@ -293,6 +313,13 @@ jdt test run io.github.kaluchi.jdtbridge.tests --coverage -f -q
 # Full UI suite (workbench PDE runtime — editors, coverage)
 jdt test run io.github.kaluchi.jdtbridge.tests.ui --coverage -f -q
 ```
+
+**UI tests must run via the full suite**, not by class FQN.
+`jdt test run <FQN>` against a class in `plugin.tests.ui` synthesises
+a headless launch config — `PlatformUI.getWorkbench()` is null in
+that runtime and the test hangs on the first `Display.syncExec`.
+Use `jdt test run io.github.kaluchi.jdtbridge.tests.ui` so the
+shared `*.tests.ui.launch` (workbench PDE) picks up the test.
 
 Both suites use shared launch configs from `launches/`. If a config
 is missing or broken, restore from the repo:

--- a/cli/lib/jdt/graph.impl.mjs
+++ b/cli/lib/jdt/graph.impl.mjs
@@ -22,6 +22,7 @@ import { keyword, isKeyword, makeErrorValue } from '@kaluchi/qlang-core';
 import { get } from '../../src/client.mjs';
 import { remapJsonPaths } from '../../src/json-output.mjs';
 import { translateHostPathFromLocal } from '../../src/path-translate.mjs';
+import { isAbsolutePath } from '../../src/paths.mjs';
 
 // ── Conversion helpers ──────────────────────────────────────────
 
@@ -255,15 +256,13 @@ const sourceImpl    = axisOp('@source',    '/source');
 // (@containingFile / @typesInPackage / @containingProject) before
 // reaching here. Path-shape fqns go through
 // translateHostPathFromLocal for remote bridges.
-const PATH_SHAPE = /^[A-Za-z]:[/\\]|^[/\\]|[/\\]/;
-
 const problemMarkersImpl = nullaryOp('@problemMarkers', async (subject) => {
     if (subject === undefined || subject === null) {
         return getEndpoint('/problems');
     }
     const fqn = fqnOf(subject);
     if (fqn === null) return missingSubject('@problemMarkers', subject);
-    const of = PATH_SHAPE.test(fqn) ? translateHostPathFromLocal(fqn) : fqn;
+    const of = isAbsolutePath(fqn) ? translateHostPathFromLocal(fqn) : fqn;
     return getEndpoint(`/problems?of=${enc(of)}`);
 });
 

--- a/cli/src/commands/editor.mjs
+++ b/cli/src/commands/editor.mjs
@@ -1,7 +1,11 @@
 import { basename } from "node:path";
 import { get } from "../client.mjs";
 import { extractPositional, parseFqn } from "../args.mjs";
-import { translateHostPath } from "../path-translate.mjs";
+import {
+  translateHostPath,
+  translateHostPathFromLocal,
+} from "../path-translate.mjs";
+import { isAbsolutePath } from "../paths.mjs";
 import { output } from "../output.mjs";
 import { formatTable } from "../format/table.mjs";
 
@@ -24,13 +28,28 @@ export async function editors(args = []) {
 
 export async function open(args) {
   const pos = extractPositional(args);
-  const parsed = parseFqn(pos[0]);
-  const fqn = parsed.className;
-  const method = parsed.method || pos[1];
-  if (!fqn) {
-    console.error("Usage: open <FQN>[#method[(param types)]]");
+  const arg = pos[0];
+  if (!arg) {
+    console.error(
+      "Usage: open <FQN>[#method[(param types)]] | open <path>");
     process.exit(1);
   }
+
+  if (isAbsolutePath(arg)) {
+    const hostPath = translateHostPathFromLocal(arg);
+    const result = await get(
+      `/openFile?path=${encodeURIComponent(hostPath)}`);
+    if (result.error) {
+      console.error(result.error);
+      return;
+    }
+    console.log("Opened");
+    return;
+  }
+
+  const parsed = parseFqn(arg);
+  const fqn = parsed.className;
+  const method = parsed.method || pos[1];
   let url = `/open?class=${encodeURIComponent(fqn)}`;
   if (method) url += `&method=${encodeURIComponent(method)}`;
   if (parsed.paramTypes) {
@@ -55,11 +74,12 @@ Examples:
   jdt editors
   jdt editors --json`;
 
-export const openHelp = `Open a type or method in the Eclipse editor.
+export const openHelp = `Open a Java element or file in the Eclipse editor.
 
 Usage:  jdt open <FQN>[#method[(param types)]]
+        jdt open <absolute-path>
 
 Examples:
   jdt open com.example.dao.UserDaoImpl
   jdt open com.example.dao.UserDaoImpl#getStaff
-  jdt open "com.example.dao.UserDaoImpl#save(Order)"`;
+  jdt open D:/git/repo/pom.xml`;

--- a/cli/src/commands/refresh.mjs
+++ b/cli/src/commands/refresh.mjs
@@ -1,5 +1,6 @@
 import { get } from "../client.mjs";
 import { extractPositional } from "../args.mjs";
+import { translateHostPathFromLocal } from "../path-translate.mjs";
 
 export async function refresh(args) {
   const quiet = args.includes("-q") || args.includes("--quiet");
@@ -13,8 +14,9 @@ export async function refresh(args) {
       // File mode: refresh each file
       let refreshed = 0;
       for (const filePath of pos) {
+        const hostPath = translateHostPathFromLocal(filePath);
         const result = await get(
-          `/refresh?file=${encodeURIComponent(filePath)}`,
+          `/refresh?file=${encodeURIComponent(hostPath)}`,
           10_000,
         );
         if (result.refreshed) refreshed++;

--- a/cli/src/commands/refresh.mjs
+++ b/cli/src/commands/refresh.mjs
@@ -1,6 +1,7 @@
 import { get } from "../client.mjs";
 import { extractPositional } from "../args.mjs";
 import { translateHostPathFromLocal } from "../path-translate.mjs";
+import { isAbsolutePath } from "../paths.mjs";
 
 export async function refresh(args) {
   const quiet = args.includes("-q") || args.includes("--quiet");
@@ -14,6 +15,10 @@ export async function refresh(args) {
       // File mode: refresh each file
       let refreshed = 0;
       for (const filePath of pos) {
+        if (!isAbsolutePath(filePath)) {
+          console.error(`Path must be absolute: ${filePath}`);
+          continue;
+        }
         const hostPath = translateHostPathFromLocal(filePath);
         const result = await get(
           `/refresh?file=${encodeURIComponent(hostPath)}`,

--- a/cli/src/paths.mjs
+++ b/cli/src/paths.mjs
@@ -6,6 +6,8 @@
 // the CLI's filesystem. This file keeps only general-purpose
 // helpers that do not require any per-response context.
 
+import { posix, win32 } from "node:path";
+
 /**
  * Ensure path starts with / for workspace-relative API calls.
  * Used by the legacy /organize-imports and /format endpoints in
@@ -44,4 +46,15 @@ export function hostToSandboxPath(p) {
 /** Normalise backslashes to forward slashes for path comparison. */
 export function normalizePath(p) {
   return p.replace(/\\/g, "/");
+}
+
+/**
+ * True for absolute paths on either POSIX (`/foo`) or Windows
+ * (`C:\foo`, `C:/foo`, `\\unc\share`). Java FQNs never start that
+ * way, so this is the gate for commands and axis wiring that accept
+ * either form (`jdt open`, `@file`, `@problems`).
+ */
+export function isAbsolutePath(s) {
+  return typeof s === "string"
+      && (posix.isAbsolute(s) || win32.isAbsolute(s));
 }

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -187,6 +187,118 @@ describe("commands (integration)", () => {
     expect(io.logs[0]).toBe("Opened");
   });
 
+  it("open routes FQN to /open with class param", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const { open } = await import("../src/commands/editor.mjs");
+    await open(["com.example.Foo"]);
+    expect(captured).toMatch(/^\/open\?class=com\.example\.Foo/);
+  });
+
+  it("open routes absolute path to /openFile", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const { open } = await import("../src/commands/editor.mjs");
+    await open(["D:/projects/pom.xml"]);
+    expect(captured).toBe(
+        "/openFile?path=" + encodeURIComponent("D:/projects/pom.xml"));
+    expect(io.logs[0]).toBe("Opened");
+  });
+
+  it("open routes POSIX absolute path to /openFile", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const { open } = await import("../src/commands/editor.mjs");
+    await open(["/workspace/repo/config.properties"]);
+    expect(captured).toBe(
+        "/openFile?path=" + encodeURIComponent(
+            "/workspace/repo/config.properties"));
+  });
+
+  it("open translates CLI-local path to host on remote", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    vi.doMock("../src/path-translate.mjs", async (importOriginal) => {
+      const orig = await importOriginal();
+      return {
+        ...orig,
+        translateHostPathFromLocal: (p) =>
+          p && p.startsWith("/workspace/")
+            ? "D:\\git" + p.slice("/workspace".length).replace(/\//g, "\\")
+            : p,
+      };
+    });
+    const { open } = await import("../src/commands/editor.mjs");
+    await open(["/workspace/repo/pom.xml"]);
+    expect(captured).toBe(
+        "/openFile?path=" + encodeURIComponent("D:\\git\\repo\\pom.xml"));
+  });
+
+  it("open surfaces plugin error", async () => {
+    await setupMock((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "File not found: /x" }));
+    });
+    const { open } = await import("../src/commands/editor.mjs");
+    await open(["/x"]);
+    expect(io.errors[0]).toBe("File not found: /x");
+  });
+
+  // ── Refresh ──
+
+  it("refresh sends raw path on local instance", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ refreshed: true, files: 1 }));
+    });
+    const { refresh } = await import("../src/commands/refresh.mjs");
+    await refresh(["D:/projects/Foo.java", "-q"]);
+    expect(captured).toBe(
+        "/refresh?file=" + encodeURIComponent("D:/projects/Foo.java"));
+    expect(io.logs[0]).toBe("Refreshed 1 file");
+  });
+
+  it("refresh translates CLI-local path to host on remote", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ refreshed: true, files: 1 }));
+    });
+    vi.doMock("../src/path-translate.mjs", async (importOriginal) => {
+      const orig = await importOriginal();
+      return {
+        ...orig,
+        translateHostPathFromLocal: (p) =>
+          p && p.startsWith("/workspace/")
+            ? "D:\\git" + p.slice("/workspace".length).replace(/\//g, "\\")
+            : p,
+      };
+    });
+    const { refresh } = await import("../src/commands/refresh.mjs");
+    await refresh(["/workspace/repo/Foo.java", "-q"]);
+    expect(captured).toBe(
+        "/refresh?file=" + encodeURIComponent("D:\\git\\repo\\Foo.java"));
+  });
+
   // ── Build ──
 
   it("build shows success with 0 errors", async () => {

--- a/cli/test/commands.test.mjs
+++ b/cli/test/commands.test.mjs
@@ -276,6 +276,19 @@ describe("commands (integration)", () => {
     expect(io.logs[0]).toBe("Refreshed 1 file");
   });
 
+  it("refresh rejects relative path with clear error", async () => {
+    let captured;
+    await setupMock((req, res) => {
+      captured = req.url;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ refreshed: false }));
+    });
+    const { refresh } = await import("../src/commands/refresh.mjs");
+    await refresh(["foo/bar.java", "-q"]);
+    expect(captured).toBeUndefined();
+    expect(io.errors[0]).toBe("Path must be absolute: foo/bar.java");
+  });
+
   it("refresh translates CLI-local path to host on remote", async () => {
     let captured;
     await setupMock((req, res) => {

--- a/cli/test/paths.test.mjs
+++ b/cli/test/paths.test.mjs
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { toWsPath, hostToSandboxPath, formatLineRange, normalizePath }
-    from "../src/paths.mjs";
+import {
+  toWsPath, hostToSandboxPath, formatLineRange, normalizePath,
+  isAbsolutePath,
+} from "../src/paths.mjs";
 import { remapJsonPaths } from "../src/json-output.mjs";
 
 describe("toWsPath", () => {
@@ -59,6 +61,41 @@ describe("normalizePath", () => {
 
   it("leaves forward-slash paths alone", () => {
     expect(normalizePath("/a/b/c")).toBe("/a/b/c");
+  });
+});
+
+describe("isAbsolutePath", () => {
+  it("accepts POSIX absolute path", () => {
+    expect(isAbsolutePath("/foo/bar.xml")).toBe(true);
+  });
+
+  it("accepts Windows drive path with backslashes", () => {
+    expect(isAbsolutePath("D:\\git\\repo\\foo.xml")).toBe(true);
+  });
+
+  it("accepts Windows drive path with forward slashes", () => {
+    expect(isAbsolutePath("D:/git/repo/foo.xml")).toBe(true);
+  });
+
+  it("accepts UNC path", () => {
+    expect(isAbsolutePath("\\\\server\\share\\file.txt")).toBe(true);
+  });
+
+  it("rejects Java FQN", () => {
+    expect(isAbsolutePath("com.example.Foo")).toBe(false);
+    expect(isAbsolutePath("com.example.Foo#bar(String)")).toBe(false);
+    expect(isAbsolutePath("com.example.Foo$Inner")).toBe(false);
+  });
+
+  it("rejects relative path", () => {
+    expect(isAbsolutePath("foo/bar.xml")).toBe(false);
+    expect(isAbsolutePath("./foo.xml")).toBe(false);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isAbsolutePath(null)).toBe(false);
+    expect(isAbsolutePath(undefined)).toBe(false);
+    expect(isAbsolutePath(42)).toBe(false);
   });
 });
 

--- a/plugin.tests.ui/src/io/github/kaluchi/jdtbridge/EditorHandlerOpenFileTest.java
+++ b/plugin.tests.ui/src/io/github/kaluchi/jdtbridge/EditorHandlerOpenFileTest.java
@@ -1,0 +1,145 @@
+package io.github.kaluchi.jdtbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.github.kaluchi.jdtbridge.support.TestFixture;
+
+/**
+ * UI-runtime tests for {@link EditorHandler#handleOpenFile}.
+ * Exercise both dispatch branches — workspace IFile vs external
+ * IFileStore — and the parameter-validation paths. Uses .java and
+ * .txt extensions exclusively: both have a single registered editor
+ * (JDT and the default text editor), so no interactive "Select
+ * Editor" dialog can pop up and stall the test under headless PDE.
+ */
+public class EditorHandlerOpenFileTest {
+
+    private static final EditorHandler handler = new EditorHandler();
+
+    private static Path externalDir;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        TestFixture.create();
+        externalDir = Files.createTempDirectory("jdt-open-file-");
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        TestFixture.destroy();
+        if (externalDir != null) {
+            try (var stream = Files.walk(externalDir)) {
+                stream.sorted(java.util.Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(File::delete);
+            }
+        }
+    }
+
+    @BeforeEach
+    void closeAllEditors() {
+        Display.getDefault().syncExec(() ->
+                PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+                        .getActivePage().closeAllEditors(false));
+    }
+
+    @AfterEach
+    void alsoCloseAllEditors() {
+        Display.getDefault().syncExec(() ->
+                PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+                        .getActivePage().closeAllEditors(false));
+    }
+
+    @Test
+    public void missingPathReturnsError() throws Exception {
+        JsonObject obj = call(Map.of());
+        assertTrue(obj.has("error"));
+        assertTrue(obj.get("error").getAsString()
+                .contains("Missing 'path' parameter"));
+    }
+
+    @Test
+    public void blankPathReturnsError() throws Exception {
+        JsonObject obj = call(Map.of("path", "   "));
+        assertTrue(obj.has("error"));
+    }
+
+    @Test
+    public void relativePathRejected() throws Exception {
+        JsonObject obj = call(Map.of("path", "foo/bar.txt"));
+        assertTrue(obj.get("error").getAsString()
+                .contains("Path must be absolute"));
+    }
+
+    @Test
+    public void missingFileReturnsError() throws Exception {
+        Path ghost = externalDir.resolve("ghost.txt");
+        JsonObject obj = call(Map.of(
+                "path", ghost.toAbsolutePath().toString()));
+        assertTrue(obj.get("error").getAsString()
+                .contains("File not found"));
+    }
+
+    @Test
+    public void directoryRejected() throws Exception {
+        JsonObject obj = call(Map.of(
+                "path", externalDir.toAbsolutePath().toString()));
+        assertTrue(obj.get("error").getAsString()
+                .contains("Path is a directory"));
+    }
+
+    @Test
+    public void workspaceJavaFileOpensViaIDE() throws Exception {
+        IProject project = ResourcesPlugin.getWorkspace().getRoot()
+                .getProject(TestFixture.PROJECT_NAME);
+        IFile dog = project.getFile("src/test/model/Dog.java");
+        assertTrue(dog.exists(), "Dog.java must exist in fixture");
+        String path = dog.getLocation().toOSString();
+
+        JsonObject obj = call(Map.of("path", path));
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "Expected ok=true: " + obj);
+        assertEquals("org.eclipse.jdt.ui.CompilationUnitEditor",
+                obj.get("editorId").getAsString(),
+                "Java workspace file routes to JDT editor");
+    }
+
+    @Test
+    public void externalTextFileOpensViaEFS() throws Exception {
+        Path external = externalDir.resolve("scratch.txt");
+        Files.writeString(external, "hello\n",
+                StandardCharsets.UTF_8);
+        JsonObject obj = call(Map.of(
+                "path", external.toAbsolutePath().toString()));
+        assertTrue(obj.get("ok").getAsBoolean(),
+                "Expected ok=true for external file: " + obj);
+        assertNotNull(obj.get("editorId").getAsString());
+    }
+
+    private JsonObject call(Map<String, String> params) throws Exception {
+        return JsonParser.parseString(handler.handleOpenFile(params))
+                .getAsJsonObject();
+    }
+}

--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Activator: io.github.kaluchi.jdtbridge.Activator
 Automatic-Module-Name: io.github.kaluchi.jdtbridge
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
+ org.eclipse.core.filesystem,
  org.eclipse.jdt.core,
  org.eclipse.jdt.core.manipulation,
  org.eclipse.jdt.ui,

--- a/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
@@ -181,6 +181,24 @@ class EditorHandler {
         IFile[] workspaceFiles =
                 root.findFilesForLocationURI(uri);
 
+        // EFS exists/isDirectory checks are filesystem I/O — keep
+        // them off the UI thread. Only the editor-opening call
+        // itself needs Display.syncExec.
+        IFileStore externalStore = null;
+        if (workspaceFiles.length == 0) {
+            externalStore = EFS.getStore(uri);
+            var info = externalStore.fetchInfo();
+            if (!info.exists()) {
+                return HttpServer.jsonError(
+                        "File not found: " + pathParam);
+            }
+            if (info.isDirectory()) {
+                return HttpServer.jsonError(
+                        "Path is a directory: " + pathParam);
+            }
+        }
+        final IFileStore store = externalStore;
+
         String[] result = {HttpServer.jsonError(
                 "Failed to open editor")};
         Display.getDefault().syncExec(() -> {
@@ -195,27 +213,9 @@ class EditorHandler {
                 }
                 IWorkbenchPage page = window.getActivePage();
 
-                IEditorPart editor;
-                if (workspaceFiles.length > 0) {
-                    editor = IDE.openEditor(
-                            page, workspaceFiles[0]);
-                } else {
-                    IFileStore store = EFS.getStore(uri);
-                    var info = store.fetchInfo();
-                    if (!info.exists()) {
-                        result[0] = HttpServer.jsonError(
-                                "File not found: " + pathParam);
-                        return;
-                    }
-                    if (info.isDirectory()) {
-                        result[0] = HttpServer.jsonError(
-                                "Path is a directory: "
-                                + pathParam);
-                        return;
-                    }
-                    editor = IDE.openEditorOnFileStore(
-                            page, store);
-                }
+                IEditorPart editor = (workspaceFiles.length > 0)
+                        ? IDE.openEditor(page, workspaceFiles[0])
+                        : IDE.openEditorOnFileStore(page, store);
 
                 JsonObject ok = new JsonObject();
                 ok.addProperty("ok", true);

--- a/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/EditorHandler.java
@@ -3,9 +3,14 @@ package io.github.kaluchi.jdtbridge;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import java.net.URI;
 import java.util.Map;
 
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
@@ -21,6 +26,7 @@ import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
 
 class EditorHandler {
 
@@ -142,6 +148,86 @@ class EditorHandler {
             } catch (Exception e) {
                 result[0] = HttpServer.jsonError(
                         e.getMessage());
+            }
+        });
+        return result[0];
+    }
+
+    /**
+     * Open an arbitrary filesystem path in Eclipse. Picks the editor
+     * via {@link IDE#openEditor(IWorkbenchPage, IFile)} for workspace
+     * resources (content-type + name/extension binding), or
+     * {@link IDE#openEditorOnFileStore} via EFS for external files.
+     * <p>
+     * {@code path} must be absolute and host-native. CLI is expected
+     * to translate from the agent-local form before sending.
+     */
+    String handleOpenFile(Map<String, String> params)
+            throws Exception {
+        String pathParam = params.get("path");
+        if (pathParam == null || pathParam.isBlank()) {
+            return HttpServer.missingParamError("path");
+        }
+
+        java.io.File f = new java.io.File(pathParam);
+        if (!f.isAbsolute()) {
+            return HttpServer.jsonError(
+                    "Path must be absolute: " + pathParam);
+        }
+
+        URI uri = f.toURI();
+        IWorkspaceRoot root =
+                ResourcesPlugin.getWorkspace().getRoot();
+        IFile[] workspaceFiles =
+                root.findFilesForLocationURI(uri);
+
+        String[] result = {HttpServer.jsonError(
+                "Failed to open editor")};
+        Display.getDefault().syncExec(() -> {
+            try {
+                IWorkbenchWindow window = PlatformUI.getWorkbench()
+                        .getActiveWorkbenchWindow();
+                if (window == null
+                        || window.getActivePage() == null) {
+                    result[0] = HttpServer.jsonError(
+                            "No active workbench page");
+                    return;
+                }
+                IWorkbenchPage page = window.getActivePage();
+
+                IEditorPart editor;
+                if (workspaceFiles.length > 0) {
+                    editor = IDE.openEditor(
+                            page, workspaceFiles[0]);
+                } else {
+                    IFileStore store = EFS.getStore(uri);
+                    var info = store.fetchInfo();
+                    if (!info.exists()) {
+                        result[0] = HttpServer.jsonError(
+                                "File not found: " + pathParam);
+                        return;
+                    }
+                    if (info.isDirectory()) {
+                        result[0] = HttpServer.jsonError(
+                                "Path is a directory: "
+                                + pathParam);
+                        return;
+                    }
+                    editor = IDE.openEditorOnFileStore(
+                            page, store);
+                }
+
+                JsonObject ok = new JsonObject();
+                ok.addProperty("ok", true);
+                if (editor != null) {
+                    ok.addProperty("editorId",
+                            editor.getSite().getId());
+                }
+                result[0] = ok.toString();
+            } catch (Exception e) {
+                String msg = e.getMessage();
+                result[0] = HttpServer.jsonError(
+                        msg != null ? msg : e.toString());
             }
         });
         return result[0];

--- a/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
+++ b/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java
@@ -618,6 +618,10 @@ public class HttpServer {
                         ? editor().handleOpen(params)
                         : jsonError(
                                 "Editor commands require a UI workbench"));
+                case "/openFile" -> Response.json(workbenchActive()
+                        ? editor().handleOpenFile(params)
+                        : jsonError(
+                                "Editor commands require a UI workbench"));
                 case "/launch/list" -> Response.json(
                         launch.handleList(params, scope));
                 case "/launch/configs" -> Response.json(


### PR DESCRIPTION
Refs #145.

Summary

- jdt open accepts an absolute filesystem path in addition to a Java FQN. Auto-detect via isAbsolutePath; falls through to the existing FQN branch otherwise.
- New plugin endpoint /openFile dispatches via IDE.openEditor for workspace files and IDE.openEditorOnFileStore (EFS) for files outside the workspace. Eclipse picks the editor by content-type / extension registry, so XML, properties, GEF / EMF, manifest, pom and similar non-Java formats route to their registered editors automatically.
- Latent bug fix: jdt refresh <path> was sending raw CLI-local paths. On remote instances the plugin could not match them and silently returned refreshed=false. Routed through translateHostPathFromLocal, same as graph.impl path-shape axes.
- Refactor: extracted isAbsolutePath() in cli/src/paths.mjs on top of node:path posix.isAbsolute + win32.isAbsolute. Replaced two inline regex copies (editor.mjs, graph.impl.mjs).

Path translation

The handler always receives host-native absolute paths. CLI translates outbound (CLI-local → eclipse-host) via translateHostPathFromLocal; identity on local instances. Round-trip with jdt editors stays symmetric.

Test plan

- [x] CLI: vitest — 19 cases in commands.test.mjs cover FQN routing, path routing (Windows + POSIX), remote translation, and plugin-error surface; 7 cases in paths.test.mjs for isAbsolutePath.
- [x] Plugin: 7 cases in EditorHandlerOpenFileTest under plugin.tests.ui — missing param, blank param, relative path, missing file, directory, workspace .java (JDT editor), external .txt (default text editor).
- [x] Smoke: jdt open D:/.../MANIFEST.MF and jdt open D:/.../pom.xml open in PDE manifest and m2e pom editors; both appear in jdt editors.