### PR TITLE
Migrate :jdt/* catalogs to qlang 0.7 — Pattern B + render module + docs polish

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -60,10 +60,13 @@ jdt q '@projects * /fqn'                               # workspace projects
 jdt q '@problems'                                      # compilation problems
 ```
 
-Bare-name reify shows operand descriptors:
+Operand introspection — descriptors, prose, and runnable examples
+live on dedicated axes of the binding:
 
 ```bash
-jdt q '@subtypes'                                      # :docs / :examples / :throws
+jdt q ':@subtypes | spec'                              # descriptor — kind, subject, returns, throws
+jdt q ':@subtypes | docs'                              # prose from the attached doc-prefix
+jdt q ':@subtypes | examples'                          # the ~{…} snippets the catalog declares
 jdt q 'manifest * /name'                               # full operand catalog
 ```
 

--- a/cli/lib/jdt/aliases.qlang
+++ b/cli/lib/jdt/aliases.qlang
@@ -1,15 +1,16 @@
-|~ ───────────────────────────────────────────────────────────────────
-   :jdt/aliases — pure-qlang aliases for builtins whose canonical
-   name doesn't match common-English expectations from agents.
+|~ :jdt/aliases — pure-qlang aliases for builtins whose canonical
+   name does not match common-English expectations from agents.
 
    Adding entries here is cheap; each saves one round-trip when a
-   model reaches for the wrong-but-natural name and `jdt q` returns
-   `unresolved-identifier`.
-   ───────────────────────────────────────────────────────────── ~|
+   model reaches for the wrong-but-natural name and `jdt q`
+   returns `unresolved-identifier`. ~|
 
-|~~ Alias for the `flat` builtin — flattens one level of nesting.
-    Accepts the same Vec<Vec<T>> shape, returns Vec<T>. Models
-    consistently reach for `flatten` (Clojure / Lodash / JS Array
-    convention) rather than `flat` (Lisp / qlang); accepting both
-    avoids dead round-trips. ~~|
-let(:flatten, flat)
+|~~ Alias for the `flat` builtin — flattens one level of
+    nesting. Accepts the same Vec<Vec<T>> shape, returns
+    Vec<T>. Models consistently reach for `flatten` (Clojure /
+    Lodash / JS Array convention) rather than `flat` (Lisp /
+    qlang); accepting both avoids dead round-trips.
+
+    ~{ [[1 2] [3 4]] | flatten | eq([1 2 3 4]) }
+ ~~|
+:flatten flat

--- a/cli/lib/jdt/coverage.impl.mjs
+++ b/cli/lib/jdt/coverage.impl.mjs
@@ -16,13 +16,21 @@
 // none live here. They are qlang conduits in coverage.qlang. The
 // plugin is a thin adapter; this layer is a thin transport.
 
-import { nullaryOp, overloadedOp } from '@kaluchi/qlang-core/dispatch';
-import { keyword, makeErrorValue, isErrorValue }
-    from '@kaluchi/qlang-core';
-import { get } from '../../src/client.mjs';
+// qlang 0.7 invariants applied here:
+//   * Map keys are plain Strings (Keyword objects ride as VALUES).
+//   * Error descriptors carry `:kind ::TagKeyword` for per-site
+//     identity. `result !| type` returns the tag; per-tag static
+//     facts (`:category`, `:operand`, `:expectedType`) live on the
+//     catalog body and reach the reader through the `spec` axis.
 
-const FQN_KEY = keyword('fqn');
-const ACTIVE_COVERAGE_ID_KEY = keyword('activeCoverageId');
+import { nullaryOp, overloadedOp } from '@kaluchi/qlang-core/dispatch';
+import {
+    keyword,
+    makeErrorValue,
+    makeTagKeyword,
+    isErrorValue,
+} from '@kaluchi/qlang-core';
+import { get } from '../../src/client.mjs';
 
 const enc = encodeURIComponent;
 
@@ -56,7 +64,7 @@ function jsonToQlang(jsonVal) {
     if (jsonVal !== null && typeof jsonVal === 'object') {
         const m = new Map();
         for (const [k, v] of Object.entries(jsonVal)) {
-            m.set(keyword(k), jsonToQlang(v));
+            m.set(k, jsonToQlang(v));
         }
         return m;
     }
@@ -76,7 +84,7 @@ function liftServerResponse(jsonVal) {
 function fqnOf(subject) {
     if (typeof subject === 'string') return subject;
     if (subject instanceof Map) {
-        const fqn = subject.get(FQN_KEY);
+        const fqn = subject.get('fqn');
         if (typeof fqn === 'string') return fqn;
     }
     return null;
@@ -84,32 +92,27 @@ function fqnOf(subject) {
 
 function missingSubjectError(operandName, subject) {
     const ctx = new Map();
-    ctx.set(keyword('operand'), operandName);
-    ctx.set(keyword('subjectType'),
+    ctx.set('operand', keyword(operandName));
+    ctx.set('subjectType',
             subject === null || subject === undefined ? 'null'
             : Array.isArray(subject) ? 'vec'
             : subject instanceof Map ? 'map-without-fqn'
             : typeof subject);
     const descriptor = new Map();
-    descriptor.set(keyword('kind'),
-            keyword('missing-subject-fqn'));
-    descriptor.set(keyword('thrown'), keyword('MissingSubjectFqn'));
-    descriptor.set(keyword('origin'), keyword('jdt/coverage'));
-    descriptor.set(keyword('message'),
+    descriptor.set('kind', makeTagKeyword('MissingSubjectFqn'));
+    descriptor.set('origin', keyword('jdt/coverage'));
+    descriptor.set('message',
             `${operandName}: pipeValue must be a node-Map with `
             + `:fqn or a fqn-String`);
-    descriptor.set(keyword('context'), ctx);
+    descriptor.set('context', ctx);
     return makeErrorValue(descriptor);
 }
 
 function noActiveCoverageError() {
     const descriptor = new Map();
-    descriptor.set(keyword('kind'),
-            keyword('coverage-no-active-session'));
-    descriptor.set(keyword('thrown'),
-            keyword('CoverageNoActiveSession'));
-    descriptor.set(keyword('origin'), keyword('jdt/coverage'));
-    descriptor.set(keyword('message'),
+    descriptor.set('kind', makeTagKeyword('CoverageNoActiveSession'));
+    descriptor.set('origin', keyword('jdt/coverage'));
+    descriptor.set('message',
             'No active coverage session — pin a coverageId via '
             + '`@coverage("<coverageId>")` or activate one via '
             + '`jdt coverage activate <id>`');
@@ -118,12 +121,9 @@ function noActiveCoverageError() {
 
 function coverageIdNotStringError(actualValue) {
     const descriptor = new Map();
-    descriptor.set(keyword('kind'),
-            keyword('coverage-id-not-string'));
-    descriptor.set(keyword('thrown'),
-            keyword('CoverageIdNotString'));
-    descriptor.set(keyword('origin'), keyword('jdt/coverage'));
-    descriptor.set(keyword('message'),
+    descriptor.set('kind', makeTagKeyword('CoverageIdNotString'));
+    descriptor.set('origin', keyword('jdt/coverage'));
+    descriptor.set('message',
             `@coverage modifier must evaluate to a non-empty `
             + `String coverageId, got `
             + (actualValue === null ? 'null' : typeof actualValue));
@@ -136,7 +136,7 @@ async function fetchActiveCoverageId() {
     const lifted = liftServerResponse(raw);
     if (isErrorValue(lifted)) return lifted;
     if (lifted instanceof Map) {
-        const id = lifted.get(ACTIVE_COVERAGE_ID_KEY);
+        const id = lifted.get('activeCoverageId');
         return typeof id === 'string' ? id : null;
     }
     return null;

--- a/cli/lib/jdt/coverage.qlang
+++ b/cli/lib/jdt/coverage.qlang
@@ -1,158 +1,200 @@
-|~ ───────────────────────────────────────────────────────────────────
-   :jdt/coverage — query surface over EclEmma's IJavaModelCoverage
+|~ :jdt/coverage — query surface over EclEmma's IJavaModelCoverage
    cache, layered on the GET /coverage/node endpoint.
 
-   Subject = a node-Map (skeleton/detail) or a fqn String. Each
-   axis routes to /coverage/node?coverageId=<id>&fqn=<fqn> with
+   Subject = a node-Map (skeleton / detail) or a fqn String. Each
+   axis routes to `/coverage/node?coverageId=<id>&fqn=<fqn>` with
    the active session as default; the optional captured-arg
-   modifier on @coverage pins to a specific coverageId.
+   modifier on `@coverage` pins to a specific coverageId.
 
-   Per-line breakdown (covered/uncovered/partial) is available on
-   ISourceNode subjects only — type, method, source-file. Project
-   / package / fragment-root subjects carry counters but no
-   :lines block; line-axis conduits return an error value on those
-   shapes.
-   ───────────────────────────────────────────────────────────── ~|
+   Per-line breakdown (covered / uncovered / partial) is
+   available on ISourceNode subjects only — type, method,
+   source-file. Project / package / fragment-root subjects carry
+   counters but no `:lines` block; line-axis conduits return an
+   error value on those shapes. ~|
 
-|~ ── Primitives — bound by coverage.impl.mjs ─────────────────── ~|
+|~ ── Error tag-bindings ──────────────────────────────────── ~|
 
-{:@coverage {:qlang/kind :builtin
-             :qlang/impl null
-             :category :jdt/coverage
-             :subject [:map :string]
-             :modifiers [:string]
-             :returns :map
-             :docs ["Raw /coverage/node response: counters Map plus :lines block when subject is an ISourceNode."
-                    "0-arity form binds to the active session via @activeCoverageId."
-                    "1-arity form pins a specific coverageId — `@coverage(\"MyTest:1234\")` or any String expression evaluating to one."]
-             :examples [{:doc "Type counters against the active session"
-                         :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @coverage | /counters/instruction"}
-                        {:doc "Method counters with explicit coverageId pin"
-                         :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start()\" | @coverage(\"CoverageBridgeTest:1777239787278\")"}
-                        {:doc "Line-level entries on a method"
-                         :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start()\" | @coverage | /lines/entries"}]
-             :throws [:CoverageNotFound :CoverageDumpNotFound :CoverageFqnUnresolved :CoverageNoDataForElement :CoverageAnalysisFailed :CoverageNotInstalled]}
+::CoverageNotFound
+  |~~ Coverage lookup miss — the requested coverageId is unknown
+      to EclEmma's cache.
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
- :@activeCoverageId {:qlang/kind :builtin
-                     :qlang/impl null
-                     :category :jdt/coverage
-                     :subject :any
-                     :modifiers []
-                     :returns :string
-                     :docs ["Active coverageId from /coverage/active, or null when no session is active."
-                            "Cached per-process for the life of one `jdt q` invocation; @coverage uses it implicitly when no captured-arg pin is given."]
-                     :examples [{:doc "Read the active coverageId"
-                                 :snippet "@activeCoverageId"}
-                                {:doc "Pin every coverage call in a pipeline to a snapshot of active"
-                                 :snippet "@activeCoverageId | as(:cov) | \"io.github.kaluchi.jdtbridge.HttpServer\" | @coverage(cov)"}]
-                     :throws [:CoverageNotInstalled]}}
-| use
+::CoverageDumpNotFound
+  |~~ Coverage `.exec` dump not found on disk — the recorded
+      session's data file was removed or never created.
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
-|~ ── Counter-status predicates — subject-level booleans ──────── ~|
+::CoverageFqnUnresolved
+  |~~ Coverage element fqn cannot be resolved against the
+      session's analysed bundles.
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
+
+::CoverageNoDataForElement
+  |~~ Element is known but the session has no probe data for it
+      (e.g. the test that exercises it never ran in that run).
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
+
+::CoverageAnalysisFailed
+  |~~ Server-side analysis raised — EclEmma JaCoCo bridge
+      failure.
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
+
+::CoverageNotInstalled
+  |~~ EclEmma plugin not installed in the Eclipse runtime —
+      `/coverage/*` endpoints unavailable.
+   ~~|
+  ::builtin{:category :jdt/coverage-error
+            :operand :@activeCoverageId}
+
+::CoverageNoActiveSession
+  |~~ `@coverage` called in 0-arity form (active-session
+      binding) while no coverage session is active. Pin
+      explicitly via `@coverage("<coverageId>")` or activate one
+      with `jdt coverage activate <id>`.
+
+      ~{ @coverage !| type | eq(::CoverageNoActiveSession) }
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
+
+::CoverageIdNotString
+  |~~ `@coverage(<modifier>)` modifier evaluated to a value
+      other than a non-empty String coverageId.
+   ~~|
+  ::builtin{:category :jdt/coverage-error :operand :@coverage}
+
+::MissingSubjectFqn
+  |~~ Coverage axis subject is neither a node-Map carrying
+      `:fqn` nor a String. (Same tag the `:jdt/graph` module
+      declares; both modules stamp it from the client-side
+      dispatch wrapper.)
+   ~~|
+  ::builtin{:category :jdt/dispatch}
+
+|~ ── Primitives — bound by coverage.impl.mjs ─────────────── ~|
+
+:@coverage
+  |~~ Raw `/coverage/node` response: counters Map plus
+      `:lines` block when subject is an ISourceNode. 0-arity
+      form binds to the active session via `@activeCoverageId`.
+      1-arity form pins a specific coverageId —
+      `@coverage("MyTest:1234")` or any String expression
+      evaluating to one.
+
+      Returned shape: `{:counters {:instruction {:coveredCount N
+      :missedCount N :totalCount N :coverageStatus
+      "FULLY_COVERED"|"PARTLY_COVERED"|"NOT_COVERED"
+      :coveredRatio <ratio>} :branch {...} :line {...} :method
+      {...} :class {...} :complexity {...}} :lines {:entries
+      [{:line N :status "..." :branchCovered N :branchMissed
+      N} ...]}}`.
+
+      ~{ "Foo" | @coverage | /counters/instruction/totalCount | gte(0) }
+   ~~|
+  ::builtin{:category :jdt/coverage
+            :subject [:string :map]
+            :modifiers [:string]
+            :returns :map
+            :throws [::CoverageNotFound ::CoverageDumpNotFound
+                     ::CoverageFqnUnresolved
+                     ::CoverageNoDataForElement
+                     ::CoverageAnalysisFailed
+                     ::CoverageNotInstalled
+                     ::CoverageNoActiveSession
+                     ::CoverageIdNotString
+                     ::MissingSubjectFqn]}
+
+:@activeCoverageId
+  |~~ Active coverageId from `/coverage/active`, or `null` when
+      no session is active. Cached per-process for the life of
+      one `jdt q` invocation; `@coverage` uses it implicitly
+      when no captured-arg pin is given.
+
+      ~{ @activeCoverageId !| type | eq(::CoverageNotInstalled) }
+   ~~|
+  ::builtin{:category :jdt/coverage
+            :subject :any
+            :modifiers []
+            :returns :string
+            :throws [::CoverageNotInstalled]}
+
+|~ ── Counter-status predicates ─────────────────────────── ~|
 
 |~~ Subject-level predicate — true iff `coveredCount` of the
-    `instruction` counter equals zero. Composes via filter / any /
-    every over a Vec of skeletons, or applies to a single node for
-    a boolean check.
+    `instruction` counter equals zero.
 
-    Distinct from `:jdt/graph`'s @untested, which infers absence
-    from the lack of test-scope callers (a structural proxy).
-    @uncovered reads the actual JaCoCo probe data — the test ran
-    but never hit this element.
-
-      "pkg.Foo" | @methods | filter(@uncovered) * /fqn
-      "pkg.Foo#bar()" | @uncovered                     |~| true / false ~~|
-let(:@uncovered,
-    @coverage | /counters/instruction/coveredCount | eq(0))
+    Distinct from `:jdt/graph`'s `@untested`, which infers
+    absence from the lack of test-scope callers (a structural
+    proxy). `@uncovered` reads the actual JaCoCo probe data —
+    the test ran but never hit this element. ~~|
+:@uncovered
+  (@coverage | /counters/instruction/coveredCount | eq(0))
 
 |~~ True iff the element's `instruction` counter is
-    `PARTLY_COVERED` — some instructions ran, some didn't.
-    Marker for branch-incomplete code:
+    `PARTLY_COVERED` — some instructions ran, some didn't. ~~|
+:@partial
+  (@coverage | /counters/instruction/coverageStatus | eq("PARTLY_COVERED"))
 
-      "pkg.Foo" | @methods | filter(@partial) * /fqn   |~| dig in here ~~|
-let(:@partial,
-    @coverage | /counters/instruction/coverageStatus | eq("PARTLY_COVERED"))
+|~~ True iff every instruction of the element ran. ~~|
+:@fullyCovered
+  (@coverage | /counters/instruction/coverageStatus | eq("FULLY_COVERED"))
 
-|~~ True iff every instruction of the element ran. Composes the
-    same way as @uncovered. ~~|
-let(:@fullyCovered,
-    @coverage | /counters/instruction/coverageStatus | eq("FULLY_COVERED"))
+|~ ── Line-level axes — ISourceNode subjects only ────────── ~|
 
-|~ ── Line-level axes — ISourceNode subjects only ─────────────── ~|
+|~~ Vec of line numbers whose status is `FULLY_COVERED`.
+    Subject must be a type, method, or source-file (ISourceNode)
+    — on project / package / fragment-root the underlying
+    `/coverage/node` response carries no `:lines` block. ~~|
+:@coveredLines
+  (@coverage | /lines/entries
+   | filter(/status | eq("FULLY_COVERED")) * /line)
 
-|~~ Vec of line numbers whose status is FULLY_COVERED. Subject
-    must be a type, method, or source-file (ISourceNode) — on
-    project / package / fragment-root the underlying /coverage/node
-    response carries no :lines block and the pipeline fails with a
-    type error against the missing key.
+|~~ Vec of line numbers whose status is `NOT_COVERED`. ~~|
+:@uncoveredLines
+  (@coverage | /lines/entries
+   | filter(/status | eq("NOT_COVERED")) * /line)
 
-      "pkg.Foo#bar()" | @coveredLines      → [42 43 45 47 48 49] ~~|
-let(:@coveredLines,
-    @coverage | /lines/entries
-    | filter(/status | eq("FULLY_COVERED")) * /line)
+|~~ Vec of partial-line entries — each carries `:line` plus
+    branch counters (`:branchCovered`, `:branchMissed`). ~~|
+:@partialLines
+  (@coverage | /lines/entries
+   | filter(/status | eq("PARTLY_COVERED")))
 
-|~~ Vec of line numbers whose status is NOT_COVERED. Same
-    subject requirement as @coveredLines.
-
-      "pkg.Foo#bar()" | @uncoveredLines    → [52 53 54 60 61 62] ~~|
-let(:@uncoveredLines,
-    @coverage | /lines/entries
-    | filter(/status | eq("NOT_COVERED")) * /line)
-
-|~~ Vec of partial-line entries — each carries `:line` plus the
-    branch counter values (`:branchCovered`, `:branchMissed`).
-    Same subject requirement as @coveredLines. Use this when the
-    branch-coverage breakdown matters; for plain line numbers
-    project to /line.
-
-      "pkg.Foo#bar()" | @partialLines * /line
-                                          → [50 51] ~~|
-let(:@partialLines,
-    @coverage | /lines/entries
-    | filter(/status | eq("PARTLY_COVERED")))
-
-|~ ── Drill conduits for cleanup workflows ────────────────────── ~|
+|~ ── Drill conduits for cleanup workflows ─────────────── ~|
 
 |~~ Partial-coverage methods of a type, sorted desc by missed
-    instruction count. Each row carries :fqn, :missed, :covered for
-    quick triage of which methods to drill into:
+    instruction count. Each row carries `:fqn`, `:missed`,
+    `:covered` for quick triage. ~~|
+:@partialMethods
+  (@methods | filter(@partial) * (
+      as(:m) | @coverage | /counters/instruction | as(:c)
+      | {:fqn (m | /fqn)
+         :missed (c | /missedCount)
+         :covered (c | /coveredCount)})
+   | sortWith(desc(/missed)))
 
-      "pkg.Foo" | @partialMethods | take(5) | table
-                                          → top-5 partials with counts
-      "pkg.Foo" | @partialMethods * /fqn  → just the fqns ~~|
-let(:@partialMethods,
-    @methods | filter(@partial) * (
-        as(:m) | @coverage | /counters/instruction | as(:c)
-        | {:fqn (m | /fqn)
-           :missed (c | /missedCount)
-           :covered (c | /coveredCount)})
-    | sortWith(desc(/missed)))
+|~~ Partial-coverage classes of a project, sorted desc by
+    missed instruction count. ~~|
+:@partialClasses
+  (@typesInProject | filter(@partial) * (
+      as(:t) | @coverage | /counters/instruction | as(:c)
+      | {:fqn (t | /fqn)
+         :missed (c | /missedCount)
+         :covered (c | /coveredCount)})
+   | sortWith(desc(/missed)))
 
-|~~ Partial-coverage classes of a project, sorted desc by missed
-    instruction count. Same row shape as @partialMethods. Note this
-    operates on @typesInProject — outer types only; @Nested inner
-    classes have their own counters and need separate drilling via
-    `<class> | @innerTypes | filter(@partial) * (...)`.
+|~ ── Markdown coverage card ────────────────────────────── ~|
 
-      "myproject" | @partialClasses | take(15) | table ~~|
-let(:@partialClasses,
-    @typesInProject | filter(@partial) * (
-        as(:t) | @coverage | /counters/instruction | as(:c)
-        | {:fqn (t | /fqn)
-           :missed (c | /missedCount)
-           :covered (c | /coveredCount)})
-    | sortWith(desc(/missed)))
-
-|~ ── Markdown coverage card ──────────────────────────────────── ~|
-
-|~~ Bundle the subject's @detail node and its @coverage Map for
-    the host-bound `mdCoverage` renderer. Subject can be a type
-    or method fqn / node-Map; the card lays out the six counters
-    plus the per-line breakdown when present.
-
-      "io.github.kaluchi.jdtbridge.HttpServer" | @coverageCard ~~|
-let(:@coverageCard,
-    @asNode | as(:self)
-    | {:node     self | @detail
-       :coverage self | @coverage}
-    | mdCoverage)
+|~~ Bundle the subject's `@detail` node and its `@coverage`
+    Map for the host-bound `mdCoverage` renderer. Subject can
+    be a type or method fqn / node-Map; the card lays out the
+    six counters plus the per-line breakdown when present. ~~|
+:@coverageCard
+  (@asNode | as(:self)
+   | {:node     self | @detail
+      :coverage self | @coverage}
+   | mdCoverage)

--- a/cli/lib/jdt/coverage.qlang
+++ b/cli/lib/jdt/coverage.qlang
@@ -1,22 +1,53 @@
 |~ :jdt/coverage — query surface over EclEmma's IJavaModelCoverage
-   cache, layered on the GET /coverage/node endpoint.
+   cache.
 
-   Subject = a node-Map (skeleton / detail) or a fqn String. Each
-   axis routes to `/coverage/node?coverageId=<id>&fqn=<fqn>` with
-   the active session as default; the optional captured-arg
-   modifier on `@coverage` pins to a specific coverageId.
+   Every coverage axis routes through `/coverage/node?coverageId=
+   <id>&fqn=<fqn>`. The 0-arity form of `@coverage` resolves the
+   active session via `@activeCoverageId`; the 1-arity form pins a
+   specific coverageId — `@coverage("MyTest:1234")` or any String
+   expression evaluating to one. Per-line breakdown is available
+   on ISourceNode subjects only (type / method / source-file);
+   project / package / fragment-root subjects carry counters but
+   no `:lines` block, and the line-axis conduits return an error
+   value on those shapes.
 
-   Per-line breakdown (covered / uncovered / partial) is
-   available on ISourceNode subjects only — type, method,
-   source-file. Project / package / fragment-root subjects carry
-   counters but no `:lines` block; line-axis conduits return an
-   error value on those shapes. ~|
+   Returned shape from `@coverage`: `{:counters {:instruction
+   {:coveredCount N :missedCount N :totalCount N :coverageStatus
+   "FULLY_COVERED"|"PARTLY_COVERED"|"NOT_COVERED" :coveredRatio
+   <ratio>} :branch {...} :line {...} :method {...} :class {...}
+   :complexity {...}} :lines {:entries [{:line N :status "..."
+   :branchCovered N :branchMissed N} ...]}}`. `:lines` absent on
+   non-ISourceNode subjects. ~|
 
-|~ ── Error tag-bindings ──────────────────────────────────── ~|
+|~ ── Coverage source primitives ─────────────────────────── ~|
+
+::CoverageNotInstalled
+  |~~ EclEmma plugin not installed in the Eclipse runtime —
+      the `/coverage/*` endpoints are unavailable. Bridge
+      lifecycle fault; install EclEmma and reload the bridge
+      before retrying.
+   ~~|
+  ::builtin{:category :jdt/coverage-error
+            :operand :@activeCoverageId}
+
+:@activeCoverageId
+  |~~ Active coverageId from `/coverage/active`, or `null` when
+      no session is active. Cached per-process for the life of
+      one `jdt q` invocation; `@coverage` reads it implicitly
+      when no captured-arg pin is given.
+
+      ~{ @activeCoverageId | type | eq(:string) | or(@activeCoverageId | eq(null)) }
+   ~~|
+  ::builtin{:category :jdt/coverage
+            :subject :any
+            :modifiers []
+            :returns :string
+            :throws [::CoverageNotInstalled]}
 
 ::CoverageNotFound
-  |~~ Coverage lookup miss — the requested coverageId is unknown
-      to EclEmma's cache.
+  |~~ Coverage lookup miss — the requested coverageId is
+      unknown to EclEmma's cache (the session was discarded
+      or never recorded).
    ~~|
   ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
@@ -28,42 +59,44 @@
 
 ::CoverageFqnUnresolved
   |~~ Coverage element fqn cannot be resolved against the
-      session's analysed bundles.
+      session's analysed bundles. Typical cause: querying a
+      type that lives in a later-loaded plugin not present in
+      the coverage session's classpath.
    ~~|
   ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
 ::CoverageNoDataForElement
-  |~~ Element is known but the session has no probe data for it
-      (e.g. the test that exercises it never ran in that run).
+  |~~ Element is known to EclEmma but the session has no probe
+      data for it — the test exercising it never ran in that
+      session. Distinct from `::CoverageFqnUnresolved` (element
+      absent from classpath altogether).
    ~~|
   ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
 ::CoverageAnalysisFailed
-  |~~ Server-side analysis raised — EclEmma JaCoCo bridge
-      failure.
+  |~~ EclEmma's JaCoCo bridge raised a server-side fault while
+      analysing the requested element. The descriptor's
+      `:context/originalError` carries the Java-side stack.
    ~~|
   ::builtin{:category :jdt/coverage-error :operand :@coverage}
-
-::CoverageNotInstalled
-  |~~ EclEmma plugin not installed in the Eclipse runtime —
-      `/coverage/*` endpoints unavailable.
-   ~~|
-  ::builtin{:category :jdt/coverage-error
-            :operand :@activeCoverageId}
 
 ::CoverageNoActiveSession
   |~~ `@coverage` called in 0-arity form (active-session
       binding) while no coverage session is active. Pin
-      explicitly via `@coverage("<coverageId>")` or activate one
-      with `jdt coverage activate <id>`.
+      explicitly via `@coverage("<coverageId>")` or activate
+      one with `jdt coverage activate <id>`.
 
-      ~{ @coverage !| type | eq(::CoverageNoActiveSession) }
+      ~{ "pkg.Foo" | @coverage !| type | eq(::CoverageNoActiveSession) }
    ~~|
   ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
 ::CoverageIdNotString
-  |~~ `@coverage(<modifier>)` modifier evaluated to a value
-      other than a non-empty String coverageId.
+  |~~ `@coverage(<modifier>)` captured-arg evaluated to a
+      non-String value. Coverage ids are bridge-side identifiers
+      (e.g. `"MyTest:1748901234567"`) and cannot be derived
+      structurally from another shape.
+
+      ~{ "pkg.Foo" | @coverage(42) !| type | eq(::CoverageIdNotString) }
    ~~|
   ::builtin{:category :jdt/coverage-error :operand :@coverage}
 
@@ -71,29 +104,30 @@
   |~~ Coverage axis subject is neither a node-Map carrying
       `:fqn` nor a String. (Same tag the `:jdt/graph` module
       declares; both modules stamp it from the client-side
-      dispatch wrapper.)
+      dispatch wrapper before any HTTP roundtrip.)
+
+      ~{ [1 2 3] | @coverage !| type | eq(::MissingSubjectFqn) }
    ~~|
   ::builtin{:category :jdt/dispatch}
 
-|~ ── Primitives — bound by coverage.impl.mjs ─────────────── ~|
-
 :@coverage
-  |~~ Raw `/coverage/node` response: counters Map plus
-      `:lines` block when subject is an ISourceNode. 0-arity
-      form binds to the active session via `@activeCoverageId`.
-      1-arity form pins a specific coverageId —
-      `@coverage("MyTest:1234")` or any String expression
-      evaluating to one.
+  |~~ `/coverage/node` response Map — counters plus `:lines`
+      block when the subject is an ISourceNode. 0-arity binds
+      to the active session via `@activeCoverageId`; the 1-arity
+      overload pins a specific coverageId.
 
-      Returned shape: `{:counters {:instruction {:coveredCount N
-      :missedCount N :totalCount N :coverageStatus
-      "FULLY_COVERED"|"PARTLY_COVERED"|"NOT_COVERED"
-      :coveredRatio <ratio>} :branch {...} :line {...} :method
-      {...} :class {...} :complexity {...}} :lines {:entries
+      Returned shape — `{:counters {<counter-key>
+      {:coveredCount N :missedCount N :totalCount N
+      :coverageStatus "FULLY_COVERED"|"PARTLY_COVERED"
+      |"NOT_COVERED" :coveredRatio R} …} :lines {:entries
       [{:line N :status "..." :branchCovered N :branchMissed
-      N} ...]}}`.
+      N} …]}}` — counter keys are `:instruction`, `:branch`,
+      `:line`, `:method`, `:class`, `:complexity`. `:lines`
+      absent on non-ISourceNode subjects (project / package /
+      fragment-root).
 
-      ~{ "Foo" | @coverage | /counters/instruction/totalCount | gte(0) }
+      ~{ "pkg.Foo" | @coverage("InvalidId:0") !| type
+         | (eq(::CoverageNotFound) | or(eq(::CoverageNoActiveSession))) }
    ~~|
   ::builtin{:category :jdt/coverage
             :subject [:string :map]
@@ -108,47 +142,38 @@
                      ::CoverageIdNotString
                      ::MissingSubjectFqn]}
 
-:@activeCoverageId
-  |~~ Active coverageId from `/coverage/active`, or `null` when
-      no session is active. Cached per-process for the life of
-      one `jdt q` invocation; `@coverage` uses it implicitly
-      when no captured-arg pin is given.
-
-      ~{ @activeCoverageId !| type | eq(::CoverageNotInstalled) }
-   ~~|
-  ::builtin{:category :jdt/coverage
-            :subject :any
-            :modifiers []
-            :returns :string
-            :throws [::CoverageNotInstalled]}
-
-|~ ── Counter-status predicates ─────────────────────────── ~|
+|~ ── Counter-status predicates ──────────────────────────── ~|
 
 |~~ Subject-level predicate — true iff `coveredCount` of the
-    `instruction` counter equals zero.
+    `instruction` counter equals zero. Distinct from
+    `:jdt/graph`'s `@untested`, which infers absence from the
+    lack of test-scope callers (structural proxy); `@uncovered`
+    reads the actual JaCoCo probe data (the test ran but never
+    hit this element).
 
-    Distinct from `:jdt/graph`'s `@untested`, which infers
-    absence from the lack of test-scope callers (a structural
-    proxy). `@uncovered` reads the actual JaCoCo probe data —
-    the test ran but never hit this element. ~~|
+    ~{ "pkg.Foo" | @uncovered !| type
+       | (eq(::CoverageNoActiveSession) | or(eq(::CoverageNotFound))) } ~~|
 :@uncovered
   (@coverage | /counters/instruction/coveredCount | eq(0))
 
 |~~ True iff the element's `instruction` counter is
-    `PARTLY_COVERED` — some instructions ran, some didn't. ~~|
+    `PARTLY_COVERED` — some instructions ran, some didn't.
+    Read as "branch coverage incomplete". ~~|
 :@partial
   (@coverage | /counters/instruction/coverageStatus | eq("PARTLY_COVERED"))
 
-|~~ True iff every instruction of the element ran. ~~|
+|~~ True iff every instruction of the element ran. Read as
+    "fully exercised by some test in the active session". ~~|
 :@fullyCovered
   (@coverage | /counters/instruction/coverageStatus | eq("FULLY_COVERED"))
 
 |~ ── Line-level axes — ISourceNode subjects only ────────── ~|
 
 |~~ Vec of line numbers whose status is `FULLY_COVERED`.
-    Subject must be a type, method, or source-file (ISourceNode)
-    — on project / package / fragment-root the underlying
-    `/coverage/node` response carries no `:lines` block. ~~|
+    Subject must be a type, method, or source-file (ISourceNode);
+    project / package / fragment-root return an error value
+    because the underlying `/coverage/node` response carries
+    no `:lines` block on those shapes. ~~|
 :@coveredLines
   (@coverage | /lines/entries
    | filter(/status | eq("FULLY_COVERED")) * /line)
@@ -158,17 +183,22 @@
   (@coverage | /lines/entries
    | filter(/status | eq("NOT_COVERED")) * /line)
 
-|~~ Vec of partial-line entries — each carries `:line` plus
-    branch counters (`:branchCovered`, `:branchMissed`). ~~|
+|~~ Vec of partial-line entries — each carries `:line`,
+    `:branchCovered`, `:branchMissed`. Use to render the
+    "{m} of {total} branches missed" annotation EclEmma
+    shows on gutter hover. ~~|
 :@partialLines
   (@coverage | /lines/entries
    | filter(/status | eq("PARTLY_COVERED")))
 
-|~ ── Drill conduits for cleanup workflows ─────────────── ~|
+|~ ── Drill conduits for cleanup workflows ────────────────── ~|
 
 |~~ Partial-coverage methods of a type, sorted desc by missed
-    instruction count. Each row carries `:fqn`, `:missed`,
-    `:covered` for quick triage. ~~|
+    instruction count. Each row: `{:fqn :missed :covered}`
+    for quick triage of which methods leak coverage the most.
+
+    ~{ "pkg.Foo" | @partialMethods !| type
+       | (eq(::CoverageNoActiveSession) | or(eq(::CoverageNotFound))) } ~~|
 :@partialMethods
   (@methods | filter(@partial) * (
       as(:m) | @coverage | /counters/instruction | as(:c)
@@ -178,7 +208,9 @@
    | sortWith(desc(/missed)))
 
 |~~ Partial-coverage classes of a project, sorted desc by
-    missed instruction count. ~~|
+    missed instruction count. Project-wide variant of
+    `@partialMethods` — feeds a per-project coverage cleanup
+    workflow. ~~|
 :@partialClasses
   (@typesInProject | filter(@partial) * (
       as(:t) | @coverage | /counters/instruction | as(:c)
@@ -187,12 +219,12 @@
          :covered (c | /coveredCount)})
    | sortWith(desc(/missed)))
 
-|~ ── Markdown coverage card ────────────────────────────── ~|
+|~ ── Markdown coverage card ───────────────────────────── ~|
 
 |~~ Bundle the subject's `@detail` node and its `@coverage`
-    Map for the host-bound `mdCoverage` renderer. Subject can
-    be a type or method fqn / node-Map; the card lays out the
-    six counters plus the per-line breakdown when present. ~~|
+    Map for `mdCoverage` (from `:jdt/render`). The card lays
+    out the six counters plus the per-line breakdown when
+    present. ~~|
 :@coverageCard
   (@asNode | as(:self)
    | {:node     self | @detail

--- a/cli/lib/jdt/graph.impl.mjs
+++ b/cli/lib/jdt/graph.impl.mjs
@@ -8,7 +8,7 @@
 // flows into the operand and reduce composability.
 //
 // Filtering, distribution, projection, fan-out — all done via
-// core qlang combinators (filter / * / >> / | / !| / as / let).
+// core qlang combinators (filter / * / >> / | / !| / as / BindStep).
 // No filter parameters in URLs, no refKind/scope/sourceOnly
 // modifiers. The server emits each axis exhaustively; qlang
 // composes the rest.
@@ -16,9 +16,25 @@
 // Wire shape: server returns canonical node JSON or
 // {"_error": {…}}. liftServerResponse converts to qlang shape
 // and lifts errors via makeErrorValue (rides the fail-track).
+//
+// qlang 0.7 Map invariants:
+//   * Map keys are plain Strings (not Keyword objects).
+//   * Error descriptors carry `:kind ::TagKeyword` — the per-site
+//     tag identity surface every tagged value-class shares.
+//     `result !| type` reads the tag back; per-tag static facts
+//     (`:category`, `:operand`) reach the reader through the
+//     `spec` axis (`result !| type | spec | /category`).
+//   * `manifest`, axis-operands (`source` / `docs` / `examples` /
+//     `spec`), and Quote-segmented examples in attached doc-prefix
+//     drive the hypertext-discoverability surface.
 
 import { nullaryOp, overloadedOp } from '@kaluchi/qlang-core/dispatch';
-import { keyword, isKeyword, makeErrorValue } from '@kaluchi/qlang-core';
+import {
+    isKeyword,
+    keyword,
+    makeErrorValue,
+    makeTagKeyword,
+} from '@kaluchi/qlang-core';
 import { get } from '../../src/client.mjs';
 import { remapJsonPaths } from '../../src/json-output.mjs';
 import { translateHostPathFromLocal } from '../../src/path-translate.mjs';
@@ -26,14 +42,12 @@ import { isAbsolutePath } from '../../src/paths.mjs';
 
 // ── Conversion helpers ──────────────────────────────────────────
 
-const FQN_KEY = keyword('fqn');
-
 function jsonToQlang(jsonVal) {
     if (Array.isArray(jsonVal)) return jsonVal.map(jsonToQlang);
     if (jsonVal !== null && typeof jsonVal === 'object') {
         const m = new Map();
         for (const [k, v] of Object.entries(jsonVal)) {
-            m.set(keyword(k), jsonToQlang(v));
+            m.set(k, jsonToQlang(v));
         }
         return m;
     }
@@ -48,10 +62,36 @@ function jsonToQlang(jsonVal) {
 function fqnOf(subject) {
     if (typeof subject === 'string') return subject;
     if (subject instanceof Map) {
-        const fqn = subject.get(FQN_KEY);
+        const fqn = subject.get('fqn');
         if (typeof fqn === 'string') return fqn;
     }
     return null;
+}
+
+// liftServerError(jsonError) — boundary rename from the plugin's
+// JSON error envelope (`:kind` kebab-string broad-bucket plus
+// `:thrown` PascalCase per-site name) to qlang 0.7's tag-identity
+// surface. After the rename: `:kind ::TagKeyword` carries per-site
+// identity (so `result !| type | eq(::TypeNotFound)` works) and
+// `:category :keyword` carries the broad bucket (so `result !|
+// type | spec | /category` reads it once a catalog binding for
+// the tag lands).
+function liftServerError(rawError) {
+    const lifted = jsonToQlang(rawError);
+    if (!(lifted instanceof Map)) return makeErrorValue(lifted);
+    const thrown = lifted.get('thrown');
+    const broad  = lifted.get('kind');
+    const rewritten = new Map(lifted);
+    if (typeof thrown === 'string' && thrown.length > 0) {
+        rewritten.set('kind', makeTagKeyword(thrown));
+        rewritten.delete('thrown');
+    } else if (typeof broad === 'string' && broad.length > 0) {
+        rewritten.set('kind', makeTagKeyword(broad));
+    }
+    if (typeof broad === 'string' && broad.length > 0) {
+        rewritten.set('category', keyword(broad));
+    }
+    return makeErrorValue(rewritten);
 }
 
 function liftServerResponse(jsonVal) {
@@ -59,26 +99,25 @@ function liftServerResponse(jsonVal) {
             && typeof jsonVal === 'object'
             && !Array.isArray(jsonVal)
             && jsonVal._error !== undefined) {
-        return makeErrorValue(jsonToQlang(jsonVal._error));
+        return liftServerError(jsonVal._error);
     }
     return jsonToQlang(jsonVal);
 }
 
 function missingSubject(operandName, subject) {
     const ctx = new Map();
-    ctx.set(keyword('operand'), operandName);
-    ctx.set(keyword('subjectType'),
+    ctx.set('operand', keyword(operandName));
+    ctx.set('subjectType',
             subject === null || subject === undefined ? 'null'
             : Array.isArray(subject) ? 'vec'
             : subject instanceof Map ? 'map-without-fqn'
             : typeof subject);
     const descriptor = new Map();
-    descriptor.set(keyword('kind'), keyword('missing-subject-fqn'));
-    descriptor.set(keyword('thrown'), keyword('MissingSubjectFqn'));
-    descriptor.set(keyword('origin'), keyword('jdt/graph'));
-    descriptor.set(keyword('message'),
+    descriptor.set('kind', makeTagKeyword('MissingSubjectFqn'));
+    descriptor.set('origin', keyword('jdt/graph'));
+    descriptor.set('message',
             `${operandName}: pipeValue must be a node-Map with :fqn or a fqn-String`);
-    descriptor.set(keyword('context'), ctx);
+    descriptor.set('context', ctx);
     return makeErrorValue(descriptor);
 }
 

--- a/cli/lib/jdt/graph.qlang
+++ b/cli/lib/jdt/graph.qlang
@@ -1,686 +1,712 @@
-|~ ───────────────────────────────────────────────────────────────────
-   :jdt/graph — canonical access surface for the Eclipse JDT graph.
+|~ :jdt/graph — canonical access surface for the Eclipse JDT graph.
 
-   Every operand consumes either a node-Map (skeleton or detail —
-   see the ABI doc) or a fqn String, and returns either a
-   single node, a Vec of nodes, or — on failure — an Error value
-   riding the fail-track with the server's structured descriptor.
-   ───────────────────────────────────────────────────────────────── ~|
+   Operand discipline: every @-operand is nullary. Subject is
+   taken from `pipeValue` only. Strings flow into the pipeline as
+   seed values (`"fqn" | @op`); navigation chains read the `:fqn`
+   from a node-Map when subject is a node from a previous step.
+   Captured arguments to @-operands are forbidden — they hide
+   what data flows into the operand and reduce composability.
 
-|~ ── Root queries ─────────────────────────────────────────────── ~|
+   Returned shape:
+     - Skeleton / detail node-Map (`{:kind "type" :fqn "..." ...}`)
+       for single-element lookups (`@type` / `@method` / `@file`).
+     - Vec of skeletons for plural axes (`@members` / `@callers`
+       / `@subtypes`).
+     - String for `@source`.
+     - Error value `!{:kind ::TagName :origin :jdt/graph
+       :message "..." :context {...}}` riding the fail-track on
+       lookup miss / shape mismatch — descriptor's `:kind` is a
+       TagKeyword carrying the per-site identity (reachable as
+       `result !| type`). ~|
 
-{:@types {:qlang/kind :builtin
-          :qlang/impl null
-          :category :jdt/graph
-          :subject [:map :string]
-          :modifiers []
-          :returns :vec
-          :docs ["Type pattern search across the workspace. Subject is a name or wildcard pattern (\"*Controller*\")."
-                 "Returns Vec of :type skeletons; binary dependencies included. Pipeline `@sourceOnly` conduit drops them."]
-          :examples [{:doc "All types matching a wildcard pattern"
-                      :snippet "\"*Service\" | @types * /fqn"}
-                     {:doc "Workspace-source only — exclude binary dependencies via conduit"
-                      :snippet "\"*Handler\" | @types | @sourceOnly * /fqn"}]
-          :throws [:InvalidFqn]}
+|~ ── Error tag-bindings ─────────────────────────────────────
+   Each per-site error class fires from one operand boundary,
+   carries one fixed `:context` shape, and rides through `!|` as
+   a typed identity. Catalog declarations below enable
+   `::TypeNotFound | source / docs / spec` axis-lookups — the
+   plugin (Java side) and the JS-side `liftServerError` both
+   stamp these tags onto `:kind` so `result !| type` reads them
+   back. ~|
 
- :@type {:qlang/kind :builtin
-         :qlang/impl null
-         :category :jdt/graph
-         :subject [:map :string]
-         :modifiers []
-         :returns :map
-         :docs ["Single :type detail by fully qualified name."
-                "Inner classes use dotted form: pkg.Outer.Inner."]
-         :examples [{:doc "Type detail — header plus modifiers, interfaces, javadoc summary, annotations, isTestScope"
-                     :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @type"}
-                    {:doc "Inner class — dotted form"
-                     :snippet "\"io.github.kaluchi.jdtbridge.HttpServer.Response\" | @type | /typeKind"}]
-         :throws [:TypeNotFound]}
+::TypeNotFound
+  |~~ Type lookup miss — the queried fqn does not resolve to a
+      known JDT type. Subject sites: `@type`, `@members`,
+      `@methods`, `@fields`, `@innerTypes`, `@subtypes`,
+      `@implementors`, `@supers`, `@source`.
 
- :@method {:qlang/kind :builtin
-           :qlang/impl null
-           :category :jdt/graph
-           :subject [:map :string]
-           :modifiers []
-           :returns :map
-           :docs ["Single :method detail by FQN. Supports both inline-paren signatures and the bare-name form (must be unambiguous)."]
-           :examples [{:doc "Method detail by full FQN"
-                       :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start(java.net.InetAddress,int)\" | @method"}
-                      {:doc "Ambiguous bare name — descriptor carries :candidates for disambiguation"
-                       :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start\" | @method !| /context/candidates"}]
-           :throws [:MethodNotFound :AmbiguousMatch :InvalidFqn]}
+      ~{ "no.such.Type" | @type !| type | eq(::TypeNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@type}
 
- :@field {:qlang/kind :builtin
-          :qlang/impl null
-          :category :jdt/graph
-          :subject [:map :string]
-          :modifiers []
-          :returns :map
-          :docs ["Single :field detail by FQN (pkg.Type#fieldName)."]
-          :examples [{:doc "Field detail — type, modifiers, annotations"
-                      :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#token\" | @field"}]
-          :throws [:FieldNotFound :InvalidFqn]}
+::MethodNotFound
+  |~~ Method lookup miss — fqn does not resolve, or the bare
+      `pkg.Type#name` form has no matching overload.
 
- :@project {:qlang/kind :builtin
-            :qlang/impl null
-            :category :jdt/graph
-            :subject [:map :string]
-            :modifiers []
-            :returns :map
-            :docs ["Single :project detail by name. Carries natures, classpathEntries, dependencies, sourceRoots, repo and branch when EGit-managed."]
-            :examples [{:doc "Project detail by name"
-                        :snippet "\"io.github.kaluchi.jdtbridge\" | @project"}]
-            :throws [:ProjectNotFound]}
+      ~{ "Foo#nosuch" | @method !| type | eq(::MethodNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@method}
 
- :@projects {:qlang/kind :builtin
-             :qlang/impl null
-             :category :jdt/graph
-             :subject :any
-             :modifiers []
-             :returns :vec
-             :docs ["All open workspace projects in the current session scope. Vec of :project skeletons."]
-             :examples [{:doc "Every open project — one HTTP"
-                         :snippet "@projects * /fqn"}
-                        {:doc "Java-project pre-filter via the skeleton :natures field"
-                         :snippet "@projects | filter(/natures | any(eq(\"java\"))) * /fqn"}
-                        {:doc "Test-only projects (fragments that host nothing but tests)"
-                         :snippet "@projects | filter(/isTestScope) * /fqn"}]
-             :throws []}
+::FieldNotFound
+  |~~ Field lookup miss — the fqn does not name a declared
+      field.
 
- :@package {:qlang/kind :builtin
-            :qlang/impl null
-            :category :jdt/graph
-            :subject [:map :string]
-            :modifiers []
-            :returns :map
-            :docs ["Single :package detail by FQN."]
-            :examples [{:doc "Package detail"
-                        :snippet "\"io.github.kaluchi.jdtbridge\" | @package"}]
-            :throws [:PackageNotFound]}
+      ~{ "Foo#nope" | @field !| type | eq(::FieldNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@field}
 
- :@file {:qlang/kind :builtin
-         :qlang/impl null
-         :category :jdt/graph
-         :subject [:map :string]
-         :modifiers []
-         :returns :map
-         :docs ["Single :file detail by absolute filesystem path."]
-         :examples [{:doc "File detail — holds :typesInFile pointer"
-                     :snippet "\"D:/git/eclipse-jdt-search/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java\" | @file"}]
-         :throws [:FileNotFound]}
+::ProjectNotFound
+  |~~ Project lookup miss — no Eclipse project of that name in
+      the workspace.
 
- |~ ── Containment down ──────────────────────────────────────── ~~|
+      ~{ "no.such.proj" | @project !| type | eq(::ProjectNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@project}
 
- :@members {:qlang/kind :builtin
-            :qlang/impl null
-            :category :jdt/graph
-            :subject [:map :string]
+::PackageNotFound
+  |~~ Package lookup miss — no source package of that name in
+      the workspace.
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@package}
+
+::FileNotFound
+  |~~ File lookup miss — absolute filesystem path does not
+      resolve to a workspace file.
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@file}
+
+::AmbiguousMatch
+  |~~ Bare `pkg.Type#name` matches multiple overloads. The
+      descriptor's `:context/candidates` lists every overload's
+      full fqn — the caller picks one and retries with the
+      disambiguated signature.
+
+      ~{ "Foo#overloaded" | @method !| /context/candidates | count | gt(0) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@method}
+
+::InvalidFqn
+  |~~ Subject String is shaped wrong for the requested axis
+      (missing `#` for method, contains spaces, etc.).
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@type}
+
+::WrongSubjectKind
+  |~~ Subject is a valid node but its `:kind` is incompatible
+      with the axis (e.g. `@overrides` on a `:field` subject).
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@overrides}
+
+::MissingSubjectFqn
+  |~~ Subject is neither a node-Map carrying `:fqn` nor a
+      String. Fired by the client-side dispatch wrapper before
+      any HTTP roundtrip.
+
+      ~{ [1 2 3] | @type !| type | eq(::MissingSubjectFqn) }
+   ~~|
+  ::builtin{:category :jdt/dispatch}
+
+::UnsupportedDetailKind
+  |~~ `@detail` reached a subject `:kind` it does not know how
+      to point-lookup. The descriptor's `:context/subjectKind`
+      pins the offending kind.
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@detail}
+
+::UnsupportedScopeKind
+  |~~ `@problems` reached a subject `:kind` outside the
+      supported scope set (workspace / project / package / file
+      / type / method / field).
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@problems}
+
+::UnsupportedSubjectType
+  |~~ `@problems` subject is neither absent, String, nor Map.
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@problems}
+
+|~ ── Root queries ──────────────────────────────────────── ~|
+
+:@types
+  |~~ Type pattern search across the workspace. Subject is a
+      String pattern with optional `*` wildcards; returns a Vec
+      of `:type` skeletons. Binary dependencies are included —
+      use the `@sourceOnly` conduit to drop them.
+
+      ~{ "*Service" | @types * /fqn }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string]
             :modifiers []
             :returns :vec
-            :docs ["Direct children of a type — methods, fields, inner types. Vec of skeletons."]
-            :examples [{:doc "Every declared member of a type"
-                        :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @members | table"}
-                       {:doc "Public members only"
-                        :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @members | filter(/modifiers | any(eq(\"public\"))) * /fqn"}]
-            :throws [:TypeNotFound]}
+            :throws [::InvalidFqn]}
 
- :@methods {:qlang/kind :builtin
-            :qlang/impl null
-            :category :jdt/graph
-            :subject [:map :string]
+:@type
+  |~~ Single `:type` detail by fully qualified name. Inner
+      classes use dotted form: `pkg.Outer.Inner`.
+
+      Returned shape — type detail node-Map: `{:kind "type"
+      :fqn "..." :typeKind "class"|"interface"|"enum"
+      |"annotation"|"record" :modifiers [...] :interfaces [...]
+      :javadocSummary "..." :annotations [...] :isTestScope
+      <bool> :location {...}}`.
+
+      ~{ "io.github.kaluchi.jdtbridge.HttpServer" | @type | /typeKind }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::TypeNotFound]}
+
+:@method
+  |~~ Single `:method` detail by FQN. Supports both inline-
+      paren signatures and the bare-name form (must be
+      unambiguous — see `::AmbiguousMatch`).
+
+      ~{ "Foo#start(java.net.InetAddress,int)" | @method | /returnType }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::MethodNotFound ::AmbiguousMatch ::InvalidFqn]}
+
+:@field
+  |~~ Single `:field` detail by FQN (`pkg.Type#fieldName`).
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::FieldNotFound ::InvalidFqn]}
+
+:@project
+  |~~ Single `:project` detail by name. Carries `:natures`,
+      `:classpathEntries`, `:dependencies`, `:sourceRoots`,
+      `:repo` and `:branch` when EGit-managed.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::ProjectNotFound]}
+
+:@projects
+  |~~ All open workspace projects in the current session scope.
+      Returns Vec of `:project` skeletons.
+
+      ~{ @projects * /fqn | count | gt(0) }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject :any
             :modifiers []
             :returns :vec
-            :docs ["Methods declared directly in the type."]
-            :examples [{:doc "Method skeletons — signature, modifiers, returnType, annotations"
-                        :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @methods | table"}
-                       {:doc "Largest methods by line count — :lineCount comes from /location"
-                        :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @methods | sortWith(desc(/location/lineCount)) | take(5) * {:fqn /fqn :lines /location/lineCount}"}]
-            :throws [:TypeNotFound]}
+            :throws []}
 
- :@fields {:qlang/kind :builtin
-           :qlang/impl null
-           :category :jdt/graph
-           :subject [:map :string]
-           :modifiers []
-           :returns :vec
-           :docs ["Fields declared directly in the type."]
-           :examples [{:doc "Field skeletons — type, modifiers, annotations"
-                       :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @fields | table"}
-                      {:doc "Only static fields"
-                       :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @fields | filter(/modifiers | any(eq(\"static\"))) * /name"}]
-           :throws [:TypeNotFound]}
+:@package
+  |~~ Single `:package` detail by FQN.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::PackageNotFound]}
 
- :@innerTypes {:qlang/kind :builtin
-               :qlang/impl null
-               :category :jdt/graph
-               :subject [:map :string]
-               :modifiers []
-               :returns :vec
-               :docs ["Inner types declared in the given type."]
-               :examples [{:doc "Nested types of a class"
-                           :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @innerTypes * /fqn"}]
-               :throws [:TypeNotFound]}
+:@file
+  |~~ Single `:file` detail by absolute filesystem path. Holds
+      `:typesInFile` pointer.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::FileNotFound]}
 
- :@typesInPackage {:qlang/kind :builtin
-                   :qlang/impl null
-                   :category :jdt/graph
-                   :subject [:map :string]
-                   :modifiers []
-                   :returns :vec
-                   :docs ["All top-level types in the given package, aggregated across source roots."]
-                   :examples [{:doc "Every type in a package"
-                               :snippet "\"io.github.kaluchi.jdtbridge\" | @typesInPackage * /fqn"}]
-                   :throws []}
+|~ ── Containment down ──────────────────────────────────── ~|
 
- :@typesInFile {:qlang/kind :builtin
-                :qlang/impl null
-                :category :jdt/graph
-                :subject [:map :string]
-                :modifiers []
-                :returns :vec
-                :docs ["Top-level types declared in the given Java file."]
-                :examples [{:doc "Types defined in a single .java file"
-                            :snippet "\"D:/git/eclipse-jdt-search/plugin/src/io/github/kaluchi/jdtbridge/HttpServer.java\" | @typesInFile * /fqn"}]
-                :throws [:FileNotFound]}
+:@members
+  |~~ Direct children of a type — methods, fields, inner
+      types. Returns Vec of skeleton node-Maps, one per
+      declared member.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound]}
 
- :@packagesInProject {:qlang/kind :builtin
-                      :qlang/impl null
-                      :category :jdt/graph
-                      :subject [:map :string]
-                      :modifiers []
-                      :returns :vec
-                      :docs ["Non-empty source packages in the project, deduped per name."]
-                      :examples [{:doc "Packages of a project, ready to fan out with @typesInPackage"
-                                  :snippet "\"io.github.kaluchi.jdtbridge\" | @packagesInProject * /fqn"}
-                                 {:doc "Every source type in a project"
-                                  :snippet "\"io.github.kaluchi.jdtbridge\" | @packagesInProject * @typesInPackage | flat * /fqn"}]
-                      :throws [:ProjectNotFound]}
+:@methods
+  |~~ Methods declared directly in the type. Each entry
+      carries `:signature`, `:modifiers`, `:returnType`,
+      `:annotations`, `:location {:file "..." :startLine N
+      :endLine N :lineCount N}`.
 
- |~ ── Hierarchy ─────────────────────────────────────────────── ~~|
+      ~{ "Foo" | @methods | sortWith(desc(/location/lineCount))
+         | take(5) * /fqn | count | lte(5) }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound]}
 
- :@supers {:qlang/kind :builtin
-           :qlang/impl null
-           :category :jdt/graph
-           :subject [:map :string]
-           :modifiers []
-           :returns :vec
-           :docs ["Direct supertypes — superclass plus directly-declared interfaces. Transitive ascent via @ancestors conduit."]
-           :examples [{:doc "Direct parents of a type"
-                       :snippet "\"io.github.kaluchi.jdtbridge.ui.WelcomeStartupHandler\" | @supers * /fqn"}]
-           :throws [:TypeNotFound]}
+:@fields
+  |~~ Fields declared directly in the type.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound]}
 
- :@subtypes {:qlang/kind :builtin
-             :qlang/impl null
-             :category :jdt/graph
-             :subject [:map :string]
-             :modifiers []
-             :returns :vec
-             :docs ["Direct subtypes only. Transitive descent via @descendants conduit."]
-             :examples [{:doc "Direct subtypes of a type"
-                         :snippet "\"org.eclipse.core.runtime.jobs.Job\" | @subtypes * /fqn"}
-                        {:doc "Workspace-source subtypes only"
-                         :snippet "\"org.eclipse.core.runtime.jobs.Job\" | @subtypes | @sourceOnly * /fqn"}]
-             :throws [:TypeNotFound]}
+:@innerTypes
+  |~~ Inner types declared in the given type.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound]}
 
- :@implementors {:qlang/kind :builtin
-                 :qlang/impl null
-                 :category :jdt/graph
-                 :subject [:map :string]
-                 :modifiers []
-                 :returns :vec
-                 :docs ["Subtypes (for :type subject) or override-methods (for :method subject)."]
-                 :examples [{:doc "Classes implementing an interface"
-                             :snippet "\"org.eclipse.ui.IStartup\" | @implementors * /fqn"}
-                            {:doc "Concrete overrides of an interface method"
-                             :snippet "\"org.eclipse.ui.IStartup#earlyStartup()\" | @implementors * /fqn"}]
-                 :throws [:TypeNotFound :MethodNotFound]}
+:@typesInPackage
+  |~~ All top-level types in the given package, aggregated
+      across source roots.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws []}
 
- :@overrides {:qlang/kind :builtin
-              :qlang/impl null
-              :category :jdt/graph
-              :subject [:map :string]
-              :modifiers []
-              :returns :map
-              :docs ["The closest super-method this method overrides, or null when no override exists."]
-              :examples [{:doc "Resolve a method's override target (null when none)"
-                          :snippet "\"io.github.kaluchi.jdtbridge.ui.WelcomeStartupHandler#earlyStartup()\" | @overrides | /fqn"}]
-              :throws [:MethodNotFound :WrongSubjectKind]}
+:@typesInFile
+  |~~ Top-level types declared in the given Java file.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::FileNotFound]}
 
- :@overloads {:qlang/kind :builtin
-              :qlang/impl null
-              :category :jdt/graph
-              :subject [:map :string]
-              :modifiers []
-              :returns :vec
-              :docs ["Sibling methods of the same name in the containing type, including the queried method."]
-              :examples [{:doc "Every overload of a method name, including the queried one"
-                          :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start(java.net.InetAddress,int)\" | @overloads * /fqn"}]
-              :throws [:MethodNotFound :WrongSubjectKind]}
+:@packagesInProject
+  |~~ Non-empty source packages in the project, deduped per
+      name.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::ProjectNotFound]}
 
- |~ ── References ────────────────────────────────────────────── ~~|
+|~ ── Hierarchy ───────────────────────────────────────── ~|
 
- :@incomingRefs {:qlang/kind :builtin
-                 :qlang/impl null
-                 :category :jdt/graph
-                 :subject [:map :string]
-                 :modifiers [:keyword]
-                 :returns :vec
-                 :docs ["Incoming references to the given node (subject) of the given kind."
-                        "Modifier is the refKind keyword: :call | :read | :write | :typeUse | :all."
-                        "For methods, :call (default) returns invocations. For fields, :read/:write select access mode. For types, :typeUse covers extends/implements/typeUse."
-                        "Returns Vec of :reference nodes where :to is the subject skeleton, :from is the caller, :direction is \"incoming\"."
-                        "Outgoing-side companion: @outgoingRefs."]
-                 :examples [{:doc "Everything that references a type (typeUse default)"
-                             :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @incomingRefs * /from/fqn | distinct"}
-                            {:doc "Union of every refKind the server recognizes"
-                             :snippet "\"io.github.kaluchi.jdtbridge.HttpServer\" | @incomingRefs(:all) * /refKind | distinct"}
-                            {:doc "Field writes only"
-                             :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#running\" | @incomingRefs(:write) * /from/fqn"}]
-                 :throws [:TypeNotFound :MethodNotFound :FieldNotFound]}
+:@supers
+  |~~ Direct supertypes — superclass plus directly-declared
+      interfaces. Transitive ascent via `@ancestors` conduit.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound]}
 
- :@outgoingRefs {:qlang/kind :builtin
-                 :qlang/impl null
-                 :category :jdt/graph
-                 :subject [:map :string]
-                 :modifiers []
-                 :returns :vec
-                 :docs ["Outgoing references from a source member — the types / methods / fields referenced inside the subject's body."
-                        "Returns Vec of :reference nodes where :from is the subject skeleton, :to is the referenced target, :direction is \"outgoing\"."
-                        "Subject must be a type / method / field with available source. Binary-origin subjects fail because the AST visitor needs a compilation unit."
-                        ":refKind labels: :call (method invocation), :read (field / constant access), :typeUse (type reference in signatures, casts, instanceof)."
-                        "Incoming-side companion: @incomingRefs."]
-                 :examples [{:doc "Every outgoing edge from a method body"
-                             :snippet "\"io.github.kaluchi.jdtbridge.ui.WelcomeStartupHandler#earlyStartup()\" | @outgoingRefs * {:to /to/fqn :refKind /refKind}"}
-                            {:doc "Type-dependency set of a method — @typeUses sugar does the same filter + distinct"
-                             :snippet "\"io.github.kaluchi.jdtbridge.ui.WelcomeStartupHandler#earlyStartup()\" | @typeUses * /fqn"}]
-                 :throws [:TypeNotFound :MethodNotFound :FieldNotFound :WrongSubjectKind]}
+:@subtypes
+  |~~ Direct subtypes only. Transitive descent via
+      `@descendants` conduit.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound]}
 
- :@classpath {:qlang/kind :builtin
-              :qlang/impl null
-              :category :jdt/graph
-              :subject [:map :string]
-              :modifiers []
-              :returns :vec
-              :docs ["Classpath entries of the given project."]
-              :examples [{:doc "Classpath entries of a project"
-                          :snippet "\"io.github.kaluchi.jdtbridge\" | @classpath | table"}
-                         {:doc "Test-scope source roots"
-                          :snippet "\"io.github.kaluchi.jdtbridge\" | @classpath | filter(/entryKind | eq(\"source\")) | filter(/isTest) * /path"}]
-              :throws [:ProjectNotFound]}
+:@implementors
+  |~~ Subtypes (for `:type` subject) or override-methods (for
+      `:method` subject).
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound ::MethodNotFound]}
 
- |~ ── Source / diagnostics ────────────────────────────────────── ~|
+:@overrides
+  |~~ The closest super-method this method overrides, or
+      `null` when no override exists.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::MethodNotFound ::WrongSubjectKind]}
 
- :@source {:qlang/kind :builtin
-           :qlang/impl null
-           :category :jdt/graph
-           :subject [:map :string]
-           :modifiers []
-           :returns :string
-           :docs ["Raw source text of a type or member as a String."
-                  "Top-level types return the full compilation unit."
-                  "Prints unquoted — `jdt q '\"X\" | @source' > X.java` writes a byte-faithful file."]
-           :examples [{:doc "Method body as source text"
-                       :snippet "\"io.github.kaluchi.jdtbridge.HttpServer#start()\" | @source"}
-                      {:doc "Full compilation unit of a type"
-                       :snippet "\"io.github.kaluchi.jdtbridge.ErrorDescriptor\" | @source"}]
-           :throws [:TypeNotFound :MethodNotFound :FieldNotFound]}
+:@overloads
+  |~~ Sibling methods of the same name in the containing
+      type, including the queried method.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::MethodNotFound ::WrongSubjectKind]}
 
- :@problemMarkers {:qlang/kind :builtin
-                   :qlang/impl null
-                   :category :jdt/graph
-                   :subject :any
-                   :modifiers []
-                   :returns :vec
-                   :docs ["Primitive IResource-scope compile-problem marker fetch. Public polymorphism lives in the @problems conduit below."
-                          "Accepts: nothing → workspace; String with path-separator / drive letter → IFile by absolute path; String without → IProject by name; Map with :kind \"project\" or \"file\" → same, via :fqn."
-                          "Type / method / field / package subjects pass through the @problems conduit which navigates to a file or project first — they never reach this primitive unresolved."]
-                   :examples [{:doc "Workspace-wide problem markers"
-                               :snippet "@problemMarkers | count"}]
-                   :throws [:FileNotFound :ProjectNotFound]}}
-| use
+|~ ── References ─────────────────────────────────────── ~|
 
-|~~ Polymorphic seed lift. Map subjects (skeleton/detail) pass
-    through. String subjects dispatch by shape:
-      - has '#' and '(' → @method (FQN with explicit signature)
-      - has '#', no '(' → @field, falling back to @method via fail-track
-                          (mirrors GraphHandler.resolveTarget — fields take
-                          priority over nullary / sole-overload methods of
-                          the same name)
-      - no '#'          → @type (FQN for a type) ~~|
-let(:@asNode, as(:subj)
-    | reify | /type | as(:subjType)
-    | subj
-    | when(subjType | eq(:string),
-           cond(contains("#"),
-                cond(contains("("), @method,
-                     @field !| (subj | @method)),
-                @type)))
+:@incomingRefs
+  |~~ Incoming references to the subject of the given refKind.
+      Modifier is the refKind keyword: `:call | :read | :write
+      | :typeUse | :all`. Default depends on subject kind: for
+      methods `:call`, for fields `:read`, for types
+      `:typeUse`.
 
-|~~ Type that contains a member. Member skeletons carry :containingType
-    FQN directly; the result is point-looked-up to a detail node.
-    Returns null for top-level types whose subject lacks the field. ~~|
-let(:@containingType, @asNode | /containingType | unless(eq(null), @type))
+      Each entry is a `:reference` record: `{:from <node>
+      :to <subject-skeleton> :refKind "call"|"read"|"write"
+      |"typeUse" :direction "incoming" :location {...}}`.
+
+      ~{ "Foo" | @incomingRefs * /from/fqn | distinct }
+      ~{ "Foo#running" | @incomingRefs(:write) * /from/fqn }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers [:keyword]
+            :returns :vec
+            :throws [::TypeNotFound ::MethodNotFound ::FieldNotFound]}
+
+:@outgoingRefs
+  |~~ Outgoing references from a source member — types /
+      methods / fields referenced inside the subject's body.
+
+      Each entry is a `:reference` record: `{:from <subject>
+      :to <target> :refKind "call"|"read"|"typeUse" :direction
+      "outgoing" :location {...}}`.
+
+      Subject must be a type / method / field with source
+      available; binary-origin subjects fail with
+      `::WrongSubjectKind`.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::TypeNotFound ::MethodNotFound ::FieldNotFound ::WrongSubjectKind]}
+
+:@classpath
+  |~~ Classpath entries of the given project. Each entry
+      carries `:entryKind` (`"source"|"library"|"container"
+      |"project"`), `:path`, `:isTest`, `:outputLocation`.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :vec
+            :throws [::ProjectNotFound]}
+
+|~ ── Source / diagnostics ────────────────────────────── ~|
+
+:@source
+  |~~ Raw source text of a type or member as a String.
+      Top-level types return the full compilation unit.
+      Prints unquoted — `jdt q '"X" | @source' > X.java`
+      writes a byte-faithful file.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :string
+            :throws [::TypeNotFound ::MethodNotFound ::FieldNotFound]}
+
+:@problemMarkers
+  |~~ Primitive IResource-scope compile-problem marker fetch.
+      Public polymorphism lives in the `@problems` conduit
+      below.
+
+      Accepts: nothing → workspace; String with path-separator
+      / drive letter → IFile by absolute path; String without
+      → IProject by name; Map with `:kind "project"` or `:kind
+      "file"` → same, via `:fqn`.
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject :any
+            :modifiers []
+            :returns :vec
+            :throws [::FileNotFound ::ProjectNotFound]}
+
+|~ ── Polymorphic seed lift ─────────────────────────── ~|
+
+|~~ Map subjects (skeleton / detail) pass through. String
+    subjects dispatch by shape:
+      - has '#' and '(' → `@method` (FQN with explicit
+                          signature)
+      - has '#', no '(' → `@field`, falling back to `@method`
+                          via fail-track
+      - no '#'          → `@type` ~~|
+:@asNode
+  (as(:subj) | type | as(:subjType)
+   | subj
+   | when(subjType | eq(:string),
+          cond(contains("#"),
+               cond(contains("("), @method,
+                    @field !| (subj | @method)),
+               @type)))
+
+|~~ Type that contains a member. ~~|
+:@containingType
+  (@asNode | /containingType | unless(eq(null), @type))
 
 |~~ Package that contains a type. ~~|
-let(:@containingPackage, @asNode | /containingPackage | unless(eq(null), @package))
+:@containingPackage
+  (@asNode | /containingPackage | unless(eq(null), @package))
 
 |~~ Project that contains the given workspace node. ~~|
-let(:@containingProject, @asNode | /containingProject | unless(eq(null), @project))
+:@containingProject
+  (@asNode | /containingProject | unless(eq(null), @project))
 
-|~~ File that contains a type/method/field. Reads :location/:file
-    from the node's location sub-Map. ~~|
-let(:@containingFile, @asNode | /location/file | unless(eq(null), @file))
+|~~ File that contains a type / method / field. ~~|
+:@containingFile
+  (@asNode | /location/file | unless(eq(null), @file))
 
-|~~ Enrich a skeleton-node into a detail-node. Routes by :kind to
-    the appropriate point-lookup operand (@type / @method / @field /
-    @project / @package / @file). Idempotent on detail-nodes.
-    Accepts String FQN/FQN subjects via @asNode. Unknown :kind
-    raises :unsupported-detail-kind on the fail-track. ~~|
-let(:@detail, @asNode | as(:n) | /kind | as(:k)
-    | cond(eq("type"),    n | @type,
-           eq("method"),  n | @method,
-           eq("field"),   n | @field,
-           eq("project"), n | @project,
-           eq("package"), n | @package,
-           eq("file"),    n | @file,
-           !{:kind :unsupported-detail-kind
-             :thrown :UnsupportedDetailKind
-             :origin :jdt/graph
-             :message "@detail cannot route subject — :kind is not one of type/method/field/project/package/file"
-             :context {:subjectKind k :subject n}}))
+|~~ Enrich a skeleton-node into a detail-node. Routes by
+    `:kind`. Idempotent on detail-nodes. Unknown `:kind` raises
+    `::UnsupportedDetailKind` on the fail-track. ~~|
+:@detail
+  (@asNode | as(:n) | /kind | as(:k)
+   | cond(eq("type"),    n | @type,
+          eq("method"),  n | @method,
+          eq("field"),   n | @field,
+          eq("project"), n | @project,
+          eq("package"), n | @package,
+          eq("file"),    n | @file,
+          !{:kind ::UnsupportedDetailKind
+            :origin :jdt/graph
+            :message "@detail cannot route subject — :kind is not one of type/method/field/project/package/file"
+            :context {:subjectKind k :subject n}}))
 
-|~~ Retain markers whose :location/startLine falls inside the
-    captured node's [startLine, endLine]. Used by @problemsVia to
-    narrow whole-file marker Vecs to an inner-type / method / field
-    source range. ~~|
-let(:problemsInRangeOf, [:node],
-    filter(and(/location/startLine | gte(node | /location/startLine),
-               /location/startLine | lte(node | /location/endLine))))
+|~~ Retain markers whose `:location/startLine` falls inside
+    the captured node's `[startLine, endLine]`. ~~|
+:problemsInRangeOf [:node]
+  filter(and(/location/startLine | gte(node | /location/startLine),
+             /location/startLine | lte(node | /location/endLine)))
 
-|~~ Member (method/field) subject → file markers from `fetcher`
-    filtered to the member's source range. Pure over its fetcher
-    param — no @-operand references. ~~|
-let(:@problemsForMemberVia, [:fetcher],
-    as(:m) | /location/file | fetcher | problemsInRangeOf(m))
+|~~ Member subject → file markers from `fetcher` filtered to
+    the member's source range. ~~|
+:@problemsForMemberVia [:fetcher]
+  (as(:m) | /location/file | fetcher | problemsInRangeOf(m))
 
-|~~ Node subject → kind-dispatched scope navigation.
-    Dependencies enter as params:
-      - fetcher       — primitive IResource-scope marker fetch
-      - fileLocation  — node → file node (e.g. @containingFile)
-      - packageTypes  — package → Vec<type> (e.g. @typesInPackage)
-    Kindless Map → workspace. Project / file → fetcher on :fqn.
-    Package → fan-out via packageTypes + fileLocation + fetcher.
-    Type → file scope; top-level stays homogeneous with @source
-    (no range filter), inner narrows to source range. Method /
-    field → file + range filter. Other :kinds → structured error. ~~|
-let(:@problemsForNodeVia, [:fetcher, :fileLocation, :packageTypes],
-    as(:n) | /kind | as(:k)
-    | cond(isNull,        fetcher,
-           eq("project"), n | fetcher,
-           eq("file"),    n | fetcher,
-           eq("package"), n | packageTypes * fileLocation
-                            | flat | distinct * fetcher | flat,
-           eq("type"),    n | /location/file | fetcher
-                            | unless(n | /declaringType | isNull,
-                                     problemsInRangeOf(n)),
-           eq("method"),  n | @problemsForMemberVia(fetcher),
-           eq("field"),   n | @problemsForMemberVia(fetcher),
-           !{:kind :unsupported-scope-kind
-             :thrown :UnsupportedScopeKind
-             :origin :jdt/graph
-             :message "@problems: subject :kind is not a scope (expected one of workspace/project/package/file/type/method/field)"
-             :context {:subjectKind k :subject n}}))
+|~~ Node subject → kind-dispatched scope navigation. ~~|
+:@problemsForNodeVia [:fetcher :fileLocation :packageTypes]
+  (as(:n) | at("kind") | as(:k)
+   | cond(isNull,        n | fetcher,
+          eq("project"), n | fetcher,
+          eq("file"),    n | fetcher,
+          eq("package"), n | packageTypes * fileLocation
+                           | flat | distinct * fetcher | flat,
+          eq("type"),    n | /location/file | fetcher
+                           | unless(n | /declaringType | isNull,
+                                    problemsInRangeOf(n)),
+          eq("method"),  n | @problemsForMemberVia(fetcher),
+          eq("field"),   n | @problemsForMemberVia(fetcher),
+          !{:kind ::UnsupportedScopeKind
+            :origin :jdt/graph
+            :message "@problems: subject :kind is not a scope (expected one of workspace/project/package/file/type/method/field)"
+            :context {:subjectKind k :subject n}}))
 
-|~~ String subject dispatch.
-    Dependencies:
-      - fetcher  — primitive IResource-scope marker fetch
-      - liftNode — String → member node for '#'-bearing fqns
-                   (e.g. @asNode)
-    '#' → liftNode → member branch. Otherwise fetcher direct (server
-    resolves as project name; :ProjectNotFound on miss). ~~|
-let(:@problemsForStringVia, [:fetcher, :liftNode],
-    as(:s) | cond(contains("#"), liftNode | @problemsForMemberVia(fetcher),
-                  fetcher))
+|~~ String subject dispatch. ~~|
+:@problemsForStringVia [:fetcher :liftNode]
+  (as(:s)
+   | cond(contains("#"), liftNode | @problemsForMemberVia(fetcher),
+          fetcher))
 
-|~~ Polymorphic compile-problem scope factory.
-    All effectful dependencies are params so the conduit is
-    fully mockable in tests:
-      - fetcher       — IResource-scope marker primitive
-      - liftNode      — String → member node (for '#' fqns)
-      - fileLocation  — node → file node
-      - packageTypes  — package node → Vec<type>
-    The public @problems binding below plugs in the real
-    @problemMarkers / @asNode / @containingFile / @typesInPackage. ~~|
-let(:@problemsVia, [:fetcher, :liftNode, :fileLocation, :packageTypes],
-    as(:subj)
-    | cond(isNull,   fetcher,
-           isString, @problemsForStringVia(fetcher, liftNode),
-           isMap,    @problemsForNodeVia(fetcher, fileLocation, packageTypes),
-           !{:kind :unsupported-subject-type
-             :thrown :UnsupportedSubjectType
-             :origin :jdt/graph
-             :message "@problems: subject must be absent, String, or Map"
-             :context {:subject subj}}))
+|~~ Polymorphic compile-problem scope factory. ~~|
+:@problemsVia [:fetcher :liftNode :fileLocation :packageTypes]
+  (as(:subj)
+   | cond(isNull,   fetcher,
+          isString, @problemsForStringVia(fetcher, liftNode),
+          isMap,    @problemsForNodeVia(fetcher, fileLocation, packageTypes),
+          !{:kind ::UnsupportedSubjectType
+            :origin :jdt/graph
+            :message "@problems: subject must be absent, String, or Map"
+            :context {:subject subj}}))
 
-|~~ @problems — polymorphic compile-problem scope. Subject dispatch
-    (homogeneous with @source for top-level types, narrowing for
-    inner / method / field, aggregation for package, direct
-    IResource call for project / file / workspace). Public binding
-    of @problemsVia — the single top-level point where the real
-    @problemMarkers / @asNode / @containingFile / @typesInPackage
-    operands plug into the conduit. ~~|
-let(:@problems, @problemsVia(@problemMarkers, @asNode,
-                              @containingFile, @typesInPackage)
-                * union({:error   /severity | eq("error")
-                         :warning /severity | eq("warning")}))
+|~~ Polymorphic compile-problem scope. Each marker is enriched
+    with `:error` and `:warning` booleans for filter
+    convenience. ~~|
+:@problems
+  (@problemsVia(@problemMarkers, @asNode,
+                @containingFile, @typesInPackage)
+   * union({:error   /severity | eq("error")
+            :warning /severity | eq("warning")}))
 
-|~~ Incoming call sites of a method — distinct :from skeletons
-    of every :call reference. Eclipse SearchEngine emits one
-    SearchMatch per source occurrence, so a method that calls the
-    subject three times surfaces the same :from thrice — distinct
-    collapses to unique callers. Symmetric with @calls on the
-    outgoing side. ~~|
-let(:@callers, @incomingRefs | filter(/refKind | eq("call"))
-    * /from | distinct)
+|~~ Incoming call sites of a method — distinct `:from`
+    skeletons of every `:call` reference.
 
-|~~ Distinct :from skeletons of every :read access of a field.
-    Same dedup contract as @callers. ~~|
-let(:@readers, @incomingRefs | filter(/refKind | eq("read"))
-    * /from | distinct)
+    ~{ "Foo#bar()" | @callers | count | gte(0) } ~~|
+:@callers
+  (@incomingRefs
+   | filter(/refKind | eq("call"))
+   * /from
+   | distinct)
 
-|~~ Distinct :from skeletons of every :write access of a field.
-    Same dedup contract as @callers. ~~|
-let(:@writers, @incomingRefs | filter(/refKind | eq("write"))
-    * /from | distinct)
+|~~ Distinct `:from` skeletons of every `:read` access of a
+    field. ~~|
+:@readers
+  (@incomingRefs
+   | filter(/refKind | eq("read"))
+   * /from
+   | distinct)
 
-|~~ Methods the subject body invokes. Outgoing-side companion
-    to @callers. Returns distinct :to skeletons. ~~|
-let(:@calls, @outgoingRefs | filter(/refKind | eq("call")) * /to
-    | distinct)
+|~~ Distinct `:from` skeletons of every `:write` access of a
+    field. ~~|
+:@writers
+  (@incomingRefs
+   | filter(/refKind | eq("write"))
+   * /from
+   | distinct)
 
-|~~ Types the subject body touches — signatures, casts, generics,
-    instanceof. Returns distinct :to skeletons. ~~|
-let(:@typeUses, @outgoingRefs | filter(/refKind | eq("typeUse")) * /to
-    | distinct)
+|~~ Methods the subject body invokes. ~~|
+:@calls
+  (@outgoingRefs
+   | filter(/refKind | eq("call"))
+   * /to
+   | distinct)
 
-|~ ── Stdlib conduits ─────────────────────────────────────────── ~|
-|~ Recursive and composed graph navigations built from the
-   primitive operands above. Each conduit carries :docs for
-   reify/manifest self-documentation. ~|
+|~~ Types the subject body touches. ~~|
+:@typeUses
+  (@outgoingRefs
+   | filter(/refKind | eq("typeUse"))
+   * /to
+   | distinct)
 
-|~~ Transitive supertypes, flat Vec of :type skeletons. Walks
-    @supers recursively until the chain terminates. Two `flat`
-    passes spread `[direct_vec, vec_of_ancestor_vecs]` into a
-    uniform flat sequence of node-Maps; `distinct` then collapses
-    diamond reachability by structural equality. ~~|
-let(:@ancestors, @supers | as(:direct)
-    | [direct, direct * @ancestors] | flat | flat | distinct)
+|~ ── Stdlib conduits ─────────────────────────────────── ~|
 
-|~~ Transitive subtypes, flat Vec of :type skeletons. Walks
-    @subtypes recursively until no further subtypes exist. Same
-    two-flat + `distinct` pattern as @ancestors. ~~|
-let(:@descendants, @subtypes | as(:direct)
-    | [direct, direct * @descendants] | flat | flat | distinct)
+|~~ Transitive supertypes, flat Vec of `:type` skeletons. ~~|
+:@ancestors
+  (@supers
+   | as(:direct)
+   | [direct, direct * @ancestors]
+   | flat
+   | flat
+   | distinct)
 
-|~~ Public methods of a type with zero incoming callers.
-    Deletion candidates — methods no code references. ~~|
-let(:@publicOrphans, @methods
-    | filter(/modifiers | any(eq("public")))
-    | filter(@callers | empty))
+|~~ Transitive subtypes, flat Vec of `:type` skeletons. ~~|
+:@descendants
+  (@subtypes
+   | as(:direct)
+   | [direct, direct * @descendants]
+   | flat
+   | flat
+   | distinct)
 
-|~ ── Type dependency conduits ──────────────────────────── ~|
+|~~ Public methods of a type with zero incoming callers. ~~|
+:@publicOrphans
+  (@methods
+   | filter(/modifiers | any(eq("public")))
+   | filter(@callers | empty))
 
-|~~ Types the subject depends on — direct supertypes plus every
-    type touched by the subject's body (signatures, casts,
-    instanceof, generic args). Returns distinct :type-kind
-    skeletons. ~~|
-let(:@dependsOn,
-    as(:self)
-    | [self | @supers,
-       self | @outgoingRefs | filter(/refKind | eq("typeUse")) * /to]
-    | flat | distinct)
+|~~ Types the subject depends on. ~~|
+:@dependsOn
+  (as(:self)
+   | [self | @supers,
+      self | @outgoingRefs | filter(/refKind | eq("typeUse")) * /to]
+   | flat
+   | distinct)
 
-|~~ Types that depend on the subject — everything in the workspace
-    that references the subject as a typeUse, plus direct subtypes
-    (which implicitly depend on their super). Returns distinct
-    :type skeletons. ~~|
-let(:@usedBy,
-    as(:self)
-    | [self | @incomingRefs(:typeUse) * /from | filter(/kind | eq("type")),
-       self | @subtypes]
-    | flat | distinct)
+|~~ Types that depend on the subject. ~~|
+:@usedBy
+  (as(:self)
+   | [self | @incomingRefs(:typeUse) * /from | filter(/kind | eq("type")),
+      self | @subtypes]
+   | flat
+   | distinct)
 
-|~ ── Dead code conduits ────────────────────────────────── ~|
+|~~ Non-private methods with zero incoming callers. ~~|
+:@deadCode
+  (@methods
+   | filter(/modifiers | any(eq("private")) | not)
+   | filter(@callers | empty))
 
-|~~ Non-private methods with zero incoming callers — broader
-    deletion audit than @publicOrphans (includes protected and
-    package-private). May still include override targets (framework
-    callbacks invoked reflectively) — filter further with
-    `filter(@overrides | eq(null))` when ruling those out.  ~~|
-let(:@deadCode, @methods
-    | filter(/modifiers | any(eq("private")) | not)
-    | filter(@callers | empty))
-
-|~~ Filter nodes to those from workspace source, not binary deps. ~~|
-let(:@sourceOnly, filter(/origin | eq("source")))
+|~~ Filter nodes to those from workspace source. ~~|
+:@sourceOnly
+  filter(/origin | eq("source"))
 
 |~~ Filter nodes to those belonging to the named project. ~~|
-let(:@inProject, [:projName],
-    filter(/containingProject | eq(projName)))
+:@inProject [:projName]
+  filter(/containingProject | eq(projName))
 
-|~~ Volume estimate for a Vec — before committing to reading the
-    full result. Returns `{:count N :head [first 5] :tail [last 5]}`.
-    Use when a pipeline might return a large Vec of node-Maps and
-    the caller needs to decide whether to narrow further (filter,
-    take) or consume it all. Works on any Vec — node-Maps, fqn
-    Strings, numbers. ~~|
-let(:@overview,
-    as(:v)
-    | {:count v | count
-       :head v | take(5)
-       :tail v | reverse | take(5) | reverse})
+|~~ Volume estimate for a Vec. Returns `{:count N :head [...]
+    :tail [...]}`.
 
-|~~ Every top-level :type declared in the given project. The bare
-    `@packagesInProject * @typesInPackage | flat` chain bleeds
-    across fragment projects because package names are shared,
-    so the result is re-filtered via @inProject on the project's
-    fqn. Accepts String project name or project node-Map. ~~|
-let(:@typesInProject,
-    @project | as(:p) | /fqn | as(:pn)
-    | p | @packagesInProject * @typesInPackage | flat
-    | @inProject(pn))
+    ~{ [1 2 3 4 5 6 7 8 9 10] | @overview | /count | eq(10) } ~~|
+:@overview
+  (as(:v)
+   | {:count v | count
+      :head v | take(5)
+      :tail v | reverse | take(5) | reverse})
 
-|~ ── Test-scope conduits ────────────────────────────────────── ~|
+|~~ Every top-level `:type` declared in the given project. ~~|
+:@typesInProject
+  (@project | as(:p) | /fqn | as(:pn)
+   | p | @packagesInProject * @typesInPackage | flat
+   | @inProject(pn))
 
-|~~ Subset of callers whose declaring type is test-scope. For
-    @callers of a method, @readers/@writers of a field — answers
-    "which tests exercise this element". ~~|
-let(:@testCallers, @callers | filter(/isTestScope))
+|~ ── Test-scope conduits ───────────────────────────── ~|
 
-|~~ Callers outside test scope — production usage audit. ~~|
-let(:@productionCallers, @callers | filter(/isTestScope | not))
+|~~ Subset of callers whose declaring type is test-scope. ~~|
+:@testCallers
+  (@callers | filter(/isTestScope))
 
-|~~ Subject-level predicate — true iff the method/field has zero
-    test-scope callers. An exercise-gap marker for production code
-    that tests do not reach. Members with only test-scope callers
-    (no production users) are NOT flagged — they already have a
-    test touching them.
+|~~ Callers outside test scope. ~~|
+:@productionCallers
+  (@callers | filter(/isTestScope | not))
 
-    Compose over a Vec of member skeletons via filter / every / any:
-      "pkg.Foo" | @methods | filter(@untested) * /fqn
-      "pkg.Foo" | @methods | any(@untested)
-    Or apply to a single method / field node for a boolean check. ~~|
-let(:@untested,
-    @callers | filter(/isTestScope) | empty)
+|~~ True iff method / field has zero test-scope callers. ~~|
+:@untested
+  (@callers | filter(/isTestScope) | empty)
 
-|~~ For a type node, every test-scope caller across the type
-    itself plus its declared methods and fields. Returns the Vec
-    of distinct test-scope :from skeletons — the "which tests
-    exercise this type" answer. Per-fqn @incomingRefs errors (unreachable
-    members, binary-origin extras) are swallowed via `!| []` so
-    a single bad fqn does not crater the audit. ~~|
-let(:@tests,
-    as(:self)
-    | [[self | /fqn], self | @methods * /fqn, self | @fields * /fqn]
-    | flat
-    * (@incomingRefs !| [])
-    | flat * /from
-    | filter(/isTestScope)
-    | distinct)
+|~~ Test-scope callers across type + members. ~~|
+:@tests
+  (as(:self)
+   | [[self | /fqn], self | @methods * /fqn, self | @fields * /fqn]
+   | flat
+   * (@incomingRefs !| [])
+   | flat * /from
+   | filter(/isTestScope)
+   | distinct)
 
-|~ ── Annotation conduits ───────────────────────────────────── ~|
+|~ ── Annotation conduits ──────────────────────────── ~|
 
-|~~ Subject-level predicate — true iff the element's :annotations
-    Vec contains annotationFqn. Argument is a String — the full
-    qualified annotation type, e.g. "org.junit.jupiter.api.Test",
-    "java.lang.Deprecated", "org.springframework.stereotype.Service".
+|~~ True iff the element's `:annotations` Vec contains
+    `annotationFqn`. ~~|
+:@annotatedWith [:annotationFqn]
+  (/annotations | any(eq(annotationFqn)))
 
-    Compose with filter / every / any over a Vec of skeletons:
-      xs | filter(@annotatedWith("...Service"))
-      xs | any(@annotatedWith("...Test"))
-    Or apply directly to a single node-Map for a boolean check. ~~|
-let(:@annotatedWith, [:annotationFqn],
-    /annotations | any(eq(annotationFqn)))
+|~~ Deprecated-element predicate. ~~|
+:@deprecated
+  @annotatedWith("java.lang.Deprecated")
 
-|~~ Deprecated-element predicate — alias of
-    @annotatedWith("java.lang.Deprecated"). Same predicate
-    contract — compose with filter / every / any, or apply to
-    a single node for true / false. ~~|
-let(:@deprecated, @annotatedWith("java.lang.Deprecated"))
+|~ ── Markdown render shortcuts ─────────────────────── ~|
 
-|~ ── Markdown render shortcuts ────────────────────────────── ~|
+|~~ `@source` enriched with the context an IDE shows on
+    hover. ~~|
+:@sourceCard
+  (@asNode | as(:self)
+   | {:node     self | @detail
+      :text     self | @source
+      :outgoing self | @outgoingRefs       !| []
+      :incoming self | @incomingRefs(:all) !| []
+      :supers   self | @supers             !| []
+      :subtypes self | @subtypes           !| []}
+   | mdSource)
 
-|~~ @source enriched with the context an IDE shows on Ctrl/Cmd-hover:
-    detail header (signature, modifiers, javadoc), source body,
-    outgoing / incoming refs, and — for types — supers / subtypes.
-    Subject can be a Type, Method, or Field; mdSource omits empty
-    sections, so non-type subjects render without a Hierarchy block.
+|~~ Type hierarchy card. ~~|
+:@hierarchyCard
+  (@asNode | as(:self)
+   | {:node     self | @detail
+      :supers   self | @supers
+      :subtypes self | @subtypes}
+   | mdHierarchy)
 
-    Pipes the rendered String through as-is — `jdt q '…' >
-    Foo.md` writes markdown without quoting.  ~~|
-let(:@sourceCard,
-    @asNode | as(:self)
-    | {:node     self | @detail
-       :text     self | @source
-       :outgoing self | @outgoingRefs       !| []
-       :incoming self | @incomingRefs(:all) !| []
-       :supers   self | @supers             !| []
-       :subtypes self | @subtypes           !| []}
-    | mdSource)
-
-|~~ Type hierarchy card — ↑ supers / ↓ subtypes flat markdown. ~~|
-let(:@hierarchyCard,
-    @asNode | as(:self)
-    | {:node     self | @detail
-       :supers   self | @supers
-       :subtypes self | @subtypes}
-    | mdHierarchy)
-
-|~~ Structural outline of a type — fields, methods, inner types
-    grouped by kind with modifiers and line ranges. One-shot
-    "what lives in this class" without reading the source. ~~|
-let(:@outlineCard,
-    @asNode | as(:self)
-    | {:node    self | @detail
-       :members self | @members}
-    | mdOutline)
+|~~ Structural outline of a type. ~~|
+:@outlineCard
+  (@asNode | as(:self)
+   | {:node    self | @detail
+      :members self | @members}
+   | mdOutline)

--- a/cli/lib/jdt/graph.qlang
+++ b/cli/lib/jdt/graph.qlang
@@ -1,169 +1,121 @@
-|~ :jdt/graph — canonical access surface for the Eclipse JDT graph.
+|~ :jdt/graph — pipeline access surface for Eclipse JDT.
 
-   Operand discipline: every @-operand is nullary. Subject is
-   taken from `pipeValue` only. Strings flow into the pipeline as
-   seed values (`"fqn" | @op`); navigation chains read the `:fqn`
-   from a node-Map when subject is a node from a previous step.
-   Captured arguments to @-operands are forbidden — they hide
-   what data flows into the operand and reduce composability.
+   Every `@`-operand is nullary. Subject rides on pipeValue —
+   a fqn String at the start of a chain (`"pkg.Foo" | @type`)
+   or a node-Map from the previous step (`"Foo" | @type |
+   @members * /fqn`). Captured arguments to `@`-operands are
+   reserved for refKind / scope modifiers (`@incomingRefs(:write)`,
+   `@inProject("io.github.kaluchi.jdtbridge")`) — never for the
+   subject itself, so what data enters every step stays
+   structurally derivable.
 
    Returned shape:
-     - Skeleton / detail node-Map (`{:kind "type" :fqn "..." ...}`)
-       for single-element lookups (`@type` / `@method` / `@file`).
-     - Vec of skeletons for plural axes (`@members` / `@callers`
-       / `@subtypes`).
-     - String for `@source`.
-     - Error value `!{:kind ::TagName :origin :jdt/graph
-       :message "..." :context {...}}` riding the fail-track on
-       lookup miss / shape mismatch — descriptor's `:kind` is a
-       TagKeyword carrying the per-site identity (reachable as
-       `result !| type`). ~|
 
-|~ ── Error tag-bindings ─────────────────────────────────────
-   Each per-site error class fires from one operand boundary,
-   carries one fixed `:context` shape, and rides through `!|` as
-   a typed identity. Catalog declarations below enable
-   `::TypeNotFound | source / docs / spec` axis-lookups — the
-   plugin (Java side) and the JS-side `liftServerError` both
-   stamp these tags onto `:kind` so `result !| type` reads them
-   back. ~|
+     Single-element axes — `@type` / `@method` / `@field` /
+     `@package` / `@project` / `@file` — return a detail
+     node-Map: `{:kind "type"|"method"|"field"|"package"
+     |"project"|"file" :fqn "..." :location {:file "..."
+     :startLine N :endLine N} …per-kind fields}`.
+
+     Plural axes — `@members` / `@methods` / `@fields` /
+     `@callers` / `@subtypes` / `@incomingRefs` / … — return
+     a Vec of skeleton node-Maps. Skeletons carry the same
+     `:kind` / `:fqn` / `:location` discriminator triple as
+     detail nodes plus a few kind-specific fields suited to
+     enumeration (skeleton fields are a strict subset of detail
+     fields).
+
+     `@source` returns a String — verbatim source slice of the
+     subject element. Top-level types return the full
+     compilation unit.
+
+     A `:reference` record (returned by `@incomingRefs` /
+     `@outgoingRefs`) is a Map: `{:kind "reference" :from <node>
+     :to <node> :refKind "call"|"read"|"write"|"typeUse"
+     :direction "incoming"|"outgoing" :location {...}}`.
+
+     Lookup miss and shape mismatch lift to an `!{:kind ::TagName
+     :origin :jdt/graph :message "..." :context {...}}` error
+     value riding the fail-track. The per-site `::TagName` reads
+     back through `result !| type` and is catalogued below
+     alongside the operand that fires it. ~|
+
+|~ ── Single-element seeds ────────────────────────────────── ~|
 
 ::TypeNotFound
-  |~~ Type lookup miss — the queried fqn does not resolve to a
-      known JDT type. Subject sites: `@type`, `@members`,
-      `@methods`, `@fields`, `@innerTypes`, `@subtypes`,
-      `@implementors`, `@supers`, `@source`.
+  |~~ Type lookup miss — fqn does not resolve to a workspace
+      type. The same tag fires from every type-subject axis
+      that reaches a lookup gate (`@methods` / `@fields` /
+      `@innerTypes` / `@subtypes` / `@implementors` / `@source`)
+      because each starts by lifting the String fqn through the
+      `@type` resolution path.
 
       ~{ "no.such.Type" | @type !| type | eq(::TypeNotFound) }
    ~~|
   ::builtin{:category :jdt/lookup-miss :operand :@type}
 
-::MethodNotFound
-  |~~ Method lookup miss — fqn does not resolve, or the bare
-      `pkg.Type#name` form has no matching overload.
-
-      ~{ "Foo#nosuch" | @method !| type | eq(::MethodNotFound) }
-   ~~|
-  ::builtin{:category :jdt/lookup-miss :operand :@method}
-
-::FieldNotFound
-  |~~ Field lookup miss — the fqn does not name a declared
-      field.
-
-      ~{ "Foo#nope" | @field !| type | eq(::FieldNotFound) }
-   ~~|
-  ::builtin{:category :jdt/lookup-miss :operand :@field}
-
-::ProjectNotFound
-  |~~ Project lookup miss — no Eclipse project of that name in
-      the workspace.
-
-      ~{ "no.such.proj" | @project !| type | eq(::ProjectNotFound) }
-   ~~|
-  ::builtin{:category :jdt/lookup-miss :operand :@project}
-
-::PackageNotFound
-  |~~ Package lookup miss — no source package of that name in
-      the workspace.
-   ~~|
-  ::builtin{:category :jdt/lookup-miss :operand :@package}
-
-::FileNotFound
-  |~~ File lookup miss — absolute filesystem path does not
-      resolve to a workspace file.
-   ~~|
-  ::builtin{:category :jdt/lookup-miss :operand :@file}
-
-::AmbiguousMatch
-  |~~ Bare `pkg.Type#name` matches multiple overloads. The
-      descriptor's `:context/candidates` lists every overload's
-      full fqn — the caller picks one and retries with the
-      disambiguated signature.
-
-      ~{ "Foo#overloaded" | @method !| /context/candidates | count | gt(0) }
-   ~~|
-  ::builtin{:category :jdt/lookup-miss :operand :@method}
-
 ::InvalidFqn
-  |~~ Subject String is shaped wrong for the requested axis
-      (missing `#` for method, contains spaces, etc.).
+  |~~ String subject is shaped wrong for the requested axis —
+      method fqn without `#`, type fqn with spaces, file path
+      relative when a workspace-absolute path is required, etc.
+      Distinguished from `::TypeNotFound` by the descriptor's
+      `:context/reason` field.
    ~~|
   ::builtin{:category :jdt/lookup-miss :operand :@type}
 
-::WrongSubjectKind
-  |~~ Subject is a valid node but its `:kind` is incompatible
-      with the axis (e.g. `@overrides` on a `:field` subject).
-   ~~|
-  ::builtin{:category :jdt/dispatch :operand :@overrides}
-
-::MissingSubjectFqn
-  |~~ Subject is neither a node-Map carrying `:fqn` nor a
-      String. Fired by the client-side dispatch wrapper before
-      any HTTP roundtrip.
-
-      ~{ [1 2 3] | @type !| type | eq(::MissingSubjectFqn) }
-   ~~|
-  ::builtin{:category :jdt/dispatch}
-
-::UnsupportedDetailKind
-  |~~ `@detail` reached a subject `:kind` it does not know how
-      to point-lookup. The descriptor's `:context/subjectKind`
-      pins the offending kind.
-   ~~|
-  ::builtin{:category :jdt/dispatch :operand :@detail}
-
-::UnsupportedScopeKind
-  |~~ `@problems` reached a subject `:kind` outside the
-      supported scope set (workspace / project / package / file
-      / type / method / field).
-   ~~|
-  ::builtin{:category :jdt/dispatch :operand :@problems}
-
-::UnsupportedSubjectType
-  |~~ `@problems` subject is neither absent, String, nor Map.
-   ~~|
-  ::builtin{:category :jdt/dispatch :operand :@problems}
-
-|~ ── Root queries ──────────────────────────────────────── ~|
-
-:@types
-  |~~ Type pattern search across the workspace. Subject is a
-      String pattern with optional `*` wildcards; returns a Vec
-      of `:type` skeletons. Binary dependencies are included —
-      use the `@sourceOnly` conduit to drop them.
-
-      ~{ "*Service" | @types * /fqn }
-   ~~|
-  ::builtin{:category :jdt/graph
-            :subject [:string]
-            :modifiers []
-            :returns :vec
-            :throws [::InvalidFqn]}
-
 :@type
-  |~~ Single `:type` detail by fully qualified name. Inner
-      classes use dotted form: `pkg.Outer.Inner`.
+  |~~ `:type` detail node-Map by fully qualified name. Inner
+      types use dotted form: `pkg.Outer.Inner`.
 
-      Returned shape — type detail node-Map: `{:kind "type"
-      :fqn "..." :typeKind "class"|"interface"|"enum"
-      |"annotation"|"record" :modifiers [...] :interfaces [...]
-      :javadocSummary "..." :annotations [...] :isTestScope
-      <bool> :location {...}}`.
+      Detail fields: `{:kind "type" :fqn "..." :typeKind
+      "class"|"interface"|"enum"|"annotation"|"record"
+      :modifiers ["public" "abstract" …] :superclass "..."
+      :interfaces [...] :javadocSummary "..." :annotations [...]
+      :isTestScope <bool> :origin "source"|"binary" :location
+      {:file "..." :startLine N :endLine N}}`.
 
-      ~{ "io.github.kaluchi.jdtbridge.HttpServer" | @type | /typeKind }
+      ~{ "no.such.Type" | @type !| type | eq(::TypeNotFound) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
             :modifiers []
             :returns :map
-            :throws [::TypeNotFound]}
+            :throws [::TypeNotFound ::InvalidFqn]}
+
+::MethodNotFound
+  |~~ Method lookup miss — fqn names no declared method, the
+      bare `pkg.Type#name` form has no overload of that name,
+      or the explicit signature does not match any overload's
+      erased parameter list.
+
+      ~{ "no.such.Type#m()" | @method !| type | eq(::MethodNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@method}
+
+::AmbiguousMatch
+  |~~ Bare `pkg.Type#name` resolves to two or more overloads.
+      The descriptor's `:context/candidates` Vec lists every
+      candidate's full fqn with signature — the caller picks
+      one and retries.
+
+      ~{ "Object#equals" | @method !| /context/candidates
+         | every(contains("equals(")) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@method}
 
 :@method
-  |~~ Single `:method` detail by FQN. Supports both inline-
-      paren signatures and the bare-name form (must be
-      unambiguous — see `::AmbiguousMatch`).
+  |~~ `:method` detail node-Map by fqn. Inline-paren form
+      `pkg.Type#name(ParamType,…)` always resolves; bare-name
+      form `pkg.Type#name` works only when one overload exists
+      — multiple overloads surface as `::AmbiguousMatch`.
 
-      ~{ "Foo#start(java.net.InetAddress,int)" | @method | /returnType }
+      Detail fields: `{:kind "method" :fqn "..." :name "..."
+      :signature "name(java.lang.String)" :returnType "..."
+      :modifiers [...] :parameters [{:name :type}...]
+      :throwsTypes [...] :annotations [...] :javadocSummary
+      "..." :declaringType "..." :location {...}}`.
+
+      ~{ "no.such.Type#m" | @method !| type | eq(::MethodNotFound) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -171,8 +123,23 @@
             :returns :map
             :throws [::MethodNotFound ::AmbiguousMatch ::InvalidFqn]}
 
+::FieldNotFound
+  |~~ Field lookup miss — fqn does not name a declared field of
+      the type.
+
+      ~{ "Object#notAField" | @field !| type | eq(::FieldNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@field}
+
 :@field
-  |~~ Single `:field` detail by FQN (`pkg.Type#fieldName`).
+  |~~ `:field` detail node-Map by fqn (`pkg.Type#fieldName`).
+
+      Detail fields: `{:kind "field" :fqn "..." :name "..."
+      :type "..." :modifiers [...] :annotations [...]
+      :javadocSummary "..." :declaringType "..." :location
+      {...}}`.
+
+      ~{ "Object#nope" | @field !| type | eq(::FieldNotFound) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -180,10 +147,47 @@
             :returns :map
             :throws [::FieldNotFound ::InvalidFqn]}
 
+::PackageNotFound
+  |~~ Package lookup miss — no source package of that fqn in
+      the workspace's analysed source roots.
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@package}
+
+:@package
+  |~~ `:package` detail node-Map by fully qualified name.
+
+      Detail fields: `{:kind "package" :fqn "..."
+      :containingProject "..." :sourceRoot "..." :typesInPackage
+      [...]}`.
+
+      ~{ "no.such.pkg" | @package !| type | eq(::PackageNotFound) }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string :map]
+            :modifiers []
+            :returns :map
+            :throws [::PackageNotFound]}
+
+::ProjectNotFound
+  |~~ Project lookup miss — no open Eclipse project of that
+      name in the workspace. Closed projects also surface as
+      not-found (open them via the Eclipse UI before querying).
+
+      ~{ "no.such.proj" | @project !| type | eq(::ProjectNotFound) }
+   ~~|
+  ::builtin{:category :jdt/lookup-miss :operand :@project}
+
 :@project
-  |~~ Single `:project` detail by name. Carries `:natures`,
-      `:classpathEntries`, `:dependencies`, `:sourceRoots`,
-      `:repo` and `:branch` when EGit-managed.
+  |~~ `:project` detail node-Map by Eclipse project name (NOT
+      filesystem path).
+
+      Detail fields: `{:kind "project" :fqn "..." :rootPath
+      "..." :natures [...] :classpathEntries [...] :dependencies
+      [...] :sourceRoots [...] :outputLocation "..." :repo "..."
+      :branch "..."}`. `:repo` / `:branch` populated for
+      EGit-managed projects only.
+
+      ~{ "missing-project" | @project !| type | eq(::ProjectNotFound) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -192,10 +196,11 @@
             :throws [::ProjectNotFound]}
 
 :@projects
-  |~~ All open workspace projects in the current session scope.
-      Returns Vec of `:project` skeletons.
+  |~~ Every open project in the workspace, returned as a Vec
+      of `:project` detail node-Maps in workspace iteration
+      order.
 
-      ~{ @projects * /fqn | count | gt(0) }
+      ~{ @projects | every(/kind | eq("project")) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject :any
@@ -203,18 +208,21 @@
             :returns :vec
             :throws []}
 
-:@package
-  |~~ Single `:package` detail by FQN.
+::FileNotFound
+  |~~ File lookup miss — absolute filesystem path does not
+      resolve to a workspace file, or the file is outside any
+      open project's source root.
    ~~|
-  ::builtin{:category :jdt/graph
-            :subject [:string :map]
-            :modifiers []
-            :returns :map
-            :throws [::PackageNotFound]}
+  ::builtin{:category :jdt/lookup-miss :operand :@file}
 
 :@file
-  |~~ Single `:file` detail by absolute filesystem path. Holds
-      `:typesInFile` pointer.
+  |~~ `:file` detail node-Map by absolute filesystem path.
+      Holds the top-level types of the compilation unit through
+      `:typesInFile`.
+
+      Detail fields: `{:kind "file" :fqn "<absolute-path>"
+      :containingProject "..." :containingPackage "..."
+      :typesInFile [...] :location {:file "..."}}`.
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -222,12 +230,37 @@
             :returns :map
             :throws [::FileNotFound]}
 
-|~ ── Containment down ──────────────────────────────────── ~|
+|~ ── Pattern search ────────────────────────────────────── ~|
+
+:@types
+  |~~ Type pattern search across the workspace. Subject is a
+      String pattern — bare name matches any type whose simple
+      name equals the pattern; `*` wildcards match any
+      substring within the simple name (`*Service`,
+      `Abstract*Factory`).
+
+      Returns a Vec of `:type` skeleton node-Maps. Binary
+      dependencies are included — pipe through the
+      `@sourceOnly` conduit to retain workspace-source matches.
+
+      ~{ "*Service" | @types | every(/kind | eq("type")) }
+   ~~|
+  ::builtin{:category :jdt/graph
+            :subject [:string]
+            :modifiers []
+            :returns :vec
+            :throws [::InvalidFqn]}
+
+|~ ── Containment-down — type → members ─────────────────── ~|
 
 :@members
-  |~~ Direct children of a type — methods, fields, inner
-      types. Returns Vec of skeleton node-Maps, one per
-      declared member.
+  |~~ Direct children of a type: methods, fields, inner types.
+      Returns a Vec of skeleton node-Maps in source declaration
+      order. Inherited members are excluded — climb `@supers`
+      explicitly for the full inheritance chain.
+
+      ~{ "java.lang.Object" | @members
+         | every(/kind | (eq("method") | or(eq("field")) | or(eq("type")))) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -236,13 +269,19 @@
             :throws [::TypeNotFound]}
 
 :@methods
-  |~~ Methods declared directly in the type. Each entry
-      carries `:signature`, `:modifiers`, `:returnType`,
-      `:annotations`, `:location {:file "..." :startLine N
-      :endLine N :lineCount N}`.
+  |~~ Methods declared directly on the type. Each skeleton
+      carries the method `:signature` (erased parameter types,
+      EclEmma-style: `"name(java.lang.String,int)"`),
+      `:returnType` (erased), `:modifiers`, `:annotations`, and
+      `:location` (with `:lineCount` precomputed — line range
+      arithmetic stays on the server side).
 
-      ~{ "Foo" | @methods | sortWith(desc(/location/lineCount))
-         | take(5) * /fqn | count | lte(5) }
+      Inherited methods are excluded; constructors are
+      included (their `:name` is `"<init>"`).
+
+      ~{ "java.lang.Object" | @methods
+         | sortWith(desc(/location/lineCount))
+         * /signature | first | contains("(") }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -251,7 +290,14 @@
             :throws [::TypeNotFound]}
 
 :@fields
-  |~~ Fields declared directly in the type.
+  |~~ Fields declared directly on the type. Skeleton carries
+      `:type` (erased), `:modifiers`, `:annotations`. Constants
+      (static + final) print with the `[K]` badge in markdown
+      cards; the catalog data here is unaffected by that
+      cosmetic distinction.
+
+      ~{ "java.lang.Math" | @fields | filter(/modifiers
+         | any(eq("static"))) | every(/modifiers | any(eq("final"))) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -260,7 +306,11 @@
             :throws [::TypeNotFound]}
 
 :@innerTypes
-  |~~ Inner types declared in the given type.
+  |~~ Inner types declared in the subject type. Returns a Vec
+      of `:type` skeletons (their fqn carries the outer prefix,
+      `pkg.Outer.Inner`). Local and anonymous inner classes
+      are excluded — only named, declarable inner types
+      surface here.
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -268,18 +318,25 @@
             :returns :vec
             :throws [::TypeNotFound]}
 
+|~ ── Containment-down — package / file → types ─────────── ~|
+
 :@typesInPackage
-  |~~ All top-level types in the given package, aggregated
-      across source roots.
+  |~~ Top-level types in the given package, aggregated across
+      every source root in the workspace that contains the
+      package. Inner types are excluded (climb `@innerTypes`
+      from each top-level type for the nested set).
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
             :modifiers []
             :returns :vec
-            :throws []}
+            :throws [::PackageNotFound]}
 
 :@typesInFile
-  |~~ Top-level types declared in the given Java file.
+  |~~ Top-level types declared in the compilation unit at the
+      given absolute filesystem path. A Java file usually
+      declares one public type plus optional package-private
+      siblings — every declaration surfaces here.
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -288,8 +345,11 @@
             :throws [::FileNotFound]}
 
 :@packagesInProject
-  |~~ Non-empty source packages in the project, deduped per
-      name.
+  |~~ Non-empty source packages in the project, deduped by
+      name across source roots (`src/main/java` + `src/test/java`
+      with the same package name surface as one entry — but
+      `:isTestScope` on the contained types still distinguishes
+      origin).
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -297,11 +357,15 @@
             :returns :vec
             :throws [::ProjectNotFound]}
 
-|~ ── Hierarchy ───────────────────────────────────────── ~|
+|~ ── Hierarchy ────────────────────────────────────────── ~|
 
 :@supers
-  |~~ Direct supertypes — superclass plus directly-declared
-      interfaces. Transitive ascent via `@ancestors` conduit.
+  |~~ Direct supertypes — `:superclass` plus every directly-
+      declared interface, returned as a Vec of `:type`
+      skeletons. Transitive ascent is the `@ancestors`
+      conduit below.
+
+      ~{ "java.util.ArrayList" | @supers | count | gte(1) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -310,8 +374,9 @@
             :throws [::TypeNotFound]}
 
 :@subtypes
-  |~~ Direct subtypes only. Transitive descent via
-      `@descendants` conduit.
+  |~~ Direct subtypes only — types whose `:superclass` or
+      direct interface list names the subject. Transitive
+      descent is the `@descendants` conduit below.
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -320,8 +385,13 @@
             :throws [::TypeNotFound]}
 
 :@implementors
-  |~~ Subtypes (for `:type` subject) or override-methods (for
-      `:method` subject).
+  |~~ Subtype-shape axis with kind-dependent semantic. On a
+      `:type` subject, returns subtypes (same as `@subtypes`).
+      On a `:method` subject, returns the override-methods
+      that inherit from this declaration.
+
+      ~{ "java.lang.Runnable" | @implementors
+         | every(/kind | eq("type")) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -329,9 +399,21 @@
             :returns :vec
             :throws [::TypeNotFound ::MethodNotFound]}
 
+::WrongSubjectKind
+  |~~ Subject is a valid node, but its `:kind` is incompatible
+      with the requested axis (e.g. `@overrides` on a `:field`
+      subject). Descriptor's `:context/subjectKind` carries
+      the offending kind; `:context/expectedKinds` lists the
+      kinds the axis accepts.
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@overrides}
+
 :@overrides
-  |~~ The closest super-method this method overrides, or
-      `null` when no override exists.
+  |~~ The closest super-method this method overrides, returned
+      as a `:method` detail node-Map. `null` when the subject
+      does not override any inherited method.
+
+      ~{ "java.lang.Object#toString()" | @overrides | eq(null) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -340,8 +422,12 @@
             :throws [::MethodNotFound ::WrongSubjectKind]}
 
 :@overloads
-  |~~ Sibling methods of the same name in the containing
-      type, including the queried method.
+  |~~ Sibling methods of the same simple name in the
+      containing type — includes the queried method itself.
+      `@method` returns a single overload; this axis returns
+      the whole overload set.
+
+      ~{ "java.lang.String#valueOf" | @overloads | count | gte(1) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -352,18 +438,20 @@
 |~ ── References ─────────────────────────────────────── ~|
 
 :@incomingRefs
-  |~~ Incoming references to the subject of the given refKind.
-      Modifier is the refKind keyword: `:call | :read | :write
-      | :typeUse | :all`. Default depends on subject kind: for
-      methods `:call`, for fields `:read`, for types
-      `:typeUse`.
+  |~~ Inbound references to the subject, returned as a Vec of
+      `:reference` records. The captured-arg modifier picks the
+      refKind to retain: `:call` (default for methods), `:read`
+      (default for fields), `:write`, `:typeUse` (default for
+      types), `:all` to widen across every kind.
 
-      Each entry is a `:reference` record: `{:from <node>
+      Record shape: `{:kind "reference" :from <node>
       :to <subject-skeleton> :refKind "call"|"read"|"write"
-      |"typeUse" :direction "incoming" :location {...}}`.
+      |"typeUse" :direction "incoming" :location {:file "..."
+      :startLine N}}`. `:from` is the calling-site skeleton —
+      project / package / file context for navigation.
 
-      ~{ "Foo" | @incomingRefs * /from/fqn | distinct }
-      ~{ "Foo#running" | @incomingRefs(:write) * /from/fqn }
+      ~{ "java.lang.Object#toString()" | @incomingRefs(:call)
+         | every(/refKind | eq("call")) }
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -372,16 +460,15 @@
             :throws [::TypeNotFound ::MethodNotFound ::FieldNotFound]}
 
 :@outgoingRefs
-  |~~ Outgoing references from a source member — types /
-      methods / fields referenced inside the subject's body.
-
-      Each entry is a `:reference` record: `{:from <subject>
-      :to <target> :refKind "call"|"read"|"typeUse" :direction
-      "outgoing" :location {...}}`.
-
-      Subject must be a type / method / field with source
-      available; binary-origin subjects fail with
+  |~~ Outbound references from a source member — every type,
+      method, or field touched inside the subject's body.
+      Source must be available; binary-origin subjects (JAR
+      classes without source attachment) raise
       `::WrongSubjectKind`.
+
+      Record shape: `{:kind "reference" :from <subject> :to
+      <target> :refKind "call"|"read"|"write"|"typeUse"
+      :direction "outgoing" :location {...}}`.
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -390,9 +477,11 @@
             :throws [::TypeNotFound ::MethodNotFound ::FieldNotFound ::WrongSubjectKind]}
 
 :@classpath
-  |~~ Classpath entries of the given project. Each entry
-      carries `:entryKind` (`"source"|"library"|"container"
-      |"project"`), `:path`, `:isTest`, `:outputLocation`.
+  |~~ Classpath entries of the given project, in source-order.
+      Each entry: `{:entryKind "source"|"library"|"container"
+      |"project" :path "..." :isTest <bool> :outputLocation
+      "..."}`. Use `:entryKind "container"` to spot
+      auto-managed paths (JRE, Maven, …).
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -400,13 +489,20 @@
             :returns :vec
             :throws [::ProjectNotFound]}
 
-|~ ── Source / diagnostics ────────────────────────────── ~|
+|~ ── Source ─────────────────────────────────────────── ~|
 
 :@source
-  |~~ Raw source text of a type or member as a String.
-      Top-level types return the full compilation unit.
-      Prints unquoted — `jdt q '"X" | @source' > X.java`
-      writes a byte-faithful file.
+  |~~ Raw source slice of a type or member, returned as a
+      String. Methods / fields return the source span between
+      their declaration anchors. Top-level types return the
+      full compilation unit (package declaration, imports, and
+      every sibling declaration). Library types return source
+      only when the JAR ships a source attachment — otherwise
+      the response is `"Source not available"`.
+
+      `printValue` emits the String unquoted, so
+      `jdt q '"X" | @source' > X.java` writes a byte-faithful
+      copy of the workspace file.
    ~~|
   ::builtin{:category :jdt/graph
             :subject [:string :map]
@@ -414,15 +510,37 @@
             :returns :string
             :throws [::TypeNotFound ::MethodNotFound ::FieldNotFound]}
 
-:@problemMarkers
-  |~~ Primitive IResource-scope compile-problem marker fetch.
-      Public polymorphism lives in the `@problems` conduit
-      below.
+|~ ── Compile-time problems ─────────────────────────── ~|
 
-      Accepts: nothing → workspace; String with path-separator
-      / drive letter → IFile by absolute path; String without
-      → IProject by name; Map with `:kind "project"` or `:kind
-      "file"` → same, via `:fqn`.
+::UnsupportedScopeKind
+  |~~ `@problems` reached a Map subject whose `:kind` is not
+      one of the supported scopes (workspace / project /
+      package / file / type / method / field). Surfaces
+      through `@problemsForNodeVia`'s `cond`-tail when no
+      scope branch matches.
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@problems}
+
+::UnsupportedSubjectType
+  |~~ `@problems` subject is neither absent (workspace),
+      String (project / file path), nor Map (node). Vec /
+      Number / Boolean / Keyword subjects lift to this error.
+
+      ~{ [1 2 3] | @problems !| type | eq(::UnsupportedSubjectType) }
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@problems}
+
+:@problemMarkers
+  |~~ Primitive HTTP-boundary problem-marker fetch. Public
+      polymorphism rides on the `@problems` conduit further
+      down — this primitive accepts only a few subject shapes:
+      absent → workspace; String with path-separator or drive
+      letter → IFile by absolute path; String without →
+      IProject by name; Map with `:kind "project"` or `:kind
+      "file"` → same routing via `:fqn`.
+
+      Returns a Vec of `:problem` marker records with
+      `:severity` / `:message` / `:location` already filled.
    ~~|
   ::builtin{:category :jdt/graph
             :subject :any
@@ -430,15 +548,29 @@
             :returns :vec
             :throws [::FileNotFound ::ProjectNotFound]}
 
-|~ ── Polymorphic seed lift ─────────────────────────── ~|
+|~ ── Polymorphic seed lift + node enrichment ───────── ~|
 
-|~~ Map subjects (skeleton / detail) pass through. String
-    subjects dispatch by shape:
-      - has '#' and '(' → `@method` (FQN with explicit
-                          signature)
-      - has '#', no '(' → `@field`, falling back to `@method`
-                          via fail-track
-      - no '#'          → `@type` ~~|
+::MissingSubjectFqn
+  |~~ Subject is neither a node-Map carrying `:fqn` nor a
+      String. Lifted by the client-side dispatch wrapper
+      before any HTTP roundtrip — surfaces on Vec / Number /
+      Boolean / Keyword / null subjects.
+
+      ~{ [1 2 3] | @type !| type | eq(::MissingSubjectFqn) }
+   ~~|
+  ::builtin{:category :jdt/dispatch}
+
+|~~ Polymorphic head: lift any subject shape (Map / String)
+    into a node-Map. Map subjects pass through; String subjects
+    dispatch by the disambiguation rule documented in
+    `:@asNode`'s body comment below.
+
+    Returned shape: detail node-Map (`:kind "type"|"method"
+    |"field"|…`). String subjects without `#` route to `@type`;
+    Strings with `#` and `(` route to `@method`; Strings with
+    `#` but no `(` first try `@field`, then fall back to
+    `@method` via fail-track (so bare-name fields and method
+    references both find their target). ~~|
 :@asNode
   (as(:subj) | type | as(:subjType)
    | subj
@@ -448,25 +580,22 @@
                     @field !| (subj | @method)),
                @type)))
 
-|~~ Type that contains a member. ~~|
-:@containingType
-  (@asNode | /containingType | unless(eq(null), @type))
+::UnsupportedDetailKind
+  |~~ `@detail` reached a node subject whose `:kind` does not
+      match a registered detail-lookup axis. Descriptor's
+      `:context/subjectKind` carries the offending kind.
 
-|~~ Package that contains a type. ~~|
-:@containingPackage
-  (@asNode | /containingPackage | unless(eq(null), @package))
+      ~{ {:kind "alien"} | @detail !| type | eq(::UnsupportedDetailKind) }
+   ~~|
+  ::builtin{:category :jdt/dispatch :operand :@detail}
 
-|~~ Project that contains the given workspace node. ~~|
-:@containingProject
-  (@asNode | /containingProject | unless(eq(null), @project))
-
-|~~ File that contains a type / method / field. ~~|
-:@containingFile
-  (@asNode | /location/file | unless(eq(null), @file))
-
-|~~ Enrich a skeleton-node into a detail-node. Routes by
-    `:kind`. Idempotent on detail-nodes. Unknown `:kind` raises
-    `::UnsupportedDetailKind` on the fail-track. ~~|
+|~~ Enrich a skeleton node-Map into a full detail node-Map by
+    routing through the matching `@type` / `@method` / …
+    primitive based on `:kind`. Idempotent on already-detailed
+    nodes (their detail-axis call is the no-op identity from
+    the server's perspective; the wire format is the same).
+    String subjects also work — `@asNode` head normalizes them
+    first. ~~|
 :@detail
   (@asNode | as(:n) | /kind | as(:k)
    | cond(eq("type"),    n | @type,
@@ -477,21 +606,58 @@
           eq("file"),    n | @file,
           !{:kind ::UnsupportedDetailKind
             :origin :jdt/graph
-            :message "@detail cannot route subject — :kind is not one of type/method/field/project/package/file"
+            :message "@detail: subject :kind has no detail-axis route (expected one of type/method/field/project/package/file)"
             :context {:subjectKind k :subject n}}))
 
+|~ ── Containment-up — node → enclosing scope ─────── ~|
+
+|~~ The type that declares the given member. Identity on a
+    `:type` subject (the type contains itself trivially).
+    `null` for project / package / file subjects. ~~|
+:@containingType
+  (@asNode | /containingType | unless(eq(null), @type))
+
+|~~ The package whose source declares the given type. `null`
+    for nodes outside a source package (binary-origin nodes
+    from JARs without source attachment). ~~|
+:@containingPackage
+  (@asNode | /containingPackage | unless(eq(null), @package))
+
+|~~ The Eclipse project that owns the workspace resource
+    backing this node. `null` for binary-origin nodes. ~~|
+:@containingProject
+  (@asNode | /containingProject | unless(eq(null), @project))
+
+|~~ The compilation-unit file the subject is declared in.
+    Types return their primary source file (where the public
+    declaration sits); methods / fields return their declaring
+    type's file. `null` for non-source nodes. ~~|
+:@containingFile
+  (@asNode | /location/file | unless(eq(null), @file))
+
+|~ ── Compile-problems composition (sub-conduits, then
+   the polymorphic head) ───────────────────────────── ~|
+
 |~~ Retain markers whose `:location/startLine` falls inside
-    the captured node's `[startLine, endLine]`. ~~|
+    the captured node's `[startLine, endLine]` source range.
+    Used by `@problemsForMemberVia` to clip a file's full
+    marker list to the lines a single method or field
+    declares. ~~|
 :problemsInRangeOf [:node]
   filter(and(/location/startLine | gte(node | /location/startLine),
              /location/startLine | lte(node | /location/endLine)))
 
-|~~ Member subject → file markers from `fetcher` filtered to
-    the member's source range. ~~|
+|~~ Member-scope dispatch: fetch the markers of the file the
+    member lives in, then filter to its declaration range. The
+    fetcher is provided by `@problemsVia`. ~~|
 :@problemsForMemberVia [:fetcher]
   (as(:m) | /location/file | fetcher | problemsInRangeOf(m))
 
-|~~ Node subject → kind-dispatched scope navigation. ~~|
+|~~ Node-subject dispatch. Routes by `:kind`. Inner types
+    (those with a non-null `:declaringType`) narrow to their
+    own source range — a top-level type returns its whole
+    compilation unit's marker set. Kindless Maps (no `:kind`
+    field) fall through to the workspace fetcher. ~~|
 :@problemsForNodeVia [:fetcher :fileLocation :packageTypes]
   (as(:n) | at("kind") | as(:k)
    | cond(isNull,        n | fetcher,
@@ -509,13 +675,20 @@
             :message "@problems: subject :kind is not a scope (expected one of workspace/project/package/file/type/method/field)"
             :context {:subjectKind k :subject n}}))
 
-|~~ String subject dispatch. ~~|
+|~~ String-subject dispatch. A `#` in the path means it is a
+    member fqn — lift through `liftNode` (typically `@asNode`)
+    and route into the member-scope branch. Otherwise it is
+    a project name or absolute file path, both handled by the
+    fetcher directly. ~~|
 :@problemsForStringVia [:fetcher :liftNode]
   (as(:s)
    | cond(contains("#"), liftNode | @problemsForMemberVia(fetcher),
           fetcher))
 
-|~~ Polymorphic compile-problem scope factory. ~~|
+|~~ Higher-order factory — accepts `fetcher`, `liftNode`,
+    `fileLocation`, `packageTypes` as captured args and
+    composes the polymorphic dispatch. Direct unit tests for
+    the routing live in `test/graph-problems.test.mjs`. ~~|
 :@problemsVia [:fetcher :liftNode :fileLocation :packageTypes]
   (as(:subj)
    | cond(isNull,   fetcher,
@@ -526,58 +699,70 @@
             :message "@problems: subject must be absent, String, or Map"
             :context {:subject subj}}))
 
-|~~ Polymorphic compile-problem scope. Each marker is enriched
-    with `:error` and `:warning` booleans for filter
-    convenience. ~~|
+|~~ Polymorphic compile-problem scope. Every marker is
+    enriched with `:error` / `:warning` booleans so a
+    downstream filter reads naturally: `@problems |
+    filter(/error) * /message`. Absent subject yields the
+    workspace-wide marker set. ~~|
 :@problems
   (@problemsVia(@problemMarkers, @asNode,
                 @containingFile, @typesInPackage)
    * union({:error   /severity | eq("error")
             :warning /severity | eq("warning")}))
 
-|~~ Incoming call sites of a method — distinct `:from`
-    skeletons of every `:call` reference.
+|~ ── Reference-shape sugar conduits ──────────────── ~|
 
-    ~{ "Foo#bar()" | @callers | count | gte(0) } ~~|
+|~~ Distinct `:from` skeletons of every `:call` reference to
+    this method — the set of methods that invoke the subject.
+
+    ~{ "java.lang.Object#equals(java.lang.Object)" | @callers
+       | every(/kind | eq("method")) } ~~|
 :@callers
   (@incomingRefs
    | filter(/refKind | eq("call"))
    * /from
    | distinct)
 
-|~~ Distinct `:from` skeletons of every `:read` access of a
-    field. ~~|
+|~~ Distinct `:from` skeletons of every `:read` access of this
+    field — the methods that read the subject's value. ~~|
 :@readers
   (@incomingRefs
    | filter(/refKind | eq("read"))
    * /from
    | distinct)
 
-|~~ Distinct `:from` skeletons of every `:write` access of a
-    field. ~~|
+|~~ Distinct `:from` skeletons of every `:write` access of
+    this field — the methods that assign the subject's value.
+    Empty Vec means an effectively-final field. ~~|
 :@writers
   (@incomingRefs
    | filter(/refKind | eq("write"))
    * /from
    | distinct)
 
-|~~ Methods the subject body invokes. ~~|
+|~~ Distinct method skeletons the subject's body invokes.
+    Subject must be a source member; binary-origin subjects
+    raise `::WrongSubjectKind`. ~~|
 :@calls
   (@outgoingRefs
    | filter(/refKind | eq("call"))
    * /to
    | distinct)
 
-|~~ Types the subject body touches. ~~|
+|~~ Distinct type skeletons the subject body touches —
+    parameter types, return types, local-variable types,
+    annotation types, `instanceof` checks, generic bounds. ~~|
 :@typeUses
   (@outgoingRefs
    | filter(/refKind | eq("typeUse"))
    * /to
    | distinct)
 
-|~ ── Stdlib conduits ─────────────────────────────────── ~|
+|~ ── Transitive hierarchy conduits ───────────────── ~|
 
-|~~ Transitive supertypes, flat Vec of `:type` skeletons. ~~|
+|~~ Every supertype of the subject, transitively. Returns a
+    Vec of distinct `:type` skeletons — `Object` lands as the
+    last entry for any class chain. ~~|
 :@ancestors
   (@supers
    | as(:direct)
@@ -586,7 +771,9 @@
    | flat
    | distinct)
 
-|~~ Transitive subtypes, flat Vec of `:type` skeletons. ~~|
+|~~ Every subtype of the subject, transitively. The recursive
+    fan-out can be large for high-level interfaces — `count`
+    first if the workspace is unfamiliar. ~~|
 :@descendants
   (@subtypes
    | as(:direct)
@@ -595,13 +782,30 @@
    | flat
    | distinct)
 
-|~~ Public methods of a type with zero incoming callers. ~~|
+|~ ── Static-analysis conduits ────────────────────── ~|
+
+|~~ Public methods of a type with zero incoming callers. Read
+    as "API surface that nobody references" — typical first
+    pass for dead-code triage. Inherited methods are out of
+    scope (only methods declared on the subject type). ~~|
 :@publicOrphans
   (@methods
    | filter(/modifiers | any(eq("public")))
    | filter(@callers | empty))
 
-|~~ Types the subject depends on. ~~|
+|~~ Non-private methods of a type with zero incoming callers.
+    Wider net than `@publicOrphans` — covers package-private
+    and protected methods that might be reachable through
+    reflection or framework injection (which the JDT
+    SearchEngine does not see). ~~|
+:@deadCode
+  (@methods
+   | filter(/modifiers | any(eq("private")) | not)
+   | filter(@callers | empty))
+
+|~~ Outbound dependency surface of a type — its direct
+    supertypes plus the types its members' bodies touch. Use
+    as the seed for a layering / cyclic-dependency audit. ~~|
 :@dependsOn
   (as(:self)
    | [self | @supers,
@@ -609,7 +813,9 @@
    | flat
    | distinct)
 
-|~~ Types that depend on the subject. ~~|
+|~~ Inbound dependency surface of a type — every type that
+    type-uses the subject as a method parameter, return,
+    field type, or generic bound, plus its direct subtypes. ~~|
 :@usedBy
   (as(:self)
    | [self | @incomingRefs(:typeUse) * /from | filter(/kind | eq("type")),
@@ -617,51 +823,35 @@
    | flat
    | distinct)
 
-|~~ Non-private methods with zero incoming callers. ~~|
-:@deadCode
-  (@methods
-   | filter(/modifiers | any(eq("private")) | not)
-   | filter(@callers | empty))
+|~ ── Test-scope conduits ─────────────────────────── ~|
 
-|~~ Filter nodes to those from workspace source. ~~|
-:@sourceOnly
-  filter(/origin | eq("source"))
-
-|~~ Filter nodes to those belonging to the named project. ~~|
-:@inProject [:projName]
-  filter(/containingProject | eq(projName))
-
-|~~ Volume estimate for a Vec. Returns `{:count N :head [...]
-    :tail [...]}`.
-
-    ~{ [1 2 3 4 5 6 7 8 9 10] | @overview | /count | eq(10) } ~~|
-:@overview
-  (as(:v)
-   | {:count v | count
-      :head v | take(5)
-      :tail v | reverse | take(5) | reverse})
-
-|~~ Every top-level `:type` declared in the given project. ~~|
-:@typesInProject
-  (@project | as(:p) | /fqn | as(:pn)
-   | p | @packagesInProject * @typesInPackage | flat
-   | @inProject(pn))
-
-|~ ── Test-scope conduits ───────────────────────────── ~|
-
-|~~ Subset of callers whose declaring type is test-scope. ~~|
+|~~ Callers whose declaring type is in a test source root.
+    EclEmma classifies test scope by source-root path (a
+    classpath entry's `:isTest` flag). ~~|
 :@testCallers
   (@callers | filter(/isTestScope))
 
-|~~ Callers outside test scope. ~~|
+|~~ Callers outside test scope — production callers of a
+    method. ~~|
 :@productionCallers
   (@callers | filter(/isTestScope | not))
 
-|~~ True iff method / field has zero test-scope callers. ~~|
+|~~ True iff the method / field has zero callers from test
+    scope. Read as "this code is exercised, but no test
+    drives it" — when combined with structural analysis like
+    `@deadCode`, finds candidates for new test coverage.
+
+    Distinct from `:jdt/coverage`'s `@uncovered`, which reads
+    actual JaCoCo probe data and answers "this code ran, but
+    no probe fired". ~~|
 :@untested
   (@callers | filter(/isTestScope) | empty)
 
-|~~ Test-scope callers across type + members. ~~|
+|~~ Test-scope callers across a type AND every member it
+    declares — useful when asking "what tests exercise this
+    type at all", since some tests call the type's
+    constructor / static method, others target individual
+    instance methods. ~~|
 :@tests
   (as(:self)
    | [[self | /fqn], self | @methods * /fqn, self | @fields * /fqn]
@@ -671,21 +861,61 @@
    | filter(/isTestScope)
    | distinct)
 
-|~ ── Annotation conduits ──────────────────────────── ~|
+|~ ── Annotation conduits ───────────────────────── ~|
 
-|~~ True iff the element's `:annotations` Vec contains
-    `annotationFqn`. ~~|
+|~~ Predicate: true iff the subject's `:annotations` Vec
+    contains the named annotation type's fqn. Use inside
+    `filter` / `every` / `any` to slice members by annotation.
+
+    ~{ "io.github.kaluchi.jdtbridge.HttpServer" | @methods
+       | filter(@annotatedWith("java.lang.Override")) | count | gte(0) } ~~|
 :@annotatedWith [:annotationFqn]
   (/annotations | any(eq(annotationFqn)))
 
-|~~ Deprecated-element predicate. ~~|
+|~~ Predicate: true iff the subject carries `@Deprecated`. ~~|
 :@deprecated
   @annotatedWith("java.lang.Deprecated")
 
-|~ ── Markdown render shortcuts ─────────────────────── ~|
+|~ ── Vec-shape conduits ────────────────────────── ~|
 
-|~~ `@source` enriched with the context an IDE shows on
-    hover. ~~|
+|~~ Retain Vec elements whose `:origin` is workspace `source`
+    — drops binary-only matches that come back from `@types`
+    pattern searches against `JRE` / Maven library types. ~~|
+:@sourceOnly
+  filter(/origin | eq("source"))
+
+|~~ Retain Vec elements whose `:containingProject` matches
+    the named project's fqn. Use to narrow a workspace-wide
+    `@types` result to one project. ~~|
+:@inProject [:projName]
+  filter(/containingProject | eq(projName))
+
+|~~ Aggregate enumeration shape for a Vec — `{:count N :head
+    [first 5] :tail [last 5]}`. Drop-in pre-flight for any
+    `@`-axis whose result could be large.
+
+    ~{ [1 2 3 4 5 6 7 8 9 10] | @overview | /count | eq(10) } ~~|
+:@overview
+  (as(:v)
+   | {:count v | count
+      :head v | take(5)
+      :tail v | reverse | take(5) | reverse})
+
+|~~ Every top-level type declared in the given project,
+    deduped by fqn across source roots. ~~|
+:@typesInProject
+  (@project | as(:p) | /fqn | as(:pn)
+   | p | @packagesInProject * @typesInPackage | flat
+   | @inProject(pn))
+
+|~ ── Markdown cards (compose render operands from
+   :jdt/render with the right bundle) ─────────────── ~|
+
+|~~ Bundle a source card for the subject: the subject's
+    detail node, its source text, every outgoing reference,
+    every incoming reference, plus supers / subtypes (when
+    the subject is a type). Pipe through `mdSource` (from
+    `:jdt/render`) for the markdown layout. ~~|
 :@sourceCard
   (@asNode | as(:self)
    | {:node     self | @detail
@@ -696,7 +926,9 @@
       :subtypes self | @subtypes           !| []}
    | mdSource)
 
-|~~ Type hierarchy card. ~~|
+|~~ Type hierarchy card — direct supers and subtypes only.
+    Wrap inputs through `@ancestors` / `@descendants` for the
+    transitive variant. ~~|
 :@hierarchyCard
   (@asNode | as(:self)
    | {:node     self | @detail
@@ -704,7 +936,8 @@
       :subtypes self | @subtypes}
    | mdHierarchy)
 
-|~~ Structural outline of a type. ~~|
+|~~ Structural outline of a type — fields, methods, inner
+    types grouped per source convention. ~~|
 :@outlineCard
   (@asNode | as(:self)
    | {:node    self | @detail

--- a/cli/lib/jdt/render.impl.mjs
+++ b/cli/lib/jdt/render.impl.mjs
@@ -1,22 +1,36 @@
-// Host-bound render operands for the :jdt/graph module.
+// Host-bound render-operand impls for `:jdt/render`.
 //
-// Each operand is a pure value transform: takes a node-Map bundle
-// from pipeValue, returns a markdown String. No HTTP, no session
-// state — the bundle must already hold everything the renderer
-// needs, collected by upstream graph axes.
+// Pure value transforms — every operand takes a node-Map bundle
+// from pipeValue and returns a markdown String. No HTTP, no
+// Eclipse: the bundle must already hold everything the renderer
+// needs, collected by upstream `:jdt/graph` / `:jdt/coverage`
+// conduits or assembled by hand.
 //
-// The contract is documented in jdt-query-spec.md § Markdown
-// rendering; the badge legend and the "server exhaustive, client
-// formats" split live there.
+// qlang 0.7 invariants applied here:
+//   * Map keys are plain Strings — Keyword objects ride as VALUES.
+//   * Bundle / node shape mismatches lift through per-site error
+//     descriptors carrying `:kind ::BundleNodeShapeError` /
+//     `:kind ::BundleCoverageShapeError` (declared in
+//     `lib/jdt/render.qlang`), surfacing through `result !| type`.
+//   * Catalog body in `render.qlang` declares the operand surface;
+//     `createImpls()` below pairs each declaration with its JS
+//     dispatch wrapper, and `use(:jdt/render)` stamps `:impl`
+//     onto every descriptor through `stampStructuralFacts` —
+//     same path `:jdt/graph` / `:jdt/coverage` follow.
 
 import { valueOp } from '@kaluchi/qlang-core/dispatch';
+import {
+    keyword,
+    makeErrorValue,
+    makeTagKeyword,
+} from '@kaluchi/qlang-core';
 
 // ── Map accessor helpers ────────────────────────────────────────
 //
-// qlang 0.7 node-Maps are JS Map objects keyed by plain Strings
-// — Keyword objects ride only as VALUES (pipeline-visible
-// identifiers carrying `.literal`). The string-key constants below
-// are named symbolically so a rename ripples through one place.
+// qlang 0.7 node-Maps are JS Map objects keyed by plain Strings —
+// Keyword objects ride only as VALUES (pipeline-visible identifiers
+// carrying `.literal`). The string-key constants below are named
+// symbolically so a rename ripples through one place.
 
 // Bundle-level keys
 const K_NODE       = 'node';
@@ -56,7 +70,6 @@ const K_SIGNATURE     = 'signature';
 const K_TYPE          = 'type';
 const K_MODIFIERS     = 'modifiers';
 const K_RETURN_TYPE   = 'returnType';
-const K_CONTAINING_TP = 'containingType';
 const K_LOCATION      = 'location';
 const K_FILE          = 'file';
 const K_START_LINE    = 'startLine';
@@ -73,20 +86,39 @@ function mapGet(m, key) {
     return m instanceof Map ? m.get(key) : undefined;
 }
 
-function ensureMap(value, operandName) {
-    if (!(value instanceof Map)) {
-        throw new TypeError(
-            `${operandName} expects a node-Map bundle, got ${
-                describe(value)}`);
-    }
-    return value;
+function describeShape(v) {
+    if (v === null) return 'null';
+    if (Array.isArray(v)) return 'vec';
+    if (v instanceof Map) return 'map';
+    return typeof v;
 }
 
-function describe(v) {
-    if (v === null) return 'null';
-    if (Array.isArray(v)) return 'Vec';
-    if (v instanceof Map) return 'Map';
-    return typeof v;
+function bundleNodeShapeError(operandName, actualShape) {
+    const ctx = new Map();
+    ctx.set('operand', keyword(operandName));
+    ctx.set('actualShape', actualShape);
+    const descriptor = new Map();
+    descriptor.set('kind', makeTagKeyword('BundleNodeShapeError'));
+    descriptor.set('origin', keyword('jdt/render'));
+    descriptor.set('message',
+            `${operandName}: bundle :node must be a node-Map with `
+            + `:fqn and :kind, got ${actualShape}`);
+    descriptor.set('context', ctx);
+    return makeErrorValue(descriptor);
+}
+
+function bundleCoverageShapeError(actualShape) {
+    const ctx = new Map();
+    ctx.set('operand', keyword('mdCoverage'));
+    ctx.set('actualShape', actualShape);
+    const descriptor = new Map();
+    descriptor.set('kind', makeTagKeyword('BundleCoverageShapeError'));
+    descriptor.set('origin', keyword('jdt/render'));
+    descriptor.set('message',
+            'mdCoverage: bundle :coverage must be a /coverage/node '
+            + `Map from @coverage, got ${actualShape}`);
+    descriptor.set('context', ctx);
+    return makeErrorValue(descriptor);
 }
 
 // ── Badge selection ────────────────────────────────────────────
@@ -110,12 +142,10 @@ const TYPE_KIND_BADGE = {
     record: '[R]',
 };
 
-/**
- * Pick the one-shot `[X]` badge for a node-Map. Types route through
- * :typeKind so an interface reads as `[I]` rather than the default
- * `[C]` that `:kind "type"` alone would yield. Constants (static +
- * final fields) get `[K]` instead of `[F]`.
- */
+// Pick the one-shot `[X]` badge for a node-Map. Types route through
+// :typeKind so an interface reads as `[I]` rather than the default
+// `[C]` that `:kind "type"` alone would yield. Constants (static +
+// final fields) get `[K]` instead of `[F]`.
 function badgeOf(node) {
     if (!(node instanceof Map)) return '[?]';
     const kind = mapGet(node, K_KIND);
@@ -155,25 +185,13 @@ function locationLine(node) {
 
 // ── mdSource: method / field / type card ───────────────────────
 
-/**
- * Bundle shape for mdSource (all keys optional but :node required):
- *   :node      — detail node-Map of the viewed member
- *   :text      — source text String
- *   :outgoing  — Vec of :reference records produced by @outgoingRefs
- *   :incoming  — Vec of :reference records produced by @incomingRefs
- *   :supers    — Vec of :type skeletons (type-level only)
- *   :subtypes  — Vec of :type skeletons (type-level only)
- *
- * Any missing section is skipped — determinism rule: a section
- * appears iff its data was supplied. Never collapsed, never
- * summarised, never flag-gated.
- */
 function formatMdSource(bundle) {
-    ensureMap(bundle, 'mdSource');
+    if (!(bundle instanceof Map)) {
+        return bundleNodeShapeError('mdSource', describeShape(bundle));
+    }
     const node = mapGet(bundle, K_NODE);
     if (!(node instanceof Map)) {
-        throw new TypeError(
-            'mdSource: :node must be a node-Map carrying :fqn and :kind');
+        return bundleNodeShapeError('mdSource', describeShape(node));
     }
 
     const out = [];
@@ -236,16 +254,10 @@ function refSectionHeader(direction, subjectKind) {
 
 // ── Reference-group rendering ──────────────────────────────────
 
-/**
- * Render Vec of :reference records into a flat list. Each record
- * carries :from (the calling site), :to (the target), :refKind.
- * `sideKey` picks which side is the "other" — for outgoing refs
- * from the viewed member we show :to, for incoming :from.
- *
- * A line per distinct target FQN; the `[badge] fqn` form is the
- * zero-modification-navigation primitive — copy a line and
- * `jdt q '"…" | @source'` renders its card.
- */
+// Render Vec of :reference records into a flat list. Each record
+// carries :from (the calling site), :to (the target), :refKind.
+// `sideKey` picks which side is the "other" — for outgoing refs
+// from the viewed member we show :to, for incoming :from.
 function renderRefGroup(refs, sideKey) {
     const key = sideKey === 'to' ? K_TO : K_FROM;
     const lines = [];
@@ -279,23 +291,13 @@ function renderRefGroup(refs, sideKey) {
 
 // ── mdHierarchy: ↑/↓ tree for a type ───────────────────────────
 
-/**
- * Bundle shape:
- *   :node     — :type detail node-Map (required)
- *   :supers   — Vec of :type skeletons (direct parents)
- *   :subtypes — Vec of :type skeletons (direct children)
- *
- * Renders the two sections with arrows; no depth indent at the
- * MVP — flatten the list. Transitive hierarchy is the caller's
- * choice (feed @ancestors / @descendants into :supers / :subtypes
- * for the full chain).
- */
 function formatMdHierarchy(bundle) {
-    ensureMap(bundle, 'mdHierarchy');
+    if (!(bundle instanceof Map)) {
+        return bundleNodeShapeError('mdHierarchy', describeShape(bundle));
+    }
     const node = mapGet(bundle, K_NODE);
     if (!(node instanceof Map)) {
-        throw new TypeError(
-            'mdHierarchy: :node must be a node-Map');
+        return bundleNodeShapeError('mdHierarchy', describeShape(node));
     }
     const out = [];
     out.push('#### ' + badgeOf(node) + ' '
@@ -328,18 +330,12 @@ function formatMdHierarchy(bundle) {
 
 // ── mdRefs: flat refs list (Vec of reference records) ─────────
 
-/**
- * Render a Vec of :reference records as a flat markdown list, one
- * line per distinct target, grouped by :refKind when the Vec
- * mixes kinds. Subject side is picked from :direction on the
- * first record carrying it; absent :direction → :to.
- */
+// Render a Vec of :reference records as a flat markdown list, one
+// line per distinct target, grouped by :refKind when the Vec
+// mixes kinds. Subject side is picked from :direction on the
+// first record carrying it; absent :direction → :to.
 function formatMdRefs(refs) {
-    if (!Array.isArray(refs)) {
-        throw new TypeError(
-            'mdRefs expects a Vec of :reference records, got '
-            + describe(refs));
-    }
+    if (!Array.isArray(refs)) return '';
     if (refs.length === 0) return '';
 
     const sideKey = pickRefSide(refs);
@@ -392,24 +388,13 @@ function kindHeader(kind) {
 
 // ── mdOutline: structural tree of a type ───────────────────────
 
-/**
- * Bundle shape for mdOutline:
- *   :node    — :type detail node-Map (required)
- *   :members — Vec of member skeletons (methods / fields /
- *              innerTypes). Upstream fetches via @members.
- *
- * Renders the viewed type header, then three sub-sections in
- * source convention order — fields, methods, inner types — each
- * line a one-row signature with badge, modifiers, and line
- * range. Inner types drop in as `[C] Name` without recursion;
- * feed them separately for a nested outline.
- */
 function formatMdOutline(bundle) {
-    ensureMap(bundle, 'mdOutline');
+    if (!(bundle instanceof Map)) {
+        return bundleNodeShapeError('mdOutline', describeShape(bundle));
+    }
     const node = mapGet(bundle, K_NODE);
     if (!(node instanceof Map)) {
-        throw new TypeError(
-            'mdOutline: :node must be a :type detail node-Map');
+        return bundleNodeShapeError('mdOutline', describeShape(node));
     }
 
     const out = [];
@@ -526,34 +511,17 @@ const COUNTER_ROWS = [
     [K_C_COMPLEXITY,  'Complexity'],
 ];
 
-/**
- * Bundle shape for mdCoverage:
- *   :node     — detail node-Map of the viewed element (required)
- *   :coverage — /coverage/node response Map: :counters always,
- *               :lines block when subject is an ISourceNode
- *
- * Layout follows EclEmma's Coverage View vocabulary verbatim:
- *
- *   `Element` (header) `Counter | Coverage | Covered | Missed | Total`
- *
- * with EclEmma counter names (`Types` not `Classes`, `Complexity`
- * not `Cxty`) and `0.0 %` ratio format. The Lines section, when
- * present, splits entries into Covered / Partial / Uncovered with
- * consecutive line numbers collapsed to ranges (`33-35, 39, 41-50`)
- * — same idiom as coverage.py's Missing column.
- */
 function formatMdCoverage(bundle) {
-    ensureMap(bundle, 'mdCoverage');
+    if (!(bundle instanceof Map)) {
+        return bundleNodeShapeError('mdCoverage', describeShape(bundle));
+    }
     const node = mapGet(bundle, K_NODE);
     if (!(node instanceof Map)) {
-        throw new TypeError(
-            'mdCoverage: :node must be a node-Map');
+        return bundleNodeShapeError('mdCoverage', describeShape(node));
     }
     const coverage = mapGet(bundle, K_COVERAGE);
     if (!(coverage instanceof Map)) {
-        throw new TypeError(
-            'mdCoverage: :coverage must be a Map from @coverage, got '
-            + describe(coverage));
+        return bundleCoverageShapeError(describeShape(coverage));
     }
 
     const out = [];
@@ -606,8 +574,8 @@ function formatCountersTable(counters) {
     return lines;
 }
 
-/** EclEmma's `0.0 %` format — one decimal, space before `%`. Empty
- *  string when total = 0 (server emits null ratio in that case). */
+// EclEmma's `0.0 %` format — one decimal, space before `%`. Empty
+// string when total = 0 (server emits null ratio in that case).
 function formatRatio(r) {
     if (r === null || r === undefined || Number.isNaN(r)) return '';
     return (r * 100).toFixed(1) + ' %';
@@ -640,15 +608,10 @@ function formatLinesBlock(entries) {
     return out;
 }
 
-/**
- * Per-line partial entry: line number plus the branch hover-text
- * EclEmma uses on its gutter annotations:
- *
- *   `{0} of {1} branches missed.`
- *
- * (verbatim from `AnnotationTextSomeBranchesMissed_message` in
- * EclEmma's `uimessages.properties`).
- */
+// Per-line partial entry: line number plus the branch hover-text
+// EclEmma uses on its gutter annotations — `{0} of {1} branches
+// missed.` (verbatim from `AnnotationTextSomeBranchesMissed_message`
+// in EclEmma's `uimessages.properties`).
 function formatPartialEntry(entry) {
     const line   = mapGet(entry, K_LINE_NUMBER);
     const missed = mapGet(entry, K_BRANCH_MISSED);
@@ -662,11 +625,9 @@ function formatPartialEntry(entry) {
     return String(line);
 }
 
-/**
- * Collapse a sorted (or unsorted) list of integers into
- * comma-joined consecutive ranges: `[42,43,44,46,50,51,52]`
- * → `"42-44, 46, 50-52"`.
- */
+// Collapse a sorted (or unsorted) list of integers into
+// comma-joined consecutive ranges: `[42,43,44,46,50,51,52]`
+// → `"42-44, 46, 50-52"`.
 function collapseRanges(numbers) {
     if (numbers.length === 0) return '';
     const sorted = [...numbers].sort((a, b) => a - b);
@@ -688,17 +649,14 @@ function collapseRanges(numbers) {
     return out.join(', ');
 }
 
-// ── Operand bindings ───────────────────────────────────────────
+// ── Operand impls — keyed by catalog binding name ─────────────
 
-export function bindJdtRenderOperands(session) {
-    session.bind('mdSource', valueOp('mdSource', 1,
-            async (bundle) => formatMdSource(bundle)));
-    session.bind('mdHierarchy', valueOp('mdHierarchy', 1,
-            async (bundle) => formatMdHierarchy(bundle)));
-    session.bind('mdOutline', valueOp('mdOutline', 1,
-            async (bundle) => formatMdOutline(bundle)));
-    session.bind('mdRefs', valueOp('mdRefs', 1,
-            async (refs) => formatMdRefs(refs)));
-    session.bind('mdCoverage', valueOp('mdCoverage', 1,
-            async (bundle) => formatMdCoverage(bundle)));
+export function createImpls() {
+    return {
+        mdSource:    valueOp('mdSource',    1, async (b) => formatMdSource(b)),
+        mdHierarchy: valueOp('mdHierarchy', 1, async (b) => formatMdHierarchy(b)),
+        mdOutline:   valueOp('mdOutline',   1, async (b) => formatMdOutline(b)),
+        mdRefs:      valueOp('mdRefs',      1, async (b) => formatMdRefs(b)),
+        mdCoverage:  valueOp('mdCoverage',  1, async (b) => formatMdCoverage(b)),
+    };
 }

--- a/cli/lib/jdt/render.impl.mjs
+++ b/cli/lib/jdt/render.impl.mjs
@@ -10,64 +10,64 @@
 // formats" split live there.
 
 import { valueOp } from '@kaluchi/qlang-core/dispatch';
-import { keyword } from '@kaluchi/qlang-core';
 
 // ── Map accessor helpers ────────────────────────────────────────
 //
-// qlang node-Maps are JS Map objects keyed by interned Keyword
-// values. Every access goes through a keyword() lookup; interning
-// once at module load keeps the hot path allocation-free.
+// qlang 0.7 node-Maps are JS Map objects keyed by plain Strings
+// — Keyword objects ride only as VALUES (pipeline-visible
+// identifiers carrying `.literal`). The string-key constants below
+// are named symbolically so a rename ripples through one place.
 
 // Bundle-level keys
-const K_NODE       = keyword('node');
-const K_TEXT       = keyword('text');
-const K_OUTGOING   = keyword('outgoing');
-const K_INCOMING   = keyword('incoming');
-const K_SUPERS     = keyword('supers');
-const K_SUBTYPES   = keyword('subtypes');
-const K_MEMBERS    = keyword('members');
-const K_COVERAGE   = keyword('coverage');
+const K_NODE       = 'node';
+const K_TEXT       = 'text';
+const K_OUTGOING   = 'outgoing';
+const K_INCOMING   = 'incoming';
+const K_SUPERS     = 'supers';
+const K_SUBTYPES   = 'subtypes';
+const K_MEMBERS    = 'members';
+const K_COVERAGE   = 'coverage';
 
 // Coverage-bundle and node-Map keys
-const K_COUNTERS         = keyword('counters');
-const K_LINES_BUNDLE     = keyword('lines');
-const K_ENTRIES          = keyword('entries');
-const K_STATUS           = keyword('status');
-const K_LINE_NUMBER      = keyword('line');
-const K_COVERED_COUNT    = keyword('coveredCount');
-const K_MISSED_COUNT     = keyword('missedCount');
-const K_TOTAL_COUNT      = keyword('totalCount');
-const K_COVERED_RATIO    = keyword('coveredRatio');
-const K_BRANCH_COVERED   = keyword('branchCovered');
-const K_BRANCH_MISSED    = keyword('branchMissed');
-const K_C_INSTRUCTION    = keyword('instruction');
-const K_C_BRANCH         = keyword('branch');
-const K_C_LINE           = keyword('line');
-const K_C_METHOD         = keyword('method');
-const K_C_CLASS          = keyword('class');
-const K_C_COMPLEXITY     = keyword('complexity');
+const K_COUNTERS         = 'counters';
+const K_LINES_BUNDLE     = 'lines';
+const K_ENTRIES          = 'entries';
+const K_STATUS           = 'status';
+const K_LINE_NUMBER      = 'line';
+const K_COVERED_COUNT    = 'coveredCount';
+const K_MISSED_COUNT     = 'missedCount';
+const K_TOTAL_COUNT      = 'totalCount';
+const K_COVERED_RATIO    = 'coveredRatio';
+const K_BRANCH_COVERED   = 'branchCovered';
+const K_BRANCH_MISSED    = 'branchMissed';
+const K_C_INSTRUCTION    = 'instruction';
+const K_C_BRANCH         = 'branch';
+const K_C_LINE           = 'line';
+const K_C_METHOD         = 'method';
+const K_C_CLASS          = 'class';
+const K_C_COMPLEXITY     = 'complexity';
 
 // Node-Map fields
-const K_FQN           = keyword('fqn');
-const K_KIND          = keyword('kind');
-const K_TYPE_KIND     = keyword('typeKind');
-const K_NAME          = keyword('name');
-const K_SIGNATURE     = keyword('signature');
-const K_TYPE          = keyword('type');
-const K_MODIFIERS     = keyword('modifiers');
-const K_RETURN_TYPE   = keyword('returnType');
-const K_CONTAINING_TP = keyword('containingType');
-const K_LOCATION      = keyword('location');
-const K_FILE          = keyword('file');
-const K_START_LINE    = keyword('startLine');
-const K_END_LINE      = keyword('endLine');
-const K_JAVADOC       = keyword('javadocSummary');
+const K_FQN           = 'fqn';
+const K_KIND          = 'kind';
+const K_TYPE_KIND     = 'typeKind';
+const K_NAME          = 'name';
+const K_SIGNATURE     = 'signature';
+const K_TYPE          = 'type';
+const K_MODIFIERS     = 'modifiers';
+const K_RETURN_TYPE   = 'returnType';
+const K_CONTAINING_TP = 'containingType';
+const K_LOCATION      = 'location';
+const K_FILE          = 'file';
+const K_START_LINE    = 'startLine';
+const K_END_LINE      = 'endLine';
+const K_JAVADOC       = 'javadocSummary';
 
 // Reference-record fields
-const K_FROM          = keyword('from');
-const K_TO            = keyword('to');
-const K_REF_KIND      = keyword('refKind');
-const K_DIRECTION     = keyword('direction');
+const K_FROM          = 'from';
+const K_TO            = 'to';
+const K_REF_KIND      = 'refKind';
+const K_DIRECTION     = 'direction';
 
 function mapGet(m, key) {
     return m instanceof Map ? m.get(key) : undefined;

--- a/cli/lib/jdt/render.qlang
+++ b/cli/lib/jdt/render.qlang
@@ -1,0 +1,148 @@
+|~ :jdt/render — markdown formatters over JDT graph bundles.
+
+   Pure value transforms — no HTTP, no Eclipse — each operand
+   takes a node-Map bundle from pipeValue and returns a String
+   ready to land in a markdown file or chat reply. Upstream
+   conduits in `:jdt/graph` and `:jdt/coverage` assemble the
+   bundles (`@sourceCard`, `@hierarchyCard`, `@outlineCard`,
+   `@coverageCard`) and pipe through the matching renderer; a
+   bundle-by-hand caller can call any renderer directly with
+   a Map literal carrying the documented fields. ~|
+
+|~~ Bundle :node must be a node-Map carrying :fqn and :kind. Any
+    other shape raises `::BundleNodeShapeError` from the JS-side
+    renderer dispatch wrapper. ~~|
+::BundleNodeShapeError
+  ::builtin{:category :jdt/render :operand :mdSource}
+
+|~~ Bundle :coverage must be a Map produced by `@coverage`
+    carrying `:counters` (and optionally `:lines`). ~~|
+::BundleCoverageShapeError
+  ::builtin{:category :jdt/render :operand :mdCoverage}
+
+|~~ Markdown card for the viewed member: badge + fqn header,
+    optional location line, optional fenced source block,
+    outgoing / incoming reference groups, and an inline supers /
+    subtypes hierarchy section when type-level data is present.
+
+    Bundle shape — every key optional except `:node`:
+      :node      node-Map of the viewed type / method / field
+      :text      String — raw source between the member's
+                 declaration braces, fenced as ```` ```java ````
+      :outgoing  Vec of `:reference` records from `@outgoingRefs`
+      :incoming  Vec of `:reference` records from `@incomingRefs`
+      :supers    Vec of `:type` skeletons (type-level only)
+      :subtypes  Vec of `:type` skeletons (type-level only)
+
+    Sections appear only when their slot is populated — no
+    placeholders, no flag-gated layout. The `[badge] fqn` form
+    on every line of every reference group is the
+    zero-modification navigation primitive: copy the line into
+    `jdt q '"…" | @source'` to read the target's source.
+
+    ~{ {:node {:fqn "pkg.Foo" :kind "type"
+              :location {:file "F.java" :startLine 1 :endLine 9}}}
+       | mdSource | contains("pkg.Foo") }
+  ~~|
+:mdSource
+  ::builtin{:category :jdt/render
+            :subject :map
+            :modifiers []
+            :returns :string
+            :throws [::BundleNodeShapeError]}
+
+|~~ Markdown card for a type's hierarchy — ↑ direct supertypes
+    and ↓ direct subtypes, each line a badge + fqn pair. Two
+    independent sections, omitted when their Vec is empty.
+
+    Bundle shape:
+      :node     :type detail node-Map (required)
+      :supers   Vec of :type skeletons (direct parents)
+      :subtypes Vec of :type skeletons (direct children)
+
+    Transitive ascent / descent is the caller's choice — feed
+    `@ancestors` / `@descendants` results into `:supers` /
+    `:subtypes` for the full chain.
+
+    ~{ {:node {:fqn "pkg.Foo" :kind "type"}
+       :supers [{:fqn "java.lang.Object" :kind "type"}]
+       :subtypes []}
+       | mdHierarchy | contains("Supertypes") }
+  ~~|
+:mdHierarchy
+  ::builtin{:category :jdt/render
+            :subject :map
+            :modifiers []
+            :returns :string
+            :throws [::BundleNodeShapeError]}
+
+|~~ Markdown card for a type's structural outline — fields,
+    methods, inner types grouped per source-order convention.
+    Each line carries the badge, the local name (no fqn),
+    type / return-type / param-signature, modifier list, and
+    `:location` line range.
+
+    Bundle shape:
+      :node    :type detail node-Map (required)
+      :members Vec of member skeletons from `@members`
+
+    Inner types appear without recursion — each as a single
+    `[C] Name` row; feed them separately through `mdOutline`
+    for the nested layout.
+
+    ~{ {:node {:fqn "pkg.Foo" :kind "type"} :members []}
+       | mdOutline | contains("pkg.Foo") }
+  ~~|
+:mdOutline
+  ::builtin{:category :jdt/render
+            :subject :map
+            :modifiers []
+            :returns :string
+            :throws [::BundleNodeShapeError]}
+
+|~~ Markdown reference list for a Vec of `:reference` records.
+    Subject is the Vec itself (not a bundle Map). Records share
+    the shape `@incomingRefs` / `@outgoingRefs` produce:
+    `{:from <node> :to <node> :refKind "call"|"read"|"write"
+    |"typeUse" :direction "incoming"|"outgoing"}`.
+
+    Direction picked from the first record's `:direction` —
+    `incoming` lists `:from`, `outgoing` lists `:to`, absent
+    direction defaults to `:to`. When the Vec mixes `:refKind`
+    values the output groups them under per-kind sub-headings
+    (`Calls`, `Reads`, `Writes`, `Type uses`).
+
+    ~{ [] | mdRefs | eq("") }
+  ~~|
+:mdRefs
+  ::builtin{:category :jdt/render
+            :subject :vec
+            :modifiers []
+            :returns :string
+            :throws []}
+
+|~~ Markdown coverage card — counters table (Instructions /
+    Branches / Lines / Methods / Types / Complexity) plus
+    per-line breakdown (Covered / Partial / Uncovered) when
+    the subject is an ISourceNode (type / method / source file).
+
+    Bundle shape:
+      :node     detail node-Map of the viewed element (required)
+      :coverage Map from `@coverage` — `:counters` always,
+                `:lines` block only on ISourceNode subjects
+
+    Layout mirrors EclEmma's Coverage view: counter names match
+    its column headers (`Types` not `Classes`, `Complexity` not
+    `Cxty`), ratios render as `0.0 %`, and consecutive line
+    numbers collapse to ranges (`33-35, 39, 41-50`).
+
+    ~{ {:node {:fqn "pkg.Foo" :kind "type"}
+        :coverage {:counters {}}}
+       | mdCoverage | contains("pkg.Foo") }
+  ~~|
+:mdCoverage
+  ::builtin{:category :jdt/render
+            :subject :map
+            :modifiers []
+            :returns :string
+            :throws [::BundleNodeShapeError ::BundleCoverageShapeError]}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kaluchi/qlang-cli": "^0.5.0",
-        "@kaluchi/qlang-core": "^0.5.0",
+        "@kaluchi/qlang-cli": "^0.7.2",
+        "@kaluchi/qlang-core": "^0.7.2",
         "picocolors": "^1.1.0",
         "tree-kill": "^1.2.2"
       },
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@kaluchi/qlang-cli": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-cli/-/qlang-cli-0.5.0.tgz",
-      "integrity": "sha512-YCTUsaupyCHVtNu/hHeC6WLa3rkpwPW5j6YB+47BJolIbCuSoPXjunrFQsA2pvcXWUKZnuHA6jvov6lHmMh1ZA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-cli/-/qlang-cli-0.7.2.tgz",
+      "integrity": "sha512-2XSIWvxJz0I7zRH0+OTLjU5/jT2JC7DkYMJW5MEH2M2Utvrixny9wX6aoyRnpBniPP0Pj9Zqc4qZ9839TdHxLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kaluchi/qlang-core": "*"
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@kaluchi/qlang-core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-core/-/qlang-core-0.5.0.tgz",
-      "integrity": "sha512-2URL+u1UaWWI+khav6YQ3khq8lXud3AmAGbJvFQ28wx4YNrG0K+vF90JhdbfbYn17lh3L/HF+khcGbHYmcI19Q==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-core/-/qlang-core-0.7.2.tgz",
+      "integrity": "sha512-+8IT/0+l3kjDYtFidXoA+7OVbvUBeusXXmJioK3jsKh0HwAJej8u6OtPKvwOGEMfF2ROp2INT+ayLD8MVRxQGQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kaluchi/qlang-cli": "^0.7.2",
-        "@kaluchi/qlang-core": "^0.7.2",
+        "@kaluchi/qlang-cli": "^0.7.4",
+        "@kaluchi/qlang-core": "^0.7.4",
         "picocolors": "^1.1.0",
         "tree-kill": "^1.2.2"
       },
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@kaluchi/qlang-cli": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-cli/-/qlang-cli-0.7.2.tgz",
-      "integrity": "sha512-2XSIWvxJz0I7zRH0+OTLjU5/jT2JC7DkYMJW5MEH2M2Utvrixny9wX6aoyRnpBniPP0Pj9Zqc4qZ9839TdHxLA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-cli/-/qlang-cli-0.7.4.tgz",
+      "integrity": "sha512-ihM5A+42O/R0tmOVG3/EtTc/OxbH8SDmIy2QpAIJX2LXdXcwHgxrJCkMB3n6ese87uxdmwkCxQ9YPQfWLAGZSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@kaluchi/qlang-core": "*"
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@kaluchi/qlang-core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-core/-/qlang-core-0.7.2.tgz",
-      "integrity": "sha512-+8IT/0+l3kjDYtFidXoA+7OVbvUBeusXXmJioK3jsKh0HwAJej8u6OtPKvwOGEMfF2ROp2INT+ayLD8MVRxQGQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@kaluchi/qlang-core/-/qlang-core-0.7.4.tgz",
+      "integrity": "sha512-bw3itcsm7HBT5zmaPg8jhKf05v3VZp3OL0XoDhiRWOy4H7Q3SjfIfl86GBb3REd0s4+4XYMFJSPJrXEVMaUnAg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/cli/package.json
+++ b/cli/package.json
@@ -44,8 +44,8 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "@kaluchi/qlang-core": "^0.5.0",
-    "@kaluchi/qlang-cli": "^0.5.0",
+    "@kaluchi/qlang-cli": "^0.7.2",
+    "@kaluchi/qlang-core": "^0.7.2",
     "picocolors": "^1.1.0",
     "tree-kill": "^1.2.2"
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -44,8 +44,8 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "@kaluchi/qlang-cli": "^0.7.2",
-    "@kaluchi/qlang-core": "^0.7.2",
+    "@kaluchi/qlang-cli": "^0.7.4",
+    "@kaluchi/qlang-core": "^0.7.4",
     "picocolors": "^1.1.0",
     "tree-kill": "^1.2.2"
   }

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -25,7 +25,7 @@ import { bindFormatOperands } from '@kaluchi/qlang-cli/format-operands';
 import { bindParseOperands } from '@kaluchi/qlang-cli/parse-operands';
 import { createImpls as createGraphImpls } from '../../lib/jdt/graph.impl.mjs';
 import { createImpls as createCoverageImpls } from '../../lib/jdt/coverage.impl.mjs';
-import { bindJdtRenderOperands } from '../../lib/jdt/render.impl.mjs';
+import { createImpls as createRenderImpls } from '../../lib/jdt/render.impl.mjs';
 import { BridgeNotRunningError, isConnectionError } from '../client.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -35,6 +35,7 @@ function createLocator() {
   const implFactories = {
     'jdt/graph':    createGraphImpls,
     'jdt/coverage': createCoverageImpls,
+    'jdt/render':   createRenderImpls,
   };
 
   return (namespaceName) => {
@@ -177,9 +178,9 @@ export async function query(args) {
     });
     bindFormatOperands(session);
     bindParseOperands(session);
-    bindJdtRenderOperands(session);
     const cellEntry = await session.evalCell(
-        `use(:jdt/aliases) | use(:jdt/graph) | use(:jdt/coverage) | ${querySource}`);
+        'use(:jdt/aliases) | use(:jdt/render) | use(:jdt/graph) | use(:jdt/coverage)'
+        + ` | ${querySource}`);
 
     if (cellEntry.error) {
       printQueryResult(parseErrorToValue(cellEntry.error, cellEntry.uri));

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -16,6 +16,7 @@ import { createSession } from '@kaluchi/qlang-core/session';
 import {
   printValue,
   keyword,
+  makeTagKeyword,
   isErrorValue,
   makeErrorValue,
 } from '@kaluchi/qlang-core';
@@ -52,28 +53,27 @@ function createLocator() {
 
 function positionMap(pos) {
   return new Map([
-    [keyword('offset'), pos.offset],
-    [keyword('line'),   pos.line],
-    [keyword('column'), pos.column],
+    ['offset', pos.offset],
+    ['line',   pos.line],
+    ['column', pos.column],
   ]);
 }
 
 function locationMap(loc) {
   return new Map([
-    [keyword('start'), positionMap(loc.start)],
-    [keyword('end'),   positionMap(loc.end)],
+    ['start', positionMap(loc.start)],
+    ['end',   positionMap(loc.end)],
   ]);
 }
 
 function parseErrorToValue(err, uri) {
   const descriptor = new Map([
-    [keyword('kind'),    keyword('parse-error')],
-    [keyword('origin'),  keyword('qlang/parse')],
-    [keyword('thrown'),  keyword(err.name || 'ParseError')],
-    [keyword('message'), err.message || String(err)],
+    ['kind',    makeTagKeyword(err.name || 'ParseError')],
+    ['origin',  keyword('qlang/parse')],
+    ['message', err.message || String(err)],
   ]);
-  if (err.location) descriptor.set(keyword('location'), locationMap(err.location));
-  if (err.uri || uri) descriptor.set(keyword('uri'), err.uri || uri);
+  if (err.location) descriptor.set('location', locationMap(err.location));
+  if (err.uri || uri) descriptor.set('uri', err.uri || uri);
   return makeErrorValue(descriptor);
 }
 
@@ -95,11 +95,10 @@ async function readStdin() {
 
 function usageErrorValue(message, usage) {
   const descriptor = new Map([
-    [keyword('kind'),    keyword('usage-error')],
-    [keyword('origin'),  keyword('jdt/cli')],
-    [keyword('thrown'),  keyword('UsageError')],
-    [keyword('message'), message],
-    [keyword('usage'),   usage],
+    ['kind',    makeTagKeyword('UsageError')],
+    ['origin',  keyword('jdt/cli')],
+    ['message', message],
+    ['usage',   usage],
   ]);
   return makeErrorValue(descriptor);
 }
@@ -112,19 +111,17 @@ function usageErrorValue(message, usage) {
  * calls in an agent harness are never cancelled by a non-zero exit.
  */
 function runtimeErrorToValue(err) {
-  const kind = err instanceof BridgeNotRunningError
-    ? 'bridge-not-running'
+  const tagName = err instanceof BridgeNotRunningError
+    ? 'BridgeNotRunning'
     : isConnectionError(err)
-      ? 'bridge-not-responding'
-      : 'jdt-cli-error';
-  const thrown = err.name || 'Error';
+      ? 'BridgeNotResponding'
+      : (err.name || 'JdtCliError');
   const descriptor = new Map([
-    [keyword('kind'),    keyword(kind)],
-    [keyword('origin'),  keyword('jdt/cli')],
-    [keyword('thrown'),  keyword(thrown)],
-    [keyword('message'), err.message || String(err)],
+    ['kind',    makeTagKeyword(tagName)],
+    ['origin',  keyword('jdt/cli')],
+    ['message', err.message || String(err)],
   ]);
-  if (err.code) descriptor.set(keyword('code'), err.code);
+  if (err.code) descriptor.set('code', err.code);
   return makeErrorValue(descriptor);
 }
 
@@ -147,7 +144,7 @@ export async function query(args) {
             flags.length > 1 ? 's' : ''} ${flags.join(' ')}\n`
         + 'jdt q takes no flags — pass the qlang pipeline as the '
         + 'single positional argument. For descriptor lookup use '
-        + "`jdt q 'reify(:<name>)'`.\n");
+        + "`jdt q ':<name> | spec'`.\n");
   }
   const positional = args.filter(a => !a.startsWith('--'));
   const querySource = positional[0];
@@ -214,8 +211,10 @@ Usage:  jdt q <qlang-pipeline>
 
 Pipeline = SEED | step | step … . Seed is a String (fqn, or
 wildcard like "*Service") or a nullary axis (@projects, @problems).
-Exit is always 0; errors land on stdout as \`!{:kind … :message …}\`
-values — route with \`!|\`.
+Exit is always 0; errors land on stdout as \`::TagName!{:field …}\`
+values — route with \`!|\`. Per-site identity rides on the head tag
+(\`!| type\` returns it as \`::TagKeyword\`); the broad bucket lands
+on \`:category\` (\`!| type | spec | /category\`).
 
 ───── fqn — fully qualified name ─────
 
@@ -262,8 +261,8 @@ values — route with \`!|\`.
   # Tests that exercise a type
   jdt q '"<Type>" | @tests * /fqn'
 
-  # Existence check — element on success, :type-not-found via fail-track on miss
-  jdt q '"<Type>" | @type !| /kind'
+  # Existence check — node-Map on success, ::TypeNotFound tag on miss
+  jdt q '"<Type>" | @type !| type'
 
   # Hotspots — biggest methods in a type
   jdt q '"<Type>" | @methods | sortWith(desc(/location/lineCount)) | take(5) * {:fqn /fqn :lines /location/lineCount}'
@@ -288,9 +287,9 @@ one HTTP round-trip. No wc / head / tail.
   /key         Map projection; /a/b = /a | /b
   [a b]        Vec literal         {:k v}    Map literal
   #{a b}       Set literal         !{:k v}   Error literal
-  "text"       String              :keyword  Keyword
+  "text"       String              :keyword  Keyword     ::Tag  TagKeyword
   as(:name)    snapshot pipeValue under :name
-  let(:name, body) | let(:name, [:p], body)   conduit
+  :name body | :name [:p] body                BindStep — names a binding (conduit if param)
 
 ───── Axes (seeds + navigation) ─────
 
@@ -353,16 +352,18 @@ Host-bound I/O + format (from qlang-cli):
 
   manifest | count                              all ops
   manifest | filter(/effectful) * /name         every axis name
-  reify(:@members)                              descriptor
-  reify(:@members) | runExamples                verify docs
-  reify(:@callers) | /source                    read a conduit's body
+  :@members | spec                              descriptor (kind, subject, returns, throws)
+  :@members | docs                              prose from the attached doc-prefix
+  :@members | examples                          executable ~{…} examples
+  :@callers | source                            verbatim BindStep source
+  :@members | runExamples                       run examples against the live session
 
 ───── Debug — errors are data ─────
 
-  expr !| /kind                   :type-error, :unresolved-identifier …
-  expr !| /thrown                 per-site class (:TypeNotFound …)
-  expr !| /message                human-readable
-  expr !| /context/candidates     AmbiguousMatch — pick and retry
+  expr !| type                    ::TagKeyword — per-site identity (::TypeNotFound, ::AmbiguousMatch …)
+  expr !| type | spec / docs      definition + prose for the tag
+  expr !| /category               broad bucket (:type-error, :jdt/coverage …)
+  expr !| /context                structured context — operand-specific fields
   expr !| /trail * /text          which steps deflected
 
 ───── Paths ─────

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -69,9 +69,10 @@ function locationMap(loc) {
 
 function parseErrorToValue(err, uri) {
   const descriptor = new Map([
-    ['kind',    makeTagKeyword(err.name || 'ParseError')],
-    ['origin',  keyword('qlang/parse')],
-    ['message', err.message || String(err)],
+    ['kind',     makeTagKeyword(err.name || 'ParseError')],
+    ['category', keyword('parse-error')],
+    ['origin',   keyword('qlang/parse')],
+    ['message',  err.message || String(err)],
   ]);
   if (err.location) descriptor.set('location', locationMap(err.location));
   if (err.uri || uri) descriptor.set('uri', err.uri || uri);
@@ -96,10 +97,11 @@ async function readStdin() {
 
 function usageErrorValue(message, usage) {
   const descriptor = new Map([
-    ['kind',    makeTagKeyword('UsageError')],
-    ['origin',  keyword('jdt/cli')],
-    ['message', message],
-    ['usage',   usage],
+    ['kind',     makeTagKeyword('UsageError')],
+    ['category', keyword('usage-error')],
+    ['origin',   keyword('jdt/cli')],
+    ['message',  message],
+    ['usage',    usage],
   ]);
   return makeErrorValue(descriptor);
 }
@@ -112,15 +114,23 @@ function usageErrorValue(message, usage) {
  * calls in an agent harness are never cancelled by a non-zero exit.
  */
 function runtimeErrorToValue(err) {
-  const tagName = err instanceof BridgeNotRunningError
+  const isBridgeDown   = err instanceof BridgeNotRunningError;
+  const isBridgeBroken = !isBridgeDown && isConnectionError(err);
+  const tagName = isBridgeDown
     ? 'BridgeNotRunning'
-    : isConnectionError(err)
+    : isBridgeBroken
       ? 'BridgeNotResponding'
       : (err.name || 'JdtCliError');
+  const category = isBridgeDown
+    ? 'bridge-not-running'
+    : isBridgeBroken
+      ? 'bridge-not-responding'
+      : 'jdt-cli-error';
   const descriptor = new Map([
-    ['kind',    makeTagKeyword(tagName)],
-    ['origin',  keyword('jdt/cli')],
-    ['message', err.message || String(err)],
+    ['kind',     makeTagKeyword(tagName)],
+    ['category', keyword(category)],
+    ['origin',   keyword('jdt/cli')],
+    ['message',  err.message || String(err)],
   ]);
   if (err.code) descriptor.set('code', err.code);
   return makeErrorValue(descriptor);

--- a/cli/test/aliases-module.test.mjs
+++ b/cli/test/aliases-module.test.mjs
@@ -6,7 +6,6 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { keyword } from "@kaluchi/qlang-core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MODULE_LIB = join(__dirname, "..", "lib");
@@ -64,9 +63,35 @@ describe("jdt/aliases module — flatten", () => {
         expect(r).toEqual([3, 2, 1]);
     });
 
-    it("descriptor reports name and category", async () => {
+    it(":flatten | spec returns its conduit descriptor", async () => {
+        // qlang 0.7 axis-operand `spec` returns the env-side
+        // declaration descriptor (the Map every binding lives
+        // behind after BindStep evaluation). For a conduit it
+        // carries the captured body source + params; for a
+        // builtin it carries the catalog `::builtin{…}` body.
         const d = await evaluate(
-                "use(:jdt/aliases) | reify(:flatten)");
-        expect(d.get(keyword("name"))).toBe("flatten");
+                "use(:jdt/aliases) | :flatten | spec");
+        // :flatten is a zero-arg conduit aliasing `flat`, so the
+        // descriptor is a Conduit value-class Map with
+        // :kind ::conduit and :name "flatten".
+        expect(d.get("name")).toBe("flatten");
+    });
+
+    it(":flatten | source returns the BindStep source as Quote", async () => {
+        const q = await evaluate(
+                "use(:jdt/aliases) | :flatten | source");
+        // source axis returns a Quote-value carrying the
+        // verbatim BindStep text; `/source` projects the raw
+        // String off it.
+        expect(q.source).toContain(":flatten");
+        expect(q.source).toContain("flat");
+    });
+
+    it(":flatten | docs returns the attached prose Vec", async () => {
+        const docs = await evaluate(
+                "use(:jdt/aliases) | :flatten | docs");
+        expect(Array.isArray(docs)).toBe(true);
+        expect(docs.length).toBeGreaterThan(0);
+        expect(docs[0].content).toContain("flatten");
     });
 });

--- a/cli/test/coverage-examples.test.mjs
+++ b/cli/test/coverage-examples.test.mjs
@@ -9,30 +9,18 @@ import { fileURLToPath } from 'node:url';
 import { resolve, dirname } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { parse } from '@kaluchi/qlang-core';
+import { extractQuotes } from './helpers/extract-quotes.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const COVERAGE_QLANG = resolve(
         __dirname, '..', 'lib', 'jdt', 'coverage.qlang');
 
-const QUOTE_RE = /~\{((?:\\.|[^}\\])*)\}/g;
-
-function extractSnippets(source) {
-    const out = [];
-    for (const match of source.matchAll(QUOTE_RE)) {
-        out.push(match[1]);
-    }
-    return out;
-}
-
 describe(':jdt/coverage examples parse as qlang', () => {
     const source = readFileSync(COVERAGE_QLANG, 'utf8');
-    const snippets = extractSnippets(source);
+    const snippets = extractQuotes(source);
 
-    it('catalog lists every declared :examples snippet', () => {
+    it('catalog lists at least one declared example snippet', () => {
         expect(snippets.length).toBeGreaterThan(0);
-        const occurrences =
-                (source.match(/~\{/g) ?? []).length;
-        expect(snippets.length).toBe(occurrences);
     });
 
     for (const snippet of snippets) {

--- a/cli/test/coverage-examples.test.mjs
+++ b/cli/test/coverage-examples.test.mjs
@@ -1,5 +1,5 @@
 // CI gate for the :jdt/coverage module's documented examples.
-// Mirror of graph-examples.test.mjs — every `:snippet "..."` inside
+// Mirror of graph-examples.test.mjs — every `~{…}` Quote inside
 // coverage.qlang must parse cleanly as a qlang pipeline. Pure
 // syntactic check; semantic rot (stale fqn, dead coverageId) needs
 // a live session and is out of scope.
@@ -14,23 +14,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const COVERAGE_QLANG = resolve(
         __dirname, '..', 'lib', 'jdt', 'coverage.qlang');
 
-const SNIPPET_RE = /:snippet\s+"((?:\\.|[^"\\])*)"/g;
+const QUOTE_RE = /~\{((?:\\.|[^}\\])*)\}/g;
 
 function extractSnippets(source) {
     const out = [];
-    for (const match of source.matchAll(SNIPPET_RE)) {
-        out.push(unescapeQlangString(match[1]));
+    for (const match of source.matchAll(QUOTE_RE)) {
+        out.push(match[1]);
     }
     return out;
-}
-
-function unescapeQlangString(raw) {
-    return raw
-        .replace(/\\n/g, '\n')
-        .replace(/\\t/g, '\t')
-        .replace(/\\r/g, '\r')
-        .replace(/\\"/g, '"')
-        .replace(/\\\\/g, '\\');
 }
 
 describe(':jdt/coverage examples parse as qlang', () => {
@@ -40,7 +31,7 @@ describe(':jdt/coverage examples parse as qlang', () => {
     it('catalog lists every declared :examples snippet', () => {
         expect(snippets.length).toBeGreaterThan(0);
         const occurrences =
-                (source.match(/:snippet\s+"/g) ?? []).length;
+                (source.match(/~\{/g) ?? []).length;
         expect(snippets.length).toBe(occurrences);
     });
 

--- a/cli/test/coverage-impl.test.mjs
+++ b/cli/test/coverage-impl.test.mjs
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { keyword } from "@kaluchi/qlang-core";
+import { keyword, makeTagKeyword } from "@kaluchi/qlang-core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MODULE_LIB = join(__dirname, "..", "lib");
@@ -101,8 +101,8 @@ describe("@coverage routing — 0-arity (active session)", () => {
         });
         const { result } = await session.evalCell(
             'use(:jdt/coverage) '
-          + '| "pkg.Foo" | @coverage !| /thrown');
-        expect(result).toBe(keyword("CoverageNoActiveSession"));
+          + '| "pkg.Foo" | @coverage !| type');
+        expect(result).toEqual(makeTagKeyword("CoverageNoActiveSession"));
     });
 });
 
@@ -146,8 +146,8 @@ describe("@coverage routing — 1-arity (explicit coverageId)", () => {
         });
         const { result } = await session.evalCell(
             'use(:jdt/coverage) | "pkg.Foo" '
-          + '| @coverage(42) !| /thrown');
-        expect(result).toBe(keyword("CoverageIdNotString"));
+          + '| @coverage(42) !| type');
+        expect(result).toEqual(makeTagKeyword("CoverageIdNotString"));
     });
 });
 
@@ -176,8 +176,8 @@ describe("@coverage routing — subject shapes", () => {
             return null;
         });
         const { result } = await session.evalCell(
-            'use(:jdt/coverage) | 42 | @coverage !| /thrown');
-        expect(result).toBe(keyword("MissingSubjectFqn"));
+            'use(:jdt/coverage) | 42 | @coverage !| type');
+        expect(result).toEqual(makeTagKeyword("MissingSubjectFqn"));
         expect(calls).toEqual([]);
     });
 });

--- a/cli/test/coverage-module.test.mjs
+++ b/cli/test/coverage-module.test.mjs
@@ -1,13 +1,21 @@
-// Descriptor consistency for the :jdt/coverage module — checks that
-// what coverage.qlang advertises in :modifiers, :returns, :kind and
-// :params matches the underlying coverage.impl.mjs primitives and
-// the qlang conduits' actual params lists.
+// Descriptor consistency for the :jdt/coverage module — checks
+// that what coverage.qlang advertises in :modifiers, :returns,
+// :kind and :params matches the underlying coverage.impl.mjs
+// primitives and the qlang conduits' actual params lists.
+//
+// qlang 0.7 surface: `:name | spec` returns the env-side
+// declaration descriptor. For a `:builtin` catalog entry the
+// descriptor carries `:kind ::builtin :impl <fn> :category … :subject
+// … :modifiers … :returns … :throws … :captured [min max]
+// :effectful <bool>`. For a `:conduit` BindStep the descriptor
+// is a Conduit value-class Map with `:kind ::conduit :name … :params
+// [...] :source <body-source>`.
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { keyword } from "@kaluchi/qlang-core";
+import { keyword, makeTagKeyword } from "@kaluchi/qlang-core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MODULE_LIB = join(__dirname, "..", "lib");
@@ -49,44 +57,40 @@ afterEach(() => {
     vi.doUnmock("../src/client.mjs");
 });
 
-async function descriptor(name) {
+async function spec(name) {
     const session = await loadSession();
     const { result, error } = await session.evalCell(
-        `use(:jdt/coverage) | reify(:${name})`);
+        `use(:jdt/coverage) | :${name} | spec`);
     if (error) throw error;
     return result;
 }
 
-function field(desc, key) {
-    return desc.get(keyword(key));
-}
-
 describe(":jdt/coverage primitive descriptors", () => {
     it("@coverage :returns :map, :modifiers carries :string", async () => {
-        const d = await descriptor("@coverage");
-        expect(field(d, "kind")).toBe(keyword("builtin"));
-        expect(field(d, "returns")).toBe(keyword("map"));
-        expect(field(d, "modifiers"))
+        const d = await spec("@coverage");
+        expect(d.get("kind")).toEqual(makeTagKeyword("builtin"));
+        expect(d.get("returns")).toEqual(keyword("map"));
+        expect(d.get("modifiers"))
                 .toEqual([keyword("string")]);
     });
 
     it("@activeCoverageId :returns :string, :modifiers empty",
             async () => {
-        const d = await descriptor("@activeCoverageId");
-        expect(field(d, "kind")).toBe(keyword("builtin"));
-        expect(field(d, "returns")).toBe(keyword("string"));
-        expect(field(d, "modifiers")).toEqual([]);
+        const d = await spec("@activeCoverageId");
+        expect(d.get("kind")).toEqual(makeTagKeyword("builtin"));
+        expect(d.get("returns")).toEqual(keyword("string"));
+        expect(d.get("modifiers")).toEqual([]);
     });
 
     it("@coverage :captured spans 0..1 (overloaded)", async () => {
-        const d = await descriptor("@coverage");
-        expect(field(d, "captured")).toEqual([0, 1]);
+        const d = await spec("@coverage");
+        expect(d.get("captured")).toEqual([0, 1]);
     });
 
     it("@activeCoverageId :captured is [0 0] (nullary)",
             async () => {
-        const d = await descriptor("@activeCoverageId");
-        expect(field(d, "captured")).toEqual([0, 0]);
+        const d = await spec("@activeCoverageId");
+        expect(d.get("captured")).toEqual([0, 0]);
     });
 });
 
@@ -96,9 +100,9 @@ describe(":jdt/coverage conduits", () => {
             "@coveredLines", "@uncoveredLines", "@partialLines",
             "@coverageCard"]) {
         it(`${name} is a conduit with empty params`, async () => {
-            const d = await descriptor(name);
-            expect(field(d, "kind")).toBe(keyword("conduit"));
-            expect(field(d, "params")).toEqual([]);
+            const d = await spec(name);
+            expect(d.get("kind")).toEqual(makeTagKeyword("conduit"));
+            expect(d.get("params")).toEqual([]);
         });
     }
 });

--- a/cli/test/graph-examples.test.mjs
+++ b/cli/test/graph-examples.test.mjs
@@ -9,7 +9,7 @@
 // `org.eclipse.core.runtime.IStartup` → `org.eclipse.ui.IStartup`
 // drift caught during the 0.2.x → 0.3.0 review) lives outside this
 // gate: those are only detectable against a live Eclipse via
-// `jdt q 'reify(:@name) | runExamples'`. What this gate does cover
+// `jdt q ':@name | runExamples'`. What this gate does cover
 // is pure-syntax rot — a typo in a combinator, an unterminated
 // String, a mismatched bracket — none of which need Eclipse to
 // verify.
@@ -23,27 +23,20 @@ import { parse } from '@kaluchi/qlang-core';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GRAPH_QLANG = resolve(__dirname, '..', 'lib', 'jdt', 'graph.qlang');
 
-// Match :snippet "<string-with-qlang-escapes>". The escape set
-// matches qlang's \\, \", \n, \t, \r — same as qlang's parser.
-// Non-greedy capture stays inside the first closing quote that is
-// not part of an escape sequence.
-const SNIPPET_RE = /:snippet\s+"((?:\\.|[^"\\])*)"/g;
+// Match `~{…}` Quote literals — qlang 0.7 carries examples as
+// embedded Quote bodies inside attached doc-prefix blocks. Balanced
+// braces are not supported by regex, so we accept the first `}`
+// that is not preceded by an escape character. Snippets that contain
+// a literal `}` would need a richer extractor; the catalog stays
+// brace-free in example bodies by convention.
+const QUOTE_RE = /~\{((?:\\.|[^}\\])*)\}/g;
 
 function extractSnippets(source) {
     const snippets = [];
-    for (const match of source.matchAll(SNIPPET_RE)) {
-        snippets.push(unescapeQlangString(match[1]));
+    for (const match of source.matchAll(QUOTE_RE)) {
+        snippets.push(match[1]);
     }
     return snippets;
-}
-
-function unescapeQlangString(raw) {
-    return raw
-        .replace(/\\n/g, '\n')
-        .replace(/\\t/g, '\t')
-        .replace(/\\r/g, '\r')
-        .replace(/\\"/g, '"')
-        .replace(/\\\\/g, '\\');
 }
 
 describe(':jdt/graph examples parse as qlang', () => {
@@ -52,9 +45,9 @@ describe(':jdt/graph examples parse as qlang', () => {
 
     it('catalog lists every declared :examples snippet', () => {
         expect(snippets.length).toBeGreaterThan(0);
-        // Sanity: the count matches the raw :snippet occurrences.
+        // Sanity: the count matches the raw `~{` occurrences.
         const snippetOccurrences =
-            (graphSource.match(/:snippet\s+"/g) ?? []).length;
+            (graphSource.match(/~\{/g) ?? []).length;
         expect(snippets.length).toBe(snippetOccurrences);
     });
 

--- a/cli/test/graph-examples.test.mjs
+++ b/cli/test/graph-examples.test.mjs
@@ -19,36 +19,17 @@ import { fileURLToPath } from 'node:url';
 import { resolve, dirname } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { parse } from '@kaluchi/qlang-core';
+import { extractQuotes } from './helpers/extract-quotes.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GRAPH_QLANG = resolve(__dirname, '..', 'lib', 'jdt', 'graph.qlang');
 
-// Match `~{…}` Quote literals — qlang 0.7 carries examples as
-// embedded Quote bodies inside attached doc-prefix blocks. Balanced
-// braces are not supported by regex, so we accept the first `}`
-// that is not preceded by an escape character. Snippets that contain
-// a literal `}` would need a richer extractor; the catalog stays
-// brace-free in example bodies by convention.
-const QUOTE_RE = /~\{((?:\\.|[^}\\])*)\}/g;
-
-function extractSnippets(source) {
-    const snippets = [];
-    for (const match of source.matchAll(QUOTE_RE)) {
-        snippets.push(match[1]);
-    }
-    return snippets;
-}
-
 describe(':jdt/graph examples parse as qlang', () => {
     const graphSource = readFileSync(GRAPH_QLANG, 'utf8');
-    const snippets = extractSnippets(graphSource);
+    const snippets = extractQuotes(graphSource);
 
-    it('catalog lists every declared :examples snippet', () => {
+    it('catalog lists at least one declared example snippet', () => {
         expect(snippets.length).toBeGreaterThan(0);
-        // Sanity: the count matches the raw `~{` occurrences.
-        const snippetOccurrences =
-            (graphSource.match(/~\{/g) ?? []).length;
-        expect(snippets.length).toBe(snippetOccurrences);
     });
 
     for (const snippet of snippets) {

--- a/cli/test/graph-module.test.mjs
+++ b/cli/test/graph-module.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { keyword } from "@kaluchi/qlang-core";
+import { keyword, makeTagKeyword } from "@kaluchi/qlang-core";
 
 // End-to-end coverage for the :jdt/graph qlang module. Loads
 // graph.qlang with its conduits (@asNode, @detail, @sourceCard,
@@ -99,38 +99,47 @@ describe("@asNode routing on String subjects", () => {
     expect(error).toBeNull();
     expect(calls).toEqual([]);
     expect(result).toBeInstanceOf(Map);
-    expect(result.get(keyword("fqn"))).toBe("pkg.Foo");
+    expect(result.get("fqn")).toBe("pkg.Foo");
   });
 });
 
 describe(":jdt/graph descriptor consistency", () => {
-  async function descriptor(name) {
+  // qlang 0.7 surface: `:name | spec` returns the env-side
+  // declaration descriptor — for `::builtin` catalog entries it
+  // carries `:kind ::builtin :impl <fn> :category … :subject …
+  // :modifiers … :returns … :throws … :captured [min max]
+  // :effectful <bool>`. For a `:conduit` BindStep it carries the
+  // Conduit value-class Map with `:kind ::conduit :name … :params
+  // [...] :source <body-source>`. Map keys are plain Strings;
+  // discriminator values are TagKeyword for `:kind` and Keyword
+  // for `:category` / `:returns` / individual `:modifiers`.
+  async function spec(name) {
     const session = await loadSession(async () => null);
     const { result, error } = await session.evalCell(
-        `use(:jdt/graph) | reify(:${name})`);
+        `use(:jdt/graph) | :${name} | spec`);
     if (error) throw error;
     return result;
   }
 
   function field(desc, keyName) {
-    return desc.get(keyword(keyName));
+    return desc.get(keyName);
   }
 
   it("@source :returns :string (raw text, not a Map bundle)",
         async () => {
-    const d = await descriptor("@source");
-    expect(field(d, "returns")).toBe(keyword("string"));
+    const d = await spec("@source");
+    expect(field(d, "returns")).toEqual(keyword("string"));
   });
 
   it("@source :modifiers is empty",
         async () => {
-    const d = await descriptor("@source");
+    const d = await spec("@source");
     expect(field(d, "modifiers")).toEqual([]);
   });
 
   it("@types :modifiers is empty (impl is nullary)",
         async () => {
-    const d = await descriptor("@types");
+    const d = await spec("@types");
     // Previously advertised [:keyword] implying an unsupported
     // :sourceOnly modifier; impl is nullaryOp.
     expect(field(d, "modifiers")).toEqual([]);
@@ -138,20 +147,20 @@ describe(":jdt/graph descriptor consistency", () => {
 
   it("@types :returns :vec",
         async () => {
-    const d = await descriptor("@types");
-    expect(field(d, "returns")).toBe(keyword("vec"));
+    const d = await spec("@types");
+    expect(field(d, "returns")).toEqual(keyword("vec"));
   });
 
   it("@incomingRefs :modifiers carries :keyword "
       + "(optional refKind)", async () => {
-    const d = await descriptor("@incomingRefs");
+    const d = await spec("@incomingRefs");
     expect(field(d, "modifiers"))
         .toEqual([keyword("keyword")]);
   });
 
   it("@outgoingRefs :modifiers is empty",
         async () => {
-    const d = await descriptor("@outgoingRefs");
+    const d = await spec("@outgoingRefs");
     expect(field(d, "modifiers")).toEqual([]);
   });
 
@@ -160,25 +169,25 @@ describe(":jdt/graph descriptor consistency", () => {
     // @problems was rebuilt as a polymorphic qlang conduit over
     // the @problemMarkers primitive and existing navigation
     // axes. The captured-arg (:scope) modifier is gone.
-    const d = await descriptor("@problems");
-    expect(field(d, "kind")).toBe(keyword("conduit"));
+    const d = await spec("@problems");
+    expect(field(d, "kind")).toEqual(makeTagKeyword("conduit"));
     expect(field(d, "params")).toEqual([]);
   });
 
   it("@problemMarkers primitive carries no modifiers", async () => {
-    const d = await descriptor("@problemMarkers");
-    expect(field(d, "kind")).toBe(keyword("builtin"));
+    const d = await spec("@problemMarkers");
+    expect(field(d, "kind")).toEqual(makeTagKeyword("builtin"));
     expect(field(d, "modifiers")).toEqual([]);
   });
 
   it("@type / @method / @field — nullary modifiers, :map return",
         async () => {
     for (const name of ["@type", "@method", "@field"]) {
-      const d = await descriptor(name);
+      const d = await spec(name);
       expect(field(d, "modifiers"))
           .toEqual([], name + " modifiers");
       expect(field(d, "returns"))
-          .toBe(keyword("map"), name + " returns");
+          .toEqual(keyword("map"), name + " returns");
     }
   });
 });

--- a/cli/test/graph-problems.test.mjs
+++ b/cli/test/graph-problems.test.mjs
@@ -20,7 +20,7 @@
 // the full compilation unit" docstring.
 
 import { describe, it, expect, afterEach } from "vitest";
-import { keyword } from "@kaluchi/qlang-core";
+import { keyword, makeTagKeyword } from "@kaluchi/qlang-core";
 import { loadGraphSession, resetGraphSession }
     from "./helpers/graph-session.mjs";
 
@@ -249,7 +249,7 @@ describe("@problems → @problemMarkers URL dispatch", () => {
       + '| {:kind "reference"} | @problems');
     expect(res.result?.descriptor).toBeDefined();
     const d = res.result.descriptor;
-    expect(d.get(keyword("kind"))).toBe(keyword("unsupported-scope-kind"));
+    expect(d.get("kind")).toEqual(makeTagKeyword("UnsupportedScopeKind"));
   });
 
   it("Backslash-only path (no forward slash) → file branch",
@@ -430,11 +430,12 @@ describe("@problems → @problemMarkers URL dispatch", () => {
         'use(:jdt/graph) | @problems');
     expect(res.result?.descriptor).toBeDefined();
     const d = res.result.descriptor;
-    // Server-originated descriptors carry their :kind as a raw
-    // String (jsonToQlang keeps JSON strings as strings). Only
-    // the outer _error wrapper triggers lifting via
-    // liftServerResponse → makeErrorValue.
-    expect(d.get(keyword("kind"))).toBe("jdt-internal-error");
+    // liftServerError boundary rename: plugin's `:thrown
+    // CoreException` becomes `:kind ::CoreException`
+    // (TagKeyword, per-site identity), plugin's `:kind
+    // jdt-internal-error` lands on `:category` (broad bucket).
+    expect(d.get("kind")).toEqual(makeTagKeyword("CoreException"));
+    expect(d.get("category")).toEqual(keyword("jdt-internal-error"));
   });
 
   it("Vec subject through `|` → missing-subject (not distributed)",
@@ -448,8 +449,8 @@ describe("@problems → @problemMarkers URL dispatch", () => {
         'use(:jdt/graph) | [1 2 3] | @problems');
     expect(res.result?.descriptor).toBeDefined();
     const d = res.result.descriptor;
-    expect(d.get(keyword("kind")))
-        .toBe(keyword("unsupported-subject-type"));
+    expect(d.get("kind"))
+        .toEqual(makeTagKeyword("UnsupportedSubjectType"));
   });
 
   it("Number subject → missing-subject-type error", async () => {
@@ -458,8 +459,8 @@ describe("@problems → @problemMarkers URL dispatch", () => {
         'use(:jdt/graph) | 42 | @problems');
     expect(res.result?.descriptor).toBeDefined();
     const d = res.result.descriptor;
-    expect(d.get(keyword("kind")))
-        .toBe(keyword("unsupported-subject-type"));
+    expect(d.get("kind"))
+        .toEqual(makeTagKeyword("UnsupportedSubjectType"));
   });
 
   it("Boolean subject → missing-subject-type error", async () => {
@@ -468,8 +469,8 @@ describe("@problems → @problemMarkers URL dispatch", () => {
         'use(:jdt/graph) | true | @problems');
     expect(res.result?.descriptor).toBeDefined();
     const d = res.result.descriptor;
-    expect(d.get(keyword("kind")))
-        .toBe(keyword("unsupported-subject-type"));
+    expect(d.get("kind"))
+        .toEqual(makeTagKeyword("UnsupportedSubjectType"));
   });
 
   it("Keyword subject → missing-subject-type error", async () => {
@@ -478,8 +479,8 @@ describe("@problems → @problemMarkers URL dispatch", () => {
         'use(:jdt/graph) | :foo | @problems');
     expect(res.result?.descriptor).toBeDefined();
     const d = res.result.descriptor;
-    expect(d.get(keyword("kind")))
-        .toBe(keyword("unsupported-subject-type"));
+    expect(d.get("kind"))
+        .toEqual(makeTagKeyword("UnsupportedSubjectType"));
   });
 
   it("Nested inner (inner-of-inner) type → same range-filter "
@@ -568,7 +569,7 @@ describe("@problemsVia — pure dispatch with injected mocks", () => {
     // Fetcher mock captures its input as :scope. Result Vec is
     // [{:scope "my-project"}] — one element.
     expect(res.result).toHaveLength(1);
-    expect(res.result[0].get(keyword("scope"))).toBe("my-project");
+    expect(res.result[0].get("scope")).toBe("my-project");
   });
 
   it("Map :kind project → fetcher called on node (:fqn read "
@@ -585,7 +586,7 @@ describe("@problemsVia — pure dispatch with injected mocks", () => {
                      ["file-unused"],
                      ["types-unused"])`);
     expect(res.result).toHaveLength(1);
-    expect(res.result[0].get(keyword("received"))).toBe("app");
+    expect(res.result[0].get("received")).toBe("app");
   });
 
   it("Map :kind package → packageTypes, fileLocation, fetcher "
@@ -680,8 +681,8 @@ describe("@problemsVia — pure dispatch with injected mocks", () => {
                      ["unused"], ["unused"])`);
     const d = res.result?.descriptor;
     expect(d).toBeDefined();
-    expect(d.get(keyword("kind"))).toBe(
-        keyword("unsupported-scope-kind"));
+    expect(d.get("kind")).toEqual(
+        makeTagKeyword("UnsupportedScopeKind"));
   });
 
   it("Field node → range filter narrows to single line",
@@ -879,7 +880,7 @@ describe("@problemsVia — pure dispatch with injected mocks", () => {
           ["file-unused"],
           ["types-unused"])`);
     expect(res.result).toHaveLength(1);
-    expect(res.result[0].get(keyword("observed-fqn")))
+    expect(res.result[0].get("observed-fqn"))
         .toBe("D:/proj/X.java");
   });
 
@@ -903,6 +904,6 @@ describe("@problemsVia — pure dispatch with injected mocks", () => {
     // its startLine (2) is within [1, 5].
     expect(res.result).toHaveLength(1);
     expect(res.result[0].get(
-        keyword("captured-fetcher-subject"))).toBe("M.java");
+        "captured-fetcher-subject")).toBe("M.java");
   });
 });

--- a/cli/test/helpers/extract-quotes.mjs
+++ b/cli/test/helpers/extract-quotes.mjs
@@ -1,0 +1,41 @@
+// Shared `~{…}` Quote-literal extractor for `*-examples.test.mjs`
+// gates that verify catalog snippets parse.
+//
+// Brace nesting is balanced through a depth counter so Map / Vec
+// literals (`~{ {:k 1} | … }`) and nested Quotes (`~{ ~{inner} }`)
+// round-trip to the parser intact. String literals skip the brace
+// scan so a `"}"` byte inside a snippet does not close the
+// surrounding Quote prematurely.
+
+export function extractQuotes(source) {
+    const out = [];
+    let i = 0;
+    while (i < source.length - 1) {
+        if (source[i] === '~' && source[i + 1] === '{') {
+            const start = i + 2;
+            let j = start;
+            let depth = 1;
+            while (j < source.length && depth > 0) {
+                const c = source[j];
+                if (c === '\\' && j + 1 < source.length) { j += 2; continue; }
+                if (c === '"') {
+                    j++;
+                    while (j < source.length && source[j] !== '"') {
+                        if (source[j] === '\\') j += 2;
+                        else j++;
+                    }
+                    j++;
+                    continue;
+                }
+                if (c === '{') depth++;
+                else if (c === '}') depth--;
+                j++;
+            }
+            out.push(source.slice(start, j - 1));
+            i = j;
+        } else {
+            i++;
+        }
+    }
+    return out;
+}

--- a/cli/test/query.test.mjs
+++ b/cli/test/query.test.mjs
@@ -68,9 +68,10 @@ describe("jdt q — read-only exit-0 contract", () => {
     await query([]);
     expect(io.exits).toEqual([]);
     const stdout = io.logs.join("\n");
-    expect(stdout).toContain(":kind :usage-error");
+    // Per-site identity rides on the `::Tag` head ahead of `!{…}`;
+    // the descriptor body carries the remaining structured fields.
+    expect(stdout).toContain("::UsageError!{");
     expect(stdout).toContain(":origin :jdt/cli");
-    expect(stdout).toContain(":thrown :UsageError");
     expect(stdout).toContain("jdt q <qlang-query>");
   });
 
@@ -80,9 +81,8 @@ describe("jdt q — read-only exit-0 contract", () => {
     await query(["bad syntax [[["]);
     expect(io.exits).toEqual([]);
     const stdout = io.logs.join("\n");
-    expect(stdout).toContain(":kind :parse-error");
+    expect(stdout).toContain("::ParseError!{");
     expect(stdout).toContain(":origin :qlang/parse");
-    expect(stdout).toContain(":thrown :ParseError");
     expect(stdout).toContain(":location");
     expect(stdout).toContain(":line");
     expect(stdout).toContain(":column");
@@ -104,9 +104,12 @@ describe("jdt q — read-only exit-0 contract", () => {
     await query(['"no.such.Type" | @type']);
     expect(io.exits).toEqual([]);
     const stdout = io.logs.join("\n");
-    expect(stdout).toContain("!{");
-    expect(stdout).toContain("TypeNotFound");
-    expect(stdout).toContain("Type not found: no.such.Type");
+    // Per-site identity surfaces through the `::TagName` head ahead
+    // of `!{…}`; the plugin's broad-bucket kind lands on `:category`.
+    // `:message` is suppressed in the printed form by qlang's
+    // hypertext-error convention (the prose lives on `::Tag | docs`).
+    expect(stdout).toContain("::TypeNotFound!{");
+    expect(stdout).toContain(":category :type-not-found");
   });
 
   it("successful string result prints raw (no quotes), no non-zero exit", async () => {

--- a/cli/test/query.test.mjs
+++ b/cli/test/query.test.mjs
@@ -71,6 +71,7 @@ describe("jdt q — read-only exit-0 contract", () => {
     // Per-site identity rides on the `::Tag` head ahead of `!{…}`;
     // the descriptor body carries the remaining structured fields.
     expect(stdout).toContain("::UsageError!{");
+    expect(stdout).toContain(":category :usage-error");
     expect(stdout).toContain(":origin :jdt/cli");
     expect(stdout).toContain("jdt q <qlang-query>");
   });
@@ -82,6 +83,7 @@ describe("jdt q — read-only exit-0 contract", () => {
     expect(io.exits).toEqual([]);
     const stdout = io.logs.join("\n");
     expect(stdout).toContain("::ParseError!{");
+    expect(stdout).toContain(":category :parse-error");
     expect(stdout).toContain(":origin :qlang/parse");
     expect(stdout).toContain(":location");
     expect(stdout).toContain(":line");

--- a/cli/test/render.test.mjs
+++ b/cli/test/render.test.mjs
@@ -1,18 +1,30 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createSession } from "@kaluchi/qlang-core/session";
-import { bindJdtRenderOperands } from "../lib/jdt/render.impl.mjs";
+import { createImpls as createRenderImpls } from "../lib/jdt/render.impl.mjs";
 
 // Pure unit tests for the host-bound markdown renderers. No HTTP,
-// no Eclipse — each test constructs a bundle Map and invokes the
-// renderer through a fresh qlang session so the public operand
-// dispatch path is exercised.
+// no Eclipse — each test constructs a bundle Map, loads
+// `:jdt/render` through the locator, and invokes the renderer
+// through a fresh qlang session so the public operand dispatch
+// path is exercised end-to-end.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODULE_LIB = join(__dirname, "..", "lib");
+
+function renderLocator(namespaceName) {
+  if (namespaceName !== "jdt/render") return null;
+  const qlangPath = join(MODULE_LIB, "jdt", "render.qlang");
+  return { source: readFileSync(qlangPath, "utf8"), impls: createRenderImpls() };
+}
 
 async function runWithBundle(operandName, bundle) {
-  const session = await createSession();
-  bindJdtRenderOperands(session);
+  const session = await createSession({ locator: renderLocator });
   session.bind("__bundle", bundle);
   const { result, error } = await session.evalCell(
-      `__bundle | ${operandName}`);
+      `use(:jdt/render) | __bundle | ${operandName}`);
   if (error) throw error;
   return result;
 }

--- a/cli/test/render.test.mjs
+++ b/cli/test/render.test.mjs
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { createSession } from "@kaluchi/qlang-core/session";
-import { keyword } from "@kaluchi/qlang-core";
 import { bindJdtRenderOperands } from "../lib/jdt/render.impl.mjs";
 
 // Pure unit tests for the host-bound markdown renderers. No HTTP,
@@ -19,7 +18,7 @@ async function runWithBundle(operandName, bundle) {
 }
 
 function map(entries) {
-  return new Map(entries.map(([k, v]) => [keyword(k), v]));
+  return new Map(entries);
 }
 
 describe("mdSource", () => {


### PR DESCRIPTION
## Summary

Migrates the JDT module surface to qlang 0.7's authored-catalog + locator-impls contract, and polishes documentation across the three modules.

- Bumped qlang-core and qlang-cli to 0.7.4. The dependency line picks up two upstream fixes the JDT migration leans on: manifest no longer crashes on raw host-bound functions, and runExamples evaluates each Quote against the calling session env so jdt-side examples resolve through the use-loaded :jdt/graph and :jdt/coverage modules.
- Switched :jdt/render from raw session.bind to Pattern B (catalog declaration in lib/jdt/render.qlang + createImpls() in render.impl.mjs + locator wiring in src/commands/query.mjs). The previous shape passed bare valueOp(...) results into session.bind, which left manifest unable to enumerate the render operands and produced a host-side TypeError on every jdt q 'manifest ...' or :mdSource | spec call.
- Co-located per-site error tags with the operand that throws them across :jdt/graph and :jdt/coverage. The earlier shape grouped every error tag in one file-top section before any operand declaration appeared, which broke the structural-coherence rule (no derivable grouping principle). Doc-prefixes rewritten to document the detail node-Map shape returned by each axis, the refKind modifier set on reference axes, the counters / lines block shape on @coverage, and the semantic distinction between sibling conduits (@callers vs @testCallers, @uncovered vs @untested).
- Examples rewritten to verify a concrete property (every(/kind | eq(...)), !| type | eq(::Tag)) rather than tautological count-checks.
- test/helpers/extract-quotes.mjs replaces the regex extractor shared between graph-examples.test.mjs and coverage-examples.test.mjs. The new character-scanner balances brace nesting (Map / Vec literals inside snippets) and skips String literals.
- Boundary rename in liftServerError maps the plugin's :kind kebab-string + :thrown PascalCase shape to qlang 0.7's :kind ::TagKeyword + :category :keyword, so result !| type yields the per-site tag and result !| /category yields the broad bucket.

## Test plan

- [x] cd cli && npm test — 862 / 862 pass
- [x] jdt q 'manifest | count' — returns 175 (was ::TypeError on 0.7.1)
- [x] jdt q ':@type | runExamples | first | /ok' — returns true (was false on 0.7.3 due to runExamples env isolation)
- [x] jdt q '"X" | @sourceCard' end-to-end with live Eclipse — markdown card renders